### PR TITLE
docs: add Igniter installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ Jido.Action transforms ad-hoc functions into structured, validated, AI-compatibl
 
 ## Installation
 
+### Igniter Installation (Recommended)
+
+The fastest way to get started is with [Igniter](https://hex.pm/packages/igniter):
+
+```bash
+mix igniter.install jido_action
+```
+
+This automatically:
+- Adds `jido_action` to your dependencies
+- Configures default settings (timeout, retries, backoff)
+- Optionally generates an example action with `--example`
+
+### Manual Installation
+
 Add `jido_action` to your list of dependencies in `mix.exs`:
 
 ```elixir


### PR DESCRIPTION
## Summary
- Updates README Installation section to include Igniter as the recommended installation method
- Adds `mix igniter.install jido_action` instructions with feature list
- Preserves existing manual installation instructions

## Test plan
- [x] README renders correctly on GitHub
- [x] Igniter installation command is accurate
- [x] Manual installation instructions still present and correct

Generated with [Claude Code](https://claude.com/claude-code)