### PR TITLE
fix(schema): add opt-in recursive strict JSON schema for tools

### DIFF
--- a/guides/ai-integration.md
+++ b/guides/ai-integration.md
@@ -66,9 +66,19 @@ This generates a tool definition map:
         "description" => "Include inactive users in results"
       }
     },
-    "required" => ["query"]
+    "required" => ["query"],
+    "additionalProperties" => false
   }
 }
+```
+
+`ActionModule.to_tool/0` now emits strict JSON Schema by default for tool parameters:
+- `additionalProperties: false` is applied recursively to all object schemas.
+
+If you need legacy non-strict schema generation for compatibility, call:
+
+```elixir
+legacy_tool = Jido.Action.Tool.to_tool(MyApp.Actions.SearchUsers, strict: false)
 ```
 
 ## Using with OpenAI

--- a/guides/schemas-validation.md
+++ b/guides/schemas-validation.md
@@ -240,6 +240,9 @@ keys = Jido.Action.Schema.known_keys(schema)
 
 # Convert to JSON Schema (for AI tools)
 json_schema = Jido.Action.Schema.to_json_schema(schema)
+
+# Strict mode (recursive `additionalProperties: false` for all objects)
+strict_json_schema = Jido.Action.Schema.to_json_schema(schema, strict: true)
 ```
 
 ## Open/Partial Validation
@@ -307,6 +310,12 @@ tool = MyApp.Actions.SearchProducts.to_tool()
 #        "required" => ["query"]
 #      }
 #    }
+
+# Action.to_tool/0 emits strict schemas by default for modern LLM tool APIs
+# (recursive `additionalProperties: false` on all object schemas).
+
+# To opt out and keep legacy non-strict schema generation:
+legacy_tool = Jido.Action.Tool.to_tool(MyApp.Actions.SearchProducts, strict: false)
 ```
 
 See the [AI Integration Guide](ai-integration.md) for more details.

--- a/lib/jido_action.ex
+++ b/lib/jido_action.ex
@@ -451,7 +451,7 @@ defmodule Jido.Action do
 
       @doc "Converts the Action to an LLM-compatible tool format."
       def to_tool do
-        Tool.to_tool(__MODULE__)
+        Tool.to_tool(__MODULE__, strict: true)
       end
 
       @doc "Returns the Action metadata. Alias for to_json/0."

--- a/lib/jido_action/schema.ex
+++ b/lib/jido_action/schema.ex
@@ -81,9 +81,23 @@ defmodule Jido.Action.Schema do
     * Map representing the JSON Schema
   """
   @spec to_json_schema(t()) :: map()
-  def to_json_schema([]), do: %{"type" => "object", "properties" => %{}, "required" => []}
-  def to_json_schema(schema) when is_list(schema), do: nimble_to_json_schema(schema)
-  def to_json_schema(schema), do: Zoi.to_json_schema(schema)
+  def to_json_schema(schema), do: to_json_schema(schema, [])
+
+  @doc """
+  Converts a schema to JSON Schema format for AI tools with optional strictness controls.
+
+  ## Options
+    * `:strict` - when `true`, recursively sets `additionalProperties: false` on all
+      object schemas (default: `false`)
+  """
+  @spec to_json_schema(t(), keyword()) :: map()
+  def to_json_schema(schema, opts) do
+    strict? = Keyword.get(opts, :strict, false)
+
+    schema
+    |> base_json_schema()
+    |> maybe_apply_strict(strict?)
+  end
 
   @doc """
   Formats validation errors into Jido.Action.Error structs.
@@ -192,6 +206,77 @@ defmodule Jido.Action.Schema do
   end
 
   defp extract_zoi_keys(_), do: []
+
+  defp base_json_schema([]), do: %{"type" => "object", "properties" => %{}, "required" => []}
+  defp base_json_schema(schema) when is_list(schema), do: nimble_to_json_schema(schema)
+  defp base_json_schema(schema), do: Zoi.to_json_schema(schema)
+
+  defp maybe_apply_strict(schema, false), do: schema
+  defp maybe_apply_strict(schema, true), do: disallow_additional_properties(schema)
+
+  # Recursively set additionalProperties: false on all object schemas.
+  # Handles both atom-key and string-key schemas for compatibility with Zoi and Nimble.
+  defp disallow_additional_properties(%{type: :object} = schema) do
+    schema
+    |> Map.put(:additionalProperties, false)
+    |> traverse_schema_values(&disallow_additional_properties/1)
+  end
+
+  defp disallow_additional_properties(%{"type" => "object"} = schema) do
+    schema
+    |> Map.put("additionalProperties", false)
+    |> traverse_schema_values(&disallow_additional_properties/1)
+  end
+
+  defp disallow_additional_properties(schema) when is_map(schema) do
+    traverse_schema_values(schema, &disallow_additional_properties/1)
+  end
+
+  defp disallow_additional_properties(schema) when is_list(schema) do
+    Enum.map(schema, &disallow_additional_properties/1)
+  end
+
+  defp disallow_additional_properties(schema), do: schema
+
+  defp traverse_schema_values(schema, fun) do
+    schema
+    |> maybe_update_key(:properties, &map_property_schemas(&1, fun))
+    |> maybe_update_key("properties", &map_property_schemas(&1, fun))
+    |> maybe_update_key(:items, fun)
+    |> maybe_update_key("items", fun)
+    |> maybe_update_key(:allOf, &map_schema_list(&1, fun))
+    |> maybe_update_key("allOf", &map_schema_list(&1, fun))
+    |> maybe_update_key(:anyOf, &map_schema_list(&1, fun))
+    |> maybe_update_key("anyOf", &map_schema_list(&1, fun))
+    |> maybe_update_key(:oneOf, &map_schema_list(&1, fun))
+    |> maybe_update_key("oneOf", &map_schema_list(&1, fun))
+    |> maybe_update_key(:not, fun)
+    |> maybe_update_key("not", fun)
+    |> maybe_update_key(:if, fun)
+    |> maybe_update_key("if", fun)
+    |> maybe_update_key(:then, fun)
+    |> maybe_update_key("then", fun)
+    |> maybe_update_key(:else, fun)
+    |> maybe_update_key("else", fun)
+    |> maybe_update_key(:contains, fun)
+    |> maybe_update_key("contains", fun)
+  end
+
+  defp maybe_update_key(map, key, fun) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> Map.put(map, key, fun.(value))
+      :error -> map
+    end
+  end
+
+  defp map_property_schemas(properties, fun) when is_map(properties) do
+    Map.new(properties, fn {key, value} -> {key, fun.(value)} end)
+  end
+
+  defp map_property_schemas(properties, _fun), do: properties
+
+  defp map_schema_list(value, fun) when is_list(value), do: Enum.map(value, fun)
+  defp map_schema_list(value, _fun), do: value
 
   defp nimble_to_json_schema(nimble_schema) do
     properties =

--- a/lib/jido_action/tool.ex
+++ b/lib/jido_action/tool.ex
@@ -8,11 +8,13 @@ defmodule Jido.Action.Tool do
   ## Tool Formats
 
   - `to_tool/1` - Returns a generic tool map with name, description, function, and schema
+  - `to_tool/2` - Same as `to_tool/1` with JSON schema options (e.g., strict mode)
 
   ## Utility Functions
 
   - `convert_params_using_schema/2` - Normalizes LLM arguments (string keys → atom keys, type coercion)
   - `build_parameters_schema/1` - Converts action schema to JSON Schema format
+  - `build_parameters_schema/2` - Same as `build_parameters_schema/1` with schema options
   - `execute_action/3` - Executes an action with schema-based param conversion
   """
 
@@ -47,12 +49,15 @@ defmodule Jido.Action.Tool do
       }
   """
   @spec to_tool(module()) :: tool()
-  def to_tool(action) when is_atom(action) do
+  def to_tool(action) when is_atom(action), do: to_tool(action, [])
+
+  @spec to_tool(module(), keyword()) :: tool()
+  def to_tool(action, opts) when is_atom(action) and is_list(opts) do
     %{
       name: action.name(),
       description: action.description(),
       function: &execute_action(action, &1, &2),
-      parameters_schema: build_parameters_schema(action.schema())
+      parameters_schema: build_parameters_schema(action.schema(), opts)
     }
   end
 
@@ -167,7 +172,9 @@ defmodule Jido.Action.Tool do
     A map representing the parameters schema in a format compatible with LangChain.
   """
   @spec build_parameters_schema(Schema.t()) :: map()
-  def build_parameters_schema(schema) do
-    Schema.to_json_schema(schema)
-  end
+  def build_parameters_schema(schema), do: build_parameters_schema(schema, [])
+
+  @spec build_parameters_schema(Schema.t(), keyword()) :: map()
+  def build_parameters_schema(schema, opts) when is_list(opts),
+    do: Schema.to_json_schema(schema, opts)
 end

--- a/test/jido_action/exec_tool_test.exs
+++ b/test/jido_action/exec_tool_test.exs
@@ -32,6 +32,30 @@ defmodule Jido.Action.ToolTest do
     end
   end
 
+  describe "to_tool/2 strict mode" do
+    test "to_tool/1 remains legacy non-strict by default" do
+      tool = Tool.to_tool(TestActions.BasicAction)
+      refute Map.has_key?(tool.parameters_schema, "additionalProperties")
+    end
+
+    test "applies strict additionalProperties recursively when enabled" do
+      tool = Tool.to_tool(TestActions.SchemaAction, strict: true)
+
+      assert tool.parameters_schema["additionalProperties"] == false
+      assert tool.parameters_schema["properties"]["map"]["additionalProperties"] == false
+    end
+
+    test "supports explicit strict false override" do
+      tool = Tool.to_tool(TestActions.BasicAction, strict: false)
+      refute Map.has_key?(tool.parameters_schema, "additionalProperties")
+    end
+
+    test "Action module to_tool/0 defaults to strict schemas" do
+      tool = TestActions.BasicAction.to_tool()
+      assert tool.parameters_schema["additionalProperties"] == false
+    end
+  end
+
   describe "execute_action/3" do
     # test "executes the action and returns JSON-encoded result" do
     #   params = %{"value" => 42}
@@ -184,9 +208,25 @@ defmodule Jido.Action.ToolTest do
                "required" => []
              }
     end
+
+    test "build_parameters_schema/2 applies strict mode recursively" do
+      schema = TestActions.SchemaAction.schema()
+      result = Tool.build_parameters_schema(schema, strict: true)
+
+      assert result["additionalProperties"] == false
+      assert result["properties"]["map"]["additionalProperties"] == false
+    end
+
+    test "build_parameters_schema/2 with strict false preserves legacy output" do
+      schema = TestActions.SchemaAction.schema()
+      legacy = Tool.build_parameters_schema(schema)
+      strict_false = Tool.build_parameters_schema(schema, strict: false)
+
+      assert strict_false == legacy
+    end
   end
 
   # Note: parameter_to_json_schema/1 and nimble_type_to_json_schema_type/1 are now
   # private implementation details in Jido.Action.Schema. The public API is
-  # Jido.Action.Schema.to_json_schema/1 which is tested via build_parameters_schema/1
+  # Jido.Action.Schema.to_json_schema/1 and /2 which are tested via build_parameters_schema/1 and /2
 end

--- a/test/jido_action/schema_json_test.exs
+++ b/test/jido_action/schema_json_test.exs
@@ -113,4 +113,39 @@ defmodule Jido.Action.SchemaJsonTest do
       assert result["properties"]["value"]["type"] == "number"
     end
   end
+
+  describe "to_json_schema/2 - strict mode" do
+    test "adds additionalProperties false to top-level object when strict" do
+      schema = [value: [type: :integer]]
+      result = Schema.to_json_schema(schema, strict: true)
+
+      assert result["additionalProperties"] == false
+    end
+
+    test "recursively sets additionalProperties false for nested map properties" do
+      schema = [config: [type: :map]]
+      result = Schema.to_json_schema(schema, strict: true)
+
+      assert result["additionalProperties"] == false
+      assert result["properties"]["config"]["additionalProperties"] == false
+    end
+
+    test "recursively sets additionalProperties false for objects in arrays" do
+      schema = [items: [type: {:list, :map}]]
+      result = Schema.to_json_schema(schema, strict: true)
+
+      assert result["additionalProperties"] == false
+      assert result["properties"]["items"]["items"]["additionalProperties"] == false
+    end
+
+    test "strict false preserves legacy schema output" do
+      schema = [config: [type: :map]]
+      legacy = Schema.to_json_schema(schema)
+      strict_false = Schema.to_json_schema(schema, strict: false)
+
+      assert strict_false == legacy
+      refute Map.has_key?(legacy, "additionalProperties")
+      refute Map.has_key?(legacy["properties"]["config"], "additionalProperties")
+    end
+  end
 end

--- a/test/jido_action/zoi_schema_test.exs
+++ b/test/jido_action/zoi_schema_test.exs
@@ -244,6 +244,42 @@ defmodule Jido.Action.ZoiSchemaTest do
       assert Map.has_key?(json_schema[:properties], :limit)
     end
 
+    test "strict mode recursively sets additionalProperties false for nested objects" do
+      schema =
+        Zoi.object(%{
+          config: Zoi.object(%{name: Zoi.string()}),
+          items: Zoi.list(Zoi.object(%{id: Zoi.string()}))
+        })
+
+      json_schema = Action.Schema.to_json_schema(schema, strict: true)
+
+      assert json_schema[:additionalProperties] == false
+      assert json_schema[:properties][:config][:additionalProperties] == false
+      assert json_schema[:properties][:items][:items][:additionalProperties] == false
+    end
+
+    test "strict mode handles mixed atom and string property keys" do
+      schema =
+        Zoi.object(%{
+          "string_outer" => Zoi.object(%{inner: Zoi.string()}),
+          atom_outer: Zoi.object(%{"inner2" => Zoi.string()})
+        })
+
+      json_schema = Action.Schema.to_json_schema(schema, strict: true)
+
+      assert json_schema[:additionalProperties] == false
+      assert json_schema[:properties]["string_outer"][:additionalProperties] == false
+      assert json_schema[:properties][:atom_outer][:additionalProperties] == false
+    end
+
+    test "strict false preserves default Zoi json schema output" do
+      schema = AIToolAction.schema()
+      legacy = Action.Schema.to_json_schema(schema)
+      strict_false = Action.Schema.to_json_schema(schema, strict: false)
+
+      assert strict_false == legacy
+    end
+
     test "provides action metadata" do
       assert AIToolAction.name() == "ai_tool_action"
       assert AIToolAction.description() == "Action for AI tool integration"


### PR DESCRIPTION
## Summary
- add `Jido.Action.Schema.to_json_schema/2` with `strict: true|false` support while preserving `to_json_schema/1`
- recursively apply `additionalProperties: false` to all object schemas when strict mode is enabled
- add `Jido.Action.Tool.to_tool/2` and `build_parameters_schema/2` while keeping `/1` arities backward-compatible
- make generated `Action.to_tool/0` default to strict schema generation (`strict: true`)
- update AI/schema guides with strict default and explicit opt-out usage

## Tests
- `mix test test/jido_action/schema_json_test.exs test/jido_action/zoi_schema_test.exs test/jido_action/exec_tool_test.exs test/jido_tools/lua_eval_test.exs test/jido_tools/workflow_test.exs`
- `mix test`

Closes #100
