### PR TITLE
fix(error): normalize instruction/schema/weather error shapes

### DIFF
--- a/guides/error-handling.md
+++ b/guides/error-handling.md
@@ -38,6 +38,27 @@ Each error type has its own struct:
 }
 ```
 
+### Runtime Error Contract
+
+At runtime, Jido execution and tool boundaries should return errors in this shape:
+
+```elixir
+{:error, %Exception{}}
+```
+
+Avoid returning bare atoms/strings/maps as `reason` across module boundaries. If legacy
+reason values are needed for compatibility, preserve them under `error.details.reason`.
+
+### Migration Notes
+
+- `Jido.Instruction.new/1` now returns `{:error, %Jido.Action.Error.InvalidInputError{}}`
+  for missing/invalid action input. Previous atom reasons are available as `details.reason`
+  (for example `:missing_action`, `:invalid_action`).
+- `Jido.Action.Schema.validate/2` now returns structured validation errors for unsupported
+  schema types instead of a bare string reason.
+- `Jido.Tools.Weather.run/2` now returns `ExecutionFailureError` on failure, with the
+  original failure value preserved under `details.reason`.
+
 ### Core Error Types
 
 #### Validation Errors

--- a/test/jido_action/instruction_test.exs
+++ b/test/jido_action/instruction_test.exs
@@ -226,15 +226,24 @@ defmodule Jido.InstructionTest do
     end
 
     test "returns error for missing action" do
-      assert {:error, :missing_action} = Instruction.new(%{params: %{value: 1}})
+      assert {:error, %Jido.Action.Error.InvalidInputError{} = error} =
+               Instruction.new(%{params: %{value: 1}})
+
+      assert error.details[:reason] == :missing_action
     end
 
     test "returns error for invalid action" do
-      assert {:error, :invalid_action} = Instruction.new(%{action: "not_a_module"})
+      assert {:error, %Jido.Action.Error.InvalidInputError{} = error} =
+               Instruction.new(%{action: "not_a_module"})
+
+      assert error.details[:reason] == :invalid_action
     end
 
     test "returns error for non-atom action" do
-      assert {:error, :invalid_action} = Instruction.new(%{action: 123})
+      assert {:error, %Jido.Action.Error.InvalidInputError{} = error} =
+               Instruction.new(%{action: 123})
+
+      assert error.details[:reason] == :invalid_action
     end
   end
 

--- a/test/jido_action/schema_test.exs
+++ b/test/jido_action/schema_test.exs
@@ -1,0 +1,26 @@
+defmodule Jido.Action.SchemaTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Action.Error
+  alias Jido.Action.Schema
+
+  describe "validate/2" do
+    test "returns structured error for unsupported schema types" do
+      assert {:error, %Error.InvalidInputError{} = error} = Schema.validate(:unsupported, %{})
+      assert error.message == "Unsupported schema type"
+      assert error.details[:reason] == :unsupported_schema_type
+      assert error.details[:schema] == ":unsupported"
+    end
+  end
+
+  describe "format_error/3" do
+    test "passes through existing exceptions" do
+      error =
+        Error.validation_error("Already normalized", %{
+          reason: :already_normalized
+        })
+
+      assert ^error = Schema.format_error(error, "Action", __MODULE__)
+    end
+  end
+end

--- a/test/jido_tools/weather_test.exs
+++ b/test/jido_tools/weather_test.exs
@@ -337,9 +337,10 @@ defmodule JidoTest.Tools.WeatherTest do
       params = %{location: "invalid_location"}
 
       assert {:error, error} = Weather.run(params, %{})
-      assert is_binary(error)
-      assert error =~ "Failed to fetch weather"
-      assert error =~ "NWS API error"
+      assert %Jido.Action.Error.ExecutionFailureError{} = error
+      assert error.message =~ "Failed to fetch weather"
+      assert error.message =~ "NWS API error"
+      assert error.details[:reason]
     end
 
     test "handles empty location gracefully" do
@@ -348,8 +349,9 @@ defmodule JidoTest.Tools.WeatherTest do
       params = %{location: ""}
 
       assert {:error, error} = Weather.run(params, %{})
-      assert is_binary(error)
-      assert error =~ "Failed to fetch weather"
+      assert %Jido.Action.Error.ExecutionFailureError{} = error
+      assert error.message =~ "Failed to fetch weather"
+      assert error.details[:reason]
     end
 
     test "handles invalid format gracefully" do
@@ -357,9 +359,10 @@ defmodule JidoTest.Tools.WeatherTest do
       params = %{format: :invalid_format}
 
       assert {:error, error} = Weather.run(params, %{})
-      assert is_binary(error)
-      assert error =~ "Invalid parameters"
-      assert error =~ "expected one of [:detailed, :summary, :text]"
+      assert %Jido.Action.Error.ExecutionFailureError{} = error
+      assert error.message =~ "Invalid parameters"
+      assert error.message =~ "expected one of [:detailed, :summary, :text]"
+      assert error.details[:reason]
     end
   end
 
@@ -379,8 +382,9 @@ defmodule JidoTest.Tools.WeatherTest do
       params = %{format: :map}
 
       assert {:error, error} = Weather.run(params, %{})
-      assert error =~ "Invalid parameters"
-      assert error =~ "expected one of [:detailed, :summary, :text]"
+      assert %Jido.Action.Error.ExecutionFailureError{} = error
+      assert error.message =~ "Invalid parameters"
+      assert error.message =~ "expected one of [:detailed, :summary, :text]"
     end
   end
 


### PR DESCRIPTION
Closes #84.

## Summary
- normalize `Jido.Instruction.new/1` failure returns to structured `InvalidInputError` values
- normalize unsupported schema type failures in `Jido.Action.Schema.validate/2`
- normalize `Jido.Tools.Weather.run/2` wrapper failures to `ExecutionFailureError` while preserving original reasons in `details.reason`
- add runtime error contract + migration notes to error handling guide

## Validation
- `mix test test/jido_action/instruction_test.exs test/jido_action/schema_test.exs test/jido_tools/weather_test.exs`
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --min-priority higher`
