### PR TITLE
fix(exec): eliminate async await monitor and mailbox leakage

### DIFF
--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -60,7 +60,11 @@ defmodule Jido.Exec do
   @type params :: map()
   @type context :: map()
   @type run_opts :: [timeout: non_neg_integer(), jido: atom()]
-  @type async_ref :: %{ref: reference(), pid: pid()}
+  @type async_ref :: %{
+          required(:ref) => reference(),
+          required(:pid) => pid(),
+          optional(:monitor_ref) => reference()
+        }
 
   # Execution result types
   @type exec_success :: {:ok, map()}

--- a/test/jido_action/exec/async_mailbox_hygiene_test.exs
+++ b/test/jido_action/exec/async_mailbox_hygiene_test.exs
@@ -1,0 +1,54 @@
+defmodule JidoTest.Exec.AsyncMailboxHygieneTest do
+  use JidoTest.ActionCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Jido.Exec
+  alias JidoTest.TestActions.BasicAction
+  alias JidoTest.TestActions.DelayAction
+
+  @moduletag :capture_log
+
+  describe "await/2 mailbox hygiene" do
+    test "cleans monitor and result messages on success" do
+      capture_log(fn ->
+        async_ref = Exec.run_async(BasicAction, %{value: 10})
+
+        assert is_reference(async_ref.monitor_ref)
+        assert {:ok, %{value: 10}} = Exec.await(async_ref, 1_000)
+        assert_no_async_residue(async_ref.ref, async_ref.pid)
+      end)
+    end
+
+    test "cleans monitor and result messages on timeout" do
+      capture_log(fn ->
+        async_ref = Exec.run_async(DelayAction, %{delay: 200}, %{}, timeout: 500)
+
+        assert {:error, %Jido.Action.Error.TimeoutError{}} = Exec.await(async_ref, 1)
+        Process.sleep(20)
+        assert_no_async_residue(async_ref.ref, async_ref.pid)
+      end)
+    end
+
+    test "supports legacy async_ref without monitor_ref and still cleans messages" do
+      capture_log(fn ->
+        parent = self()
+        ref = make_ref()
+
+        {:ok, pid} =
+          Task.start(fn ->
+            Process.sleep(20)
+            send(parent, {:action_async_result, ref, {:ok, %{legacy: true}}})
+          end)
+
+        assert {:ok, %{legacy: true}} = Exec.await(%{ref: ref, pid: pid}, 500)
+        assert_no_async_residue(ref, pid)
+      end)
+    end
+  end
+
+  defp assert_no_async_residue(ref, pid) do
+    refute_receive {:action_async_result, ^ref, _}, 50
+    refute_receive {:DOWN, _, :process, ^pid, _}, 50
+  end
+end


### PR DESCRIPTION
## Summary
- Add deterministic async monitor lifecycle handling in `Jido.Exec.Async`
- Include `monitor_ref` in async references while preserving compatibility for legacy `%{ref, pid}` maps
- Replace race-prone cleanup with explicit `demonitor(..., [:flush])` and targeted result flush
- Add dedicated mailbox hygiene tests for success, timeout, and legacy async refs

## Scope
- `lib/jido_action/exec/async.ex`
- `lib/jido_action/exec.ex`
- `test/jido_action/exec/async_mailbox_hygiene_test.exs`

## Validation
- `mix test test/jido_action/exec_async_test.exs test/jido_action/exec/async_mailbox_hygiene_test.exs`
- `mix test`

## Changelog Note (for rollup PR)
- Fixed: Async await path now cleans monitor/result messages deterministically
