### PR TITLE
fix(async): enforce ownership for await/cancel

### DIFF
--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -78,6 +78,7 @@ defmodule Jido.Exec do
   @type async_ref :: %{
           required(:ref) => reference(),
           required(:pid) => pid(),
+          optional(:owner) => pid(),
           optional(:monitor_ref) => reference()
         }
 
@@ -223,6 +224,7 @@ defmodule Jido.Exec do
   An `async_ref` map containing:
   - `:ref` - A unique reference for this async action.
   - `:pid` - The PID of the process executing the Action.
+  - `:owner` - The PID of the caller that started the async action.
 
   ## Examples
 
@@ -249,6 +251,7 @@ defmodule Jido.Exec do
 
   - `{:ok, result}` if the Action executes successfully.
   - `{:error, reason}` if an error occurs during execution or if the action times out.
+  - `{:error, %Jido.Action.Error.InvalidInputError{}}` when awaited by a non-owner process.
 
   ## Examples
 
@@ -290,6 +293,7 @@ defmodule Jido.Exec do
 
   - `:ok` if the cancellation was successful.
   - `{:error, reason}` if the cancellation failed or the input was invalid.
+  - `{:error, %Jido.Action.Error.InvalidInputError{}}` when cancelled by a non-owner process.
 
   ## Examples
 


### PR DESCRIPTION
## Summary
- add owner PID tracking to async refs returned by `Jido.Exec.run_async/4`
- enforce owner validation in `await/2` and `cancel/1` (including pid cancel path when owner metadata is available)
- return structured `InvalidInputError` for non-owner await/cancel attempts
- add async ownership contract tests for owner and non-owner paths

## Testing
- `mix format`
- `mix test test/jido_action/exec_async_test.exs test/jido_action/exec/async_mailbox_hygiene_test.exs`
- `mix test`
- `mix quality`

Closes #92
