### PR TITLE
chore(mix): remove duplicate elixirc_paths key

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,6 @@ defmodule JidoAction.MixProject do
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),
-      elixirc_paths: elixirc_paths(Mix.env()),
 
       # Docs
       name: "Jido Action",


### PR DESCRIPTION
## Summary
- Remove duplicate `elixirc_paths` key from `project/0` in `mix.exs`
- Keep effective project config unchanged while eliminating redundant configuration noise

## Scope
- `mix.exs` only

## Validation
- `mix test`

## Changelog Note (for rollup PR)
- Fixed: Remove duplicate `elixirc_paths` entry from Mix project configuration
