### PR TITLE
fix(error): normalize workflow/action-plan/lua/weather leaf error contracts

### DIFF
--- a/lib/jido_tools/weather/by_location.ex
+++ b/lib/jido_tools/weather/by_location.ex
@@ -9,6 +9,8 @@ defmodule Jido.Tools.Weather.ByLocation do
   Provides a simple interface for getting weather by location in one call.
   """
 
+  alias Jido.Action.Error
+
   use Jido.Action,
     name: "weather_by_location",
     description: "Get weather forecast for any location using NWS API",
@@ -52,11 +54,12 @@ defmodule Jido.Tools.Weather.ByLocation do
       {:ok, grid_info} ->
         {:ok, grid_info}
 
-      {:error, %Jido.Action.Error.ExecutionFailureError{message: message}} ->
-        {:error, "Failed to get grid info: #{message}"}
-
       {:error, reason} ->
-        {:error, "Failed to get grid info: #{inspect(reason)}"}
+        {:error,
+         Error.execution_error("Failed to get grid info: #{error_message(reason)}", %{
+           type: :grid_lookup_failed,
+           reason: reason
+         })}
     end
   end
 
@@ -71,11 +74,12 @@ defmodule Jido.Tools.Weather.ByLocation do
       {:ok, forecast} ->
         {:ok, forecast}
 
-      {:error, %Jido.Action.Error.ExecutionFailureError{message: message}} ->
-        {:error, "Failed to get forecast: #{message}"}
-
       {:error, reason} ->
-        {:error, "Failed to get forecast: #{inspect(reason)}"}
+        {:error,
+         Error.execution_error("Failed to get forecast: #{error_message(reason)}", %{
+           type: :forecast_fetch_failed,
+           reason: reason
+         })}
     end
   end
 
@@ -125,4 +129,7 @@ defmodule Jido.Tools.Weather.ByLocation do
   defp format_forecast_output(periods, _format) do
     periods
   end
+
+  defp error_message(reason) when is_exception(reason), do: Exception.message(reason)
+  defp error_message(reason), do: inspect(reason)
 end

--- a/lib/jido_tools/weather/forecast.ex
+++ b/lib/jido_tools/weather/forecast.ex
@@ -6,6 +6,8 @@ defmodule Jido.Tools.Weather.Forecast do
   weather information including temperature, wind, and conditions.
   """
 
+  alias Jido.Action.Error
+
   use Jido.Action,
     name: "weather_forecast",
     description: "Get detailed weather forecast from NWS forecast URL",
@@ -49,7 +51,12 @@ defmodule Jido.Tools.Weather.Forecast do
         response: %{status: response.status, body: response.body, headers: response.headers}
       })
     rescue
-      e -> {:error, "HTTP error: #{Exception.message(e)}"}
+      e ->
+        {:error,
+         Error.execution_error("HTTP error fetching forecast: #{Exception.message(e)}", %{
+           type: :forecast_http_error,
+           reason: e
+         })}
     end
   end
 
@@ -75,11 +82,20 @@ defmodule Jido.Tools.Weather.Forecast do
   end
 
   defp transform_result(%{response: %{status: status, body: body}}) when status != 200 do
-    {:error, "NWS forecast API error (#{status}): #{inspect(body)}"}
+    {:error,
+     Error.execution_error("NWS forecast API error (#{status})", %{
+       type: :forecast_request_failed,
+       status: status,
+       reason: %{status: status, body: body}
+     })}
   end
 
   defp transform_result(_payload) do
-    {:error, "Unexpected forecast response format"}
+    {:error,
+     Error.execution_error("Unexpected forecast response format", %{
+       type: :forecast_response_invalid,
+       reason: :unexpected_response_format
+     })}
   end
 
   defp format_summary_periods(periods) do

--- a/lib/jido_tools/weather/hourly_forecast.ex
+++ b/lib/jido_tools/weather/hourly_forecast.ex
@@ -5,6 +5,8 @@ defmodule Jido.Tools.Weather.HourlyForecast do
   Provides hour-by-hour weather conditions for more detailed planning needs.
   """
 
+  alias Jido.Action.Error
+
   use Jido.Action,
     name: "weather_hourly_forecast",
     description: "Get hourly weather forecast from NWS API",
@@ -43,7 +45,12 @@ defmodule Jido.Tools.Weather.HourlyForecast do
         response: %{status: response.status, body: response.body, headers: response.headers}
       })
     rescue
-      e -> {:error, "HTTP error: #{Exception.message(e)}"}
+      e ->
+        {:error,
+         Error.execution_error("HTTP error fetching hourly forecast: #{Exception.message(e)}", %{
+           type: :hourly_forecast_http_error,
+           reason: e
+         })}
     end
   end
 
@@ -78,10 +85,19 @@ defmodule Jido.Tools.Weather.HourlyForecast do
   end
 
   defp transform_result(%{response: %{status: status, body: body}}) when status != 200 do
-    {:error, "NWS hourly forecast API error (#{status}): #{inspect(body)}"}
+    {:error,
+     Error.execution_error("NWS hourly forecast API error (#{status})", %{
+       type: :hourly_forecast_request_failed,
+       status: status,
+       reason: %{status: status, body: body}
+     })}
   end
 
   defp transform_result(_payload) do
-    {:error, "Unexpected hourly forecast response format"}
+    {:error,
+     Error.execution_error("Unexpected hourly forecast response format", %{
+       type: :hourly_forecast_response_invalid,
+       reason: :unexpected_response_format
+     })}
   end
 end

--- a/lib/jido_tools/weather/location_to_grid.ex
+++ b/lib/jido_tools/weather/location_to_grid.ex
@@ -6,6 +6,8 @@ defmodule Jido.Tools.Weather.LocationToGrid do
   Returns grid coordinates and forecast URLs needed for detailed weather information.
   """
 
+  alias Jido.Action.Error
+
   use Jido.Action,
     name: "weather_location_to_grid",
     description: "Convert location to NWS grid coordinates and forecast URLs",
@@ -41,7 +43,12 @@ defmodule Jido.Tools.Weather.LocationToGrid do
         response: %{status: response.status, body: response.body, headers: response.headers}
       })
     rescue
-      e -> {:error, "HTTP error: #{Exception.message(e)}"}
+      e ->
+        {:error,
+         Error.execution_error("HTTP error fetching grid location: #{Exception.message(e)}", %{
+           type: :location_to_grid_http_error,
+           reason: e
+         })}
     end
   end
 
@@ -70,10 +77,19 @@ defmodule Jido.Tools.Weather.LocationToGrid do
   end
 
   defp transform_result(%{response: %{status: status, body: body}}) when status != 200 do
-    {:error, "NWS API error (#{status}): #{inspect(body)}"}
+    {:error,
+     Error.execution_error("NWS API error (#{status})", %{
+       type: :location_to_grid_request_failed,
+       status: status,
+       reason: %{status: status, body: body}
+     })}
   end
 
   defp transform_result(_payload) do
-    {:error, "Unexpected response format"}
+    {:error,
+     Error.execution_error("Unexpected location-to-grid response format", %{
+       type: :location_to_grid_response_invalid,
+       reason: :unexpected_response_format
+     })}
   end
 end

--- a/test/jido_tools/lua_eval_supervision_test.exs
+++ b/test/jido_tools/lua_eval_supervision_test.exs
@@ -1,6 +1,7 @@
 defmodule Jido.Tools.LuaEvalSupervisionTest do
   use ExUnit.Case, async: false
 
+  alias Jido.Action.Error
   alias Jido.Tools.LuaEval
 
   @context %{}
@@ -25,7 +26,9 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
       send(caller, :run)
       assert_new_supervisor_child(baseline_children)
 
-      assert_receive {:done, ^caller, {:error, %{type: :timeout, timeout_ms: 200}}}, 500
+      assert_receive {:done, ^caller, {:error, %Error.TimeoutError{} = error}}, 500
+      assert error.timeout == 200
+      assert error.details[:reason] == %{type: :timeout, timeout_ms: 200}
     end
 
     test "does not link Lua task to the caller process" do
@@ -50,7 +53,9 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
       links_during_execution = caller |> Process.info(:links) |> elem(1) |> MapSet.new()
       assert links_during_execution == baseline_links
 
-      assert_receive {:done, ^caller, {:error, %{type: :timeout, timeout_ms: 200}}}, 500
+      assert_receive {:done, ^caller, {:error, %Error.TimeoutError{} = error}}, 500
+      assert error.timeout == 200
+      assert error.details[:reason] == %{type: :timeout, timeout_ms: 200}
     end
   end
 

--- a/test/jido_tools/weather_error_contract_test.exs
+++ b/test/jido_tools/weather_error_contract_test.exs
@@ -1,0 +1,93 @@
+defmodule JidoTest.Tools.WeatherErrorContractTest do
+  use JidoTest.ActionCase, async: false
+
+  import Mimic
+
+  alias Jido.Action.Error
+  alias Jido.Tools.Weather.ByLocation
+  alias Jido.Tools.Weather.CurrentConditions
+  alias Jido.Tools.Weather.Forecast
+  alias Jido.Tools.Weather.Geocode
+  alias Jido.Tools.Weather.HourlyForecast
+  alias Jido.Tools.Weather.LocationToGrid
+
+  setup :set_mimic_global
+
+  describe "weather leaf actions return structured errors" do
+    test "LocationToGrid returns ExecutionFailureError for non-200 responses" do
+      expect(Req, :request!, fn _opts ->
+        %{status: 404, body: %{"detail" => "not found"}, headers: %{}}
+      end)
+
+      assert {:error, %Error.ExecutionFailureError{} = error} =
+               LocationToGrid.run(%{location: "invalid"}, %{})
+
+      assert error.details[:type] == :location_to_grid_request_failed
+      assert %{status: 404} = error.details[:reason]
+    end
+
+    test "Forecast returns ExecutionFailureError for non-200 responses" do
+      expect(Req, :request!, fn _opts ->
+        %{status: 503, body: %{"detail" => "service unavailable"}, headers: %{}}
+      end)
+
+      assert {:error, %Error.ExecutionFailureError{} = error} =
+               Forecast.run(%{forecast_url: "https://api.weather.gov/fail"}, %{})
+
+      assert error.details[:type] == :forecast_request_failed
+      assert %{status: 503} = error.details[:reason]
+    end
+
+    test "HourlyForecast returns ExecutionFailureError for non-200 responses" do
+      expect(Req, :request!, fn _opts ->
+        %{status: 500, body: %{"detail" => "internal error"}, headers: %{}}
+      end)
+
+      assert {:error, %Error.ExecutionFailureError{} = error} =
+               HourlyForecast.run(%{hourly_forecast_url: "https://api.weather.gov/fail"}, %{})
+
+      assert error.details[:type] == :hourly_forecast_request_failed
+      assert %{status: 500} = error.details[:reason]
+    end
+
+    test "Geocode returns ExecutionFailureError when no results are found" do
+      expect(Req, :request!, fn _opts ->
+        %{status: 200, body: [], headers: %{}}
+      end)
+
+      assert {:error, %Error.ExecutionFailureError{} = error} =
+               Geocode.run(%{location: "nowhere"}, %{})
+
+      assert error.details[:type] == :geocode_no_results
+      assert %{location: "nowhere"} = error.details[:reason]
+    end
+
+    test "CurrentConditions returns ExecutionFailureError when no stations are available" do
+      expect(Req, :request!, fn _opts ->
+        %{status: 200, body: %{"features" => []}, headers: %{}}
+      end)
+
+      assert {:error, %Error.ExecutionFailureError{} = error} =
+               CurrentConditions.run(
+                 %{observation_stations_url: "https://api.weather.gov/stations"},
+                 %{}
+               )
+
+      assert error.details[:type] == :observation_stations_empty
+      assert error.details[:reason] == :no_observation_stations
+    end
+
+    test "ByLocation wraps child failures into structured errors" do
+      expect(Req, :request!, fn opts ->
+        assert opts[:url] == "https://api.weather.gov/points/invalid"
+        %{status: 404, body: %{"detail" => "not found"}, headers: %{}}
+      end)
+
+      assert {:error, %Error.ExecutionFailureError{} = error} =
+               ByLocation.run(%{location: "invalid"}, %{})
+
+      assert error.details[:type] == :grid_lookup_failed
+      assert is_exception(error.details[:reason])
+    end
+  end
+end

--- a/test/jido_tools/workflow_test.exs
+++ b/test/jido_tools/workflow_test.exs
@@ -267,7 +267,8 @@ defmodule JidoTest.Tools.WorkflowTest do
 
       result = InvalidStepWorkflow.execute_step({:invalid_type, [], []}, params, context)
       assert {:error, error} = result
-      assert error.type == :invalid_step
+      assert %Error.ExecutionFailureError{} = error
+      assert error.details[:type] == :invalid_step
     end
   end
 
@@ -338,7 +339,8 @@ defmodule JidoTest.Tools.WorkflowTest do
       context = %{}
 
       assert {:error, error} = InvalidBranchWorkflow.run(params, context)
-      assert error.type == :invalid_condition
+      assert %Error.ExecutionFailureError{} = error
+      assert error.details[:type] == :invalid_condition
     end
   end
 


### PR DESCRIPTION
Closes #90.

## Summary
- normalize raw map/string `{:error, reason}` returns to structured `Jido.Action.Error.*` exceptions in:
  - `Jido.Tools.Workflow.Execution`
  - `Jido.Tools.ActionPlan`
  - `Jido.Tools.LuaEval`
  - weather leaf actions (`ByLocation`, `CurrentConditions`, `Forecast`, `Geocode`, `HourlyForecast`, `LocationToGrid`)
- preserve original raw reasons under `error.details.reason` for compatibility and debugging
- normalize ActionPlan transform callback failures and invalid callback return shapes to structured execution errors
- update existing workflow/action-plan/lua tests for structured error contracts
- add `test/jido_tools/weather_error_contract_test.exs` to enforce leaf-action error contract behavior

## Validation
- `mix format`
- `mix test`
- `mix quality`
