### PR TITLE
Fix CI pipeline configuration issues

### DIFF
--- a/.github/workflows/elixir-ci.yml
+++ b/.github/workflows/elixir-ci.yml
@@ -47,4 +47,5 @@ jobs:
       - name: Run tests with coverage
         run: mix coveralls.github
         env:
+          MIX_ENV: test
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,8 @@ defmodule JidoAction.MixProject do
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      elixirc_paths: elixirc_paths(Mix.env())
+      elixirc_paths: elixirc_paths(Mix.env()),
+      test_coverage: [tool: ExCoveralls]
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule JidoAction.MixProject do
     [
       app: :jido_action,
       version: "0.1.0",
-      elixir: "~> 1.18",
+      elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env())


### PR DESCRIPTION
Fixes #1. 

## This PR resolves CI pipeline failures by addressing two configuration issues: 

1. Updated Elixir version requirement in mix.exs from 1.18 to 1.17 to match the CI workflow configuration 
2. Added missing ExCoveralls configuration to enable coverage reporting 
3. Set MIX_ENV=test in CI workflow for proper test environment. 

---

The changes ensure CI runs successfully and provides coverage reports. 

All tests pass locally and CI is now working correctly.