### PR TITLE
fix(exec): run async chains under Task.Supervisor without caller linkage

### DIFF
--- a/lib/jido_action/exec/chain.ex
+++ b/lib/jido_action/exec/chain.ex
@@ -19,6 +19,7 @@ defmodule Jido.Exec.Chain do
 
   alias Jido.Action.Error
   alias Jido.Exec
+  alias Jido.Exec.Supervisors
 
   require Logger
 
@@ -63,7 +64,12 @@ defmodule Jido.Exec.Chain do
       end)
     end
 
-    if async, do: Task.async(chain_fun), else: chain_fun.()
+    if async do
+      task_sup = Supervisors.task_supervisor(opts)
+      Task.Supervisor.async_nolink(task_sup, chain_fun)
+    else
+      chain_fun.()
+    end
   end
 
   @spec should_interrupt?(interrupt_check | nil) :: boolean()

--- a/test/jido_action/exec/chain_supervision_test.exs
+++ b/test/jido_action/exec/chain_supervision_test.exs
@@ -1,0 +1,44 @@
+defmodule JidoTest.Exec.ChainSupervisionTest do
+  use JidoTest.ActionCase, async: false
+
+  alias Jido.Exec.Chain
+  alias JidoTest.TestActions.Add
+  alias JidoTest.TestActions.Multiply
+
+  describe "async chain supervision" do
+    test "returns an unlinked task so caller is isolated from task crashes" do
+      task =
+        Chain.chain([Add], %{value: 1},
+          async: true,
+          interrupt_check: fn -> raise "interrupt check crashed" end
+        )
+
+      assert %Task{} = task
+
+      caller_links =
+        self()
+        |> Process.info(:links)
+        |> elem(1)
+
+      refute task.pid in caller_links
+      assert catch_exit(Task.await(task, 1_000))
+      assert Process.alive?(self())
+    end
+
+    test "routes async chain task through the jido instance supervisor" do
+      start_supervised!({Task.Supervisor, name: ChainTenant.TaskSupervisor})
+
+      task = Chain.chain([Add, Multiply], %{value: 2, amount: 3}, async: true, jido: ChainTenant)
+
+      assert %Task{} = task
+      assert task.pid in Task.Supervisor.children(ChainTenant.TaskSupervisor)
+      assert {:ok, %{value: 15, amount: 3}} = Task.await(task, 1_000)
+    end
+
+    test "raises when async chain jido supervisor is not running" do
+      assert_raise ArgumentError, ~r/Instance task supervisor.*is not running/, fn ->
+        Chain.chain([Add], %{value: 1}, async: true, jido: Missing.Chain.Instance)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Change `Jido.Exec.Chain` async mode from linked `Task.async/1` to supervised `Task.Supervisor.async_nolink/2`
- Route async chain tasks through instance-aware supervisor resolution (`jido:` option)
- Add tests for caller isolation and instance supervisor routing

## Scope
- `lib/jido_action/exec/chain.ex`
- `test/jido_action/exec/chain_supervision_test.exs`

## Validation
- `mix test test/jido_action/exec/chain_test.exs test/jido_action/exec/chain_supervision_test.exs`
- `mix test`

## Changelog Note (for rollup PR)
- Fixed: Async chain execution now runs under `Task.Supervisor` without caller linkage
