### PR TITLE
fix: derive Jason.Encoder for error structs

### DIFF
--- a/.spec/decisions/jido_action.error_struct_json_encoding.md
+++ b/.spec/decisions/jido_action.error_struct_json_encoding.md
@@ -1,0 +1,42 @@
+---
+id: jido_action.error_struct_json_encoding
+status: accepted
+date: 2026-04-10
+affects:
+  - jido_action.error_handling
+  - jido_action.package
+---
+
+# Keep direct error JSON encoding shallow and preserve `to_map/1` as the full transport boundary
+
+## Context
+
+`Jido.Action.Error` already owned the package's transport-safe error-map conversion through
+`to_map/1`, but callers and tests also treat the concrete exception structs as part of the public
+failure surface. This branch adds direct `Jason.encode/1` support for the concrete error structs.
+
+Those structs still carry a `:details` field that may include stacktraces, tuples, nested
+exceptions, or other runtime terms that are not safe to dump directly through Jason. That means the
+branch changes both the error-handling subject and the package-level execution failure surface in a
+durable way.
+
+## Decision
+
+The package supports two JSON-facing error representations with different responsibilities:
+
+- direct `Jason.encode/1` on concrete `Jido.Action.Error.*Error` structs is supported for stable
+  top-level fields such as `message`, `field`, `value`, and `timeout`
+- derived struct encoding shall omit raw `:details`
+- callers that need a full structured payload shall use `Jido.Action.Error.to_map/1`, which
+  remains the path that sanitizes nested runtime terms into transport-safe data
+- shared error tests may prove both surfaces because they describe the same durable failure
+  contract from different access paths
+
+## Consequences
+
+- Direct JSON encoding stays convenient for shallow transport cases that only need the stable
+  top-level fields.
+- The richer `:details` contract remains explicit and sanitized through `to_map/1` instead of
+  relying on Jason protocol implementations for arbitrary runtime terms.
+- Future changes that add or remove directly encoded fields should update both impacted subject
+  specs and this ADR together.

--- a/.spec/specs/error_handling.spec.md
+++ b/.spec/specs/error_handling.spec.md
@@ -10,13 +10,14 @@ Describe the package-wide error surface that execution and action helpers return
 id: jido_action.error_handling
 kind: module
 status: active
-summary: Centralized error classes, concrete exceptions, and normalization helpers for Jido action failures.
+summary: Centralized error classes, concrete exceptions, direct JSON encoding, and normalization helpers for Jido action failures.
 surface:
   - lib/jido_action/error.ex
   - guides/error-handling.md
   - test/jido_action/error_test.exs
 decisions:
   - jido_action.spec_migration
+  - jido_action.error_struct_json_encoding
 ```
 
 ## Requirements
@@ -26,6 +27,11 @@ decisions:
   statement: Jido.Action.Error shall provide concrete exception structs and helper constructors for validation, execution, timeout, configuration, and internal errors, with normalized mapping suitable for cross-package handling.
   priority: must
   stability: stable
+
+- id: jido_action.error_handling.direct_json_struct_fields
+  statement: Jido.Action.Error shall let callers encode its concrete exception structs directly through Jason for stable top-level fields such as message, field, value, and timeout, while omitting raw `:details` values that may still contain non-JSON-safe runtime terms.
+  priority: should
+  stability: evolving
 
 - id: jido_action.error_handling.transport_safe_error_maps
   statement: Jido.Action.Error.to_map/1 shall normalize action errors into maps whose `:details` payload is transport-safe recursive data for maps, structs, exceptions, tuples, and nested runtime terms without mutating the original in-process error value.
@@ -46,6 +52,7 @@ decisions:
   execute: true
   covers:
     - jido_action.error_handling.normalized_errors
+    - jido_action.error_handling.direct_json_struct_fields
     - jido_action.error_handling.transport_safe_error_maps
     - jido_action.error_handling.retryable_hints
 ```

--- a/.spec/specs/package.spec.md
+++ b/.spec/specs/package.spec.md
@@ -22,15 +22,18 @@ surface:
   - test/support/*.ex
   - usage-rules.md
   - lib/jido_action.ex
+  - lib/jido_action/error.ex
   - lib/jido_action/exec.ex
   - lib/jido_action/tool.ex
   - lib/jido_instruction.ex
   - lib/jido_plan.ex
+  - test/jido_action/error_test.exs
 decisions:
   - jido_action.spec_migration
   - jido_action.cross_subject_ci_stabilization
   - jido_action.action_effect_boundary_docs
   - jido_action.execution_logging_hygiene
+  - jido_action.error_struct_json_encoding
 ```
 
 ## Requirements
@@ -42,7 +45,7 @@ decisions:
   stability: stable
 
 - id: jido_action.package.execution_failure_surface
-  statement: The package-level execution surface shall expose runtime failures as normalized exception structs with string messages and structured, transport-safe details suitable for downstream handling and JSON encoding.
+  statement: The package-level execution surface shall expose runtime failures as normalized exception structs with string messages and directly Jason-encodable stable top-level fields, while routing full transport-safe details through Jido.Action.Error.to_map/1 for downstream handling.
   priority: should
   stability: evolving
 

--- a/.spec/state.json
+++ b/.spec/state.json
@@ -26,6 +26,17 @@
       },
       {
         "affects": [
+          "jido_action.error_handling",
+          "jido_action.package"
+        ],
+        "date": "2026-04-10",
+        "file": ".spec/decisions/jido_action.error_struct_json_encoding.md",
+        "id": "jido_action.error_struct_json_encoding",
+        "status": "accepted",
+        "title": "Keep direct error JSON encoding shallow and preserve `to_map/1` as the full transport boundary"
+      },
+      {
+        "affects": [
           "jido_action.exec",
           "jido_action.package",
           "jido_action.tools"
@@ -99,6 +110,14 @@
         "stability": "evolving",
         "statement": "Jido.Action.Tool.execute_action/3 shall preserve the legacy `{:ok, json}` and `{:error, json}` contract while emitting sanitized success payloads and binary error payloads even when raw failure inspection is unsafe.",
         "subject_id": "jido_action.action"
+      },
+      {
+        "file": ".spec/specs/error_handling.spec.md",
+        "id": "jido_action.error_handling.direct_json_struct_fields",
+        "priority": "should",
+        "stability": "evolving",
+        "statement": "Jido.Action.Error shall let callers encode its concrete exception structs directly through Jason for stable top-level fields such as message, field, value, and timeout, while omitting raw `:details` values that may still contain non-JSON-safe runtime terms.",
+        "subject_id": "jido_action.error_handling"
       },
       {
         "file": ".spec/specs/error_handling.spec.md",
@@ -193,7 +212,7 @@
         "id": "jido_action.package.execution_failure_surface",
         "priority": "should",
         "stability": "evolving",
-        "statement": "The package-level execution surface shall expose runtime failures as normalized exception structs with string messages and structured, transport-safe details suitable for downstream handling and JSON encoding.",
+        "statement": "The package-level execution surface shall expose runtime failures as normalized exception structs with string messages and directly Jason-encodable stable top-level fields, while routing full transport-safe details through Jido.Action.Error.to_map/1 for downstream handling.",
         "subject_id": "jido_action.package"
       },
       {
@@ -416,12 +435,13 @@
         "id": "jido_action.error_handling",
         "meta": {
           "decisions": [
-            "jido_action.spec_migration"
+            "jido_action.spec_migration",
+            "jido_action.error_struct_json_encoding"
           ],
           "id": "jido_action.error_handling",
           "kind": "module",
           "status": "active",
-          "summary": "Centralized error classes, concrete exceptions, and normalization helpers for Jido action failures.",
+          "summary": "Centralized error classes, concrete exceptions, direct JSON encoding, and normalization helpers for Jido action failures.",
           "surface": [
             "lib/jido_action/error.ex",
             "guides/error-handling.md",
@@ -467,7 +487,8 @@
             "jido_action.spec_migration",
             "jido_action.cross_subject_ci_stabilization",
             "jido_action.action_effect_boundary_docs",
-            "jido_action.execution_logging_hygiene"
+            "jido_action.execution_logging_hygiene",
+            "jido_action.error_struct_json_encoding"
           ],
           "id": "jido_action.package",
           "kind": "package",
@@ -484,10 +505,12 @@
             "test/support/*.ex",
             "usage-rules.md",
             "lib/jido_action.ex",
+            "lib/jido_action/error.ex",
             "lib/jido_action/exec.ex",
             "lib/jido_action/tool.ex",
             "lib/jido_instruction.ex",
-            "lib/jido_plan.ex"
+            "lib/jido_plan.ex",
+            "test/jido_action/error_test.exs"
           ],
           "verification_minimum_strength": null
         },
@@ -680,6 +703,7 @@
       {
         "covers": [
           "jido_action.error_handling.normalized_errors",
+          "jido_action.error_handling.direct_json_struct_fields",
           "jido_action.error_handling.transport_safe_error_maps",
           "jido_action.error_handling.retryable_hints"
         ],
@@ -975,10 +999,10 @@
   "specification_version": "1.0",
   "summary": {
     "decision_parse_errors": 0,
-    "decisions": 4,
+    "decisions": 5,
     "exceptions": 0,
     "findings": 0,
-    "requirements": 41,
+    "requirements": 42,
     "scenarios": 0,
     "subjects": 10,
     "verifications": 32
@@ -1061,6 +1085,17 @@
         "subject_id": "jido_action.action",
         "target": "guides/actions-guide.md",
         "verification_index": 2
+      },
+      {
+        "cover_id": "jido_action.error_handling.direct_json_struct_fields",
+        "file": ".spec/specs/error_handling.spec.md",
+        "kind": "command",
+        "meets_minimum": true,
+        "required_strength": "claimed",
+        "strength": "executed",
+        "subject_id": "jido_action.error_handling",
+        "target": "mix test test/jido_action/error_test.exs",
+        "verification_index": 0
       },
       {
         "cover_id": "jido_action.error_handling.normalized_errors",
@@ -1573,13 +1608,13 @@
     "default_minimum_strength": "claimed",
     "strength_summary": {
       "claimed": 2,
-      "executed": 33,
+      "executed": 34,
       "linked": 18
     },
     "threshold_failures": 0
   },
   "workspace": {
-    "decision_count": 4,
+    "decision_count": 5,
     "spec_count": 10
   }
 }

--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -147,6 +147,7 @@ defmodule Jido.Action.Error do
   # Define specific error structs inline
   defmodule InvalidInputError do
     @moduledoc "Error for invalid input parameters"
+    @derive {Jason.Encoder, only: [:message, :field, :value]}
     defexception [:message, :field, :value, :details]
 
     @type t :: %__MODULE__{
@@ -171,6 +172,7 @@ defmodule Jido.Action.Error do
 
   defmodule ExecutionFailureError do
     @moduledoc "Error for runtime execution failures"
+    @derive {Jason.Encoder, only: [:message]}
     defexception [:message, :details]
 
     @type t :: %__MODULE__{
@@ -189,6 +191,7 @@ defmodule Jido.Action.Error do
 
   defmodule TimeoutError do
     @moduledoc "Error for action timeouts"
+    @derive {Jason.Encoder, only: [:message, :timeout]}
     defexception [:message, :timeout, :details]
 
     @type t :: %__MODULE__{
@@ -209,6 +212,7 @@ defmodule Jido.Action.Error do
 
   defmodule ConfigurationError do
     @moduledoc "Error for configuration issues"
+    @derive {Jason.Encoder, only: [:message]}
     defexception [:message, :details]
 
     @type t :: %__MODULE__{
@@ -227,6 +231,7 @@ defmodule Jido.Action.Error do
 
   defmodule InternalError do
     @moduledoc "Error for unexpected internal failures"
+    @derive {Jason.Encoder, only: [:message]}
     defexception [:message, :details]
 
     @type t :: %__MODULE__{

--- a/test/jido_action/error_test.exs
+++ b/test/jido_action/error_test.exs
@@ -394,6 +394,49 @@ defmodule Jido.Action.ErrorTest do
     end
   end
 
+  describe "Jason.Encoder for error structs" do
+    test "InvalidInputError is directly JSON-encodable" do
+      error = Error.validation_error("bad input", field: :name, value: 123)
+      assert {:ok, json} = Jason.encode(error)
+      decoded = Jason.decode!(json)
+      assert decoded["message"] == "bad input"
+      assert decoded["field"] == "name"
+      # details excluded — may contain non-serializable terms
+      refute Map.has_key?(decoded, "details")
+    end
+
+    test "ExecutionFailureError is directly JSON-encodable" do
+      error = Error.execution_error("boom", %{stacktrace: [{Enum, :map, 2, []}]})
+      assert {:ok, json} = Jason.encode(error)
+      decoded = Jason.decode!(json)
+      assert decoded["message"] == "boom"
+      # details excluded — contains stacktrace tuples
+      refute Map.has_key?(decoded, "details")
+    end
+
+    test "TimeoutError is directly JSON-encodable" do
+      error = Error.timeout_error("timed out", timeout: 5000)
+      assert {:ok, json} = Jason.encode(error)
+      decoded = Jason.decode!(json)
+      assert decoded["message"] == "timed out"
+      assert decoded["timeout"] == 5000
+    end
+
+    test "ConfigurationError is directly JSON-encodable" do
+      error = Error.config_error("missing key", %{key: :api_url})
+      assert {:ok, json} = Jason.encode(error)
+      decoded = Jason.decode!(json)
+      assert decoded["message"] == "missing key"
+    end
+
+    test "InternalError is directly JSON-encodable" do
+      error = Error.internal_error("unexpected", %{reason: :unknown})
+      assert {:ok, json} = Jason.encode(error)
+      decoded = Jason.decode!(json)
+      assert decoded["message"] == "unexpected"
+    end
+  end
+
   describe "retryable?/1" do
     test "matches timeout and transient action errors" do
       assert Error.retryable?(Error.timeout_error("timed out", timeout: 500))


### PR DESCRIPTION
## Problem

jido_ai's ReAct strategy serializes tool execution errors as JSON when appending them to the conversation context (`Jido.AI.Turn.encode_tool_result_envelope/2`). The error structs don't implement `Jason.Encoder`, causing `Jason.EncodeError` crashes:

```
** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for
%Jido.Action.Error.ExecutionFailureError{...}
```

## Fix

Add `@derive {Jason.Encoder, only: [...]}` to each error struct:

| Struct | Encoded fields |
|--------|---------------|
| `InvalidInputError` | `message`, `field`, `value` |
| `ExecutionFailureError` | `message` |
| `TimeoutError` | `message`, `timeout` |
| `ConfigurationError` | `message` |
| `InternalError` | `message` |

The `details` field is intentionally excluded — it may contain stacktrace tuples (`{Module, :function, arity, location}`) and other non-JSON-serializable terms that would cause `Jason.EncodeError`.

## Tests

Added 5 tests verifying each error struct is directly JSON-encodable, including a case where `details` contains stacktrace tuples. All 799 tests pass.

Related: agentjido/jido_ai#250 (fixes the content parts encoding issue on the jido_ai side)