### PR TITLE
docs(exec): clarify async supervision and config fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ async_ref = Jido.Exec.run_async(MyApp.Actions.GreetUser, %{name: "Bob"})
 {:ok, result} = Jido.Exec.await(async_ref)
 ```
 
+#### Async Contract
+
+- `run_async/4` executes under `Task.Supervisor` (global or instance-scoped via `jido:`).
+- `async_ref` is mailbox-bound to the process that started the async call; await/cancel from that same process.
+- `await/2` timeout kills the task and drains monitor/result mailbox residue before returning.
+- `cancel/1` sends `:shutdown`, waits a bounded grace period, and flushes monitor/result residue.
+
+See the detailed contract in [Execution Engine Guide](guides/execution-engine.md#asynchronous-execution-contract).
+
 ### 3. Create Workflows with Jido.Instruction
 
 ```elixir
@@ -410,6 +419,9 @@ config :jido_action,
   default_max_retries: 3,
   default_backoff: 500
 ```
+
+If any of these values are invalid at runtime (non-integer or negative), Jido logs a warning and
+falls back to the built-in defaults instead of crashing. See [Configuration Guide](guides/configuration.md#runtime-config-validation-and-fallback).
 
 ### Instance Isolation (Multi-Tenant)
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -49,6 +49,31 @@ config :jido_action,
 
 ## Runtime Configuration
 
+### Runtime Config Validation and Fallback
+
+`Jido.Exec`, `Jido.Exec.Async`, and `Jido.Exec.Retry` validate runtime values for:
+
+- `:default_timeout`
+- `:default_max_retries`
+- `:default_backoff`
+
+Each value must be a non-negative integer.
+
+If a value is invalid (for example `-1`, `:bad`, or `"5000"`), Jido:
+
+1. Logs a warning with the invalid value and config key.
+2. Uses the internal fallback default for that key.
+3. Continues execution without crashing.
+
+Example warning behavior:
+
+```elixir
+Application.put_env(:jido_action, :default_timeout, :bad_value)
+
+# Exec/Async calls will warn and use fallback timeout.
+{:ok, _result} = Jido.Exec.run(MyAction, %{input: "ok"}, %{})
+```
+
 ### Per-Action Configuration
 
 Actions define compensation settings at compile time:
@@ -378,9 +403,9 @@ end
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `:default_timeout` | integer | 30000 | Default action timeout in milliseconds |
-| `:default_max_retries` | integer | 1 | Default number of retry attempts |
-| `:default_backoff` | integer | 250 | Initial backoff time in ms (exponential) |
+| `:default_timeout` | non-negative integer | 30000 | Default action timeout in milliseconds (invalid values warn + fallback) |
+| `:default_max_retries` | non-negative integer | 1 | Default number of retry attempts (invalid values warn + fallback) |
+| `:default_backoff` | non-negative integer | 250 | Initial backoff time in ms (exponential, invalid values warn + fallback) |
 
 ### Action Compensation Config
 
@@ -424,7 +449,8 @@ Passed to `Jido.Exec.run/4`:
 ## Next Steps
 
 **→ [Testing Guide](testing.md)** - Testing configurations and environments  
-**→ [Error Handling Guide](error-handling.md)** - Error handling patterns
+**→ [Error Handling Guide](error-handling.md)** - Error handling patterns  
+**→ [Execution Engine Guide](execution-engine.md)** - Async execution lifecycle and guarantees
 
 ---
 ← [Error Handling Guide](error-handling.md) | **Next: [Testing Guide](testing.md)** →


### PR DESCRIPTION
Closes #85.

## Summary
- document async execution contract in README and execution-engine guide
- document async cleanup guarantees for `await/2` and `cancel/1`
- document mailbox-bound async ref expectations (start/await/cancel from same process)
- document runtime config validation/fallback behavior for timeout/retry defaults
- add cross-links between execution and configuration guides

## Validation
- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --min-priority higher`
