### PR TITLE
fix: propagate OTel context through Task.Supervisor in execute_action_with_timeout

### DIFF
--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -494,12 +494,19 @@ defmodule Jido.Exec do
       parent = self()
       ref = make_ref()
 
+      # Capture the current OTel context so the spawned task runs as a child
+      # of whatever span is active in the caller — otherwise spans created by
+      # the action are orphaned (root) spans in their own traces.
+      otel_ctx = otel_get_current_context()
+
       # Spawn process under the supervisor and send the result back explicitly.
       # This avoids relying on Task.yield/2 behavior/typing (Elixir 1.18+).
       {:ok, pid} =
         Task.Supervisor.start_child(task_sup, fn ->
           # Use the parent's group leader to ensure IO is properly captured
           Process.group_leader(self(), current_gl)
+
+          otel_attach_context(otel_ctx)
 
           result = execute_action(action, params, context, opts)
           send(parent, {:execute_action_result, ref, result})
@@ -739,6 +746,22 @@ defmodule Jido.Exec do
 
     defp build_exception_message(e, action) do
       "An unexpected error occurred during execution of #{inspect(action)}: #{inspect(e)}"
+    end
+
+    # OTel context propagation helpers — no-ops when OpenTelemetry isn't loaded
+    # (it's an optional dependency for host apps). The compile directive
+    # suppresses "undefined module" warnings; runtime check guards the calls.
+    @compile {:no_warn_undefined, OpenTelemetry.Ctx}
+
+    defp otel_get_current_context do
+      if Code.ensure_loaded?(OpenTelemetry.Ctx), do: OpenTelemetry.Ctx.get_current()
+    end
+
+    defp otel_attach_context(nil), do: :ok
+
+    defp otel_attach_context(ctx) do
+      if Code.ensure_loaded?(OpenTelemetry.Ctx), do: OpenTelemetry.Ctx.attach(ctx)
+      :ok
     end
   end
 end

--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -23,6 +23,15 @@ defmodule Jido.Exec do
   - Telemetry integration for monitoring and tracing
   - Action cancellation and cleanup
 
+  ## OpenTelemetry
+
+  When the optional `:opentelemetry_api` dependency is present in the host
+  application, `Jido.Exec` propagates the caller's OpenTelemetry context across
+  the `Task.Supervisor` boundary used for timeout-enforced execution. This
+  keeps spans created inside an action correctly parented to spans started by
+  the caller. Hosts that do not depend on OpenTelemetry are unaffected — the
+  context helpers are no-ops when the module isn't loaded.
+
   ## Usage
 
   Basic action execution:
@@ -748,11 +757,10 @@ defmodule Jido.Exec do
       "An unexpected error occurred during execution of #{inspect(action)}: #{inspect(e)}"
     end
 
-    # OTel context propagation helpers — no-ops when OpenTelemetry isn't loaded
-    # (it's an optional dependency for host apps). The compile directive
-    # suppresses "undefined module" warnings; runtime check guards the calls.
-    @compile {:no_warn_undefined, OpenTelemetry.Ctx}
-
+    # OTel context propagation helpers — no-ops when OpenTelemetry isn't loaded.
+    # :opentelemetry_api is declared as an optional dep, so host apps that don't
+    # opt in won't have the module at runtime; the Code.ensure_loaded?/1 guard
+    # makes these calls safe in that case.
     defp otel_get_current_context do
       if Code.ensure_loaded?(OpenTelemetry.Ctx), do: OpenTelemetry.Ctx.get_current()
     end

--- a/mix.exs
+++ b/mix.exs
@@ -241,7 +241,7 @@ defmodule JidoAction.MixProject do
        only: [:dev, :test],
        runtime: false},
       {:stream_data, "~> 1.0", only: [:dev, :test]},
-      {:opentelemetry_api, "~> 1.4", only: :test},
+      {:opentelemetry_api, "~> 1.4", optional: true},
 
       # Code generation
       {:igniter, "~> 0.7", optional: true}

--- a/mix.exs
+++ b/mix.exs
@@ -241,6 +241,7 @@ defmodule JidoAction.MixProject do
        only: [:dev, :test],
        runtime: false},
       {:stream_data, "~> 1.0", only: [:dev, :test]},
+      {:opentelemetry_api, "~> 1.4", only: :test},
 
       # Code generation
       {:igniter, "~> 0.7", optional: true}

--- a/mix.lock
+++ b/mix.lock
@@ -34,6 +34,7 @@
   "nimble_options": {:hex, :nimble_options, "1.1.1", "e3a492d54d85fc3fd7c5baf411d9d2852922f66e69476317787a7b2bb000a61b", [:mix], [], "hexpm", "821b2470ca9442c4b6984882fe9bb0389371b8ddec4d45a9504f00a66f650b44"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "nimble_pool": {:hex, :nimble_pool, "1.1.0", "bf9c29fbdcba3564a8b800d1eeb5a3c58f36e1e11d7b7fb2e084a643f645f06b", [:mix], [], "hexpm", "af2e4e6b34197db81f7aad230c1118eac993acc0dae6bc83bac0126d4ae0813a"},
+  "opentelemetry_api": {:hex, :opentelemetry_api, "1.5.0", "1a676f3e3340cab81c763e939a42e11a70c22863f645aa06aafefc689b5550cf", [:mix, :rebar3], [], "hexpm", "f53ec8a1337ae4a487d43ac89da4bd3a3c99ddf576655d071deed8b56a2d5dda"},
   "owl": {:hex, :owl, "0.13.0", "26010e066d5992774268f3163506972ddac0a7e77bfe57fa42a250f24d6b876e", [:mix], [{:ucwidth, "~> 0.2", [hex: :ucwidth, repo: "hexpm", optional: true]}], "hexpm", "59bf9d11ce37a4db98f57cb68fbfd61593bf419ec4ed302852b6683d3d2f7475"},
   "private": {:hex, :private, "0.1.2", "da4add9f36c3818a9f849840ca43016c8ae7f76d7a46c3b2510f42dcc5632932", [:mix], [], "hexpm", "22ee01c3f450cf8d135da61e10ec59dde006238fab1ea039014791fc8f3ff075"},
   "recase": {:hex, :recase, "0.8.1", "ab98cd35857a86fa5ca99036f575241d71d77d9c2ab0c39aacf1c9b61f6f7d1d", [:mix], [], "hexpm", "9fd8d63e7e43bd9ea385b12364e305778b2bbd92537e95c4b2e26fc507d5e4c2"},

--- a/test/jido_action/exec_otel_test.exs
+++ b/test/jido_action/exec_otel_test.exs
@@ -1,7 +1,7 @@
 defmodule Jido.ExecOtelTest do
   @moduledoc """
-  Regression tests for OTel context propagation through Task.Supervisor in
-  `Jido.Exec.execute_action_with_timeout/5`.
+  Regression tests for OTel context propagation through Task.Supervisor when
+  `Jido.Exec.run/4` is invoked with a positive timeout.
 
   When timeout > 0, the action runs in a spawned child task. Without explicit
   propagation, the OTel process-dictionary context does not flow into the task
@@ -32,7 +32,7 @@ defmodule Jido.ExecOtelTest do
       OpenTelemetry.Ctx.attach(caller_ctx)
 
       assert {:ok, %{ctx_in_action: action_ctx}} =
-               Exec.execute_action_with_timeout(CaptureCtxAction, %{}, %{}, 1_000)
+               Exec.run(CaptureCtxAction, %{}, %{}, timeout: 1_000)
 
       assert OpenTelemetry.Ctx.get_value(action_ctx, :test_key, nil) == :test_value
     end
@@ -41,7 +41,7 @@ defmodule Jido.ExecOtelTest do
       OpenTelemetry.Ctx.attach(OpenTelemetry.Ctx.new())
 
       assert {:ok, %{ctx_in_action: action_ctx}} =
-               Exec.execute_action_with_timeout(CaptureCtxAction, %{}, %{}, 1_000)
+               Exec.run(CaptureCtxAction, %{}, %{}, timeout: 1_000)
 
       assert is_map(action_ctx)
     end

--- a/test/jido_action/exec_otel_test.exs
+++ b/test/jido_action/exec_otel_test.exs
@@ -1,0 +1,49 @@
+defmodule Jido.ExecOtelTest do
+  @moduledoc """
+  Regression tests for OTel context propagation through Task.Supervisor in
+  `Jido.Exec.execute_action_with_timeout/5`.
+
+  When timeout > 0, the action runs in a spawned child task. Without explicit
+  propagation, the OTel process-dictionary context does not flow into the task
+  and any spans created inside the action become orphan root spans.
+  """
+  use ExUnit.Case, async: false
+
+  alias Jido.Exec
+
+  defmodule CaptureCtxAction do
+    @moduledoc false
+    use Jido.Action,
+      name: "capture_ctx",
+      description: "Captures the OTel context current in its own process",
+      schema: []
+
+    @impl true
+    def run(_params, _context) do
+      {:ok, %{ctx_in_action: OpenTelemetry.Ctx.get_current()}}
+    end
+  end
+
+  describe "OTel context propagation through Task.Supervisor" do
+    test "action sees the same OTel context as the caller (timeout > 0)" do
+      caller_ctx =
+        OpenTelemetry.Ctx.set_value(OpenTelemetry.Ctx.new(), :test_key, :test_value)
+
+      OpenTelemetry.Ctx.attach(caller_ctx)
+
+      assert {:ok, %{ctx_in_action: action_ctx}} =
+               Exec.execute_action_with_timeout(CaptureCtxAction, %{}, %{}, 1_000)
+
+      assert OpenTelemetry.Ctx.get_value(action_ctx, :test_key, nil) == :test_value
+    end
+
+    test "empty caller context still works (no-op propagation)" do
+      OpenTelemetry.Ctx.attach(OpenTelemetry.Ctx.new())
+
+      assert {:ok, %{ctx_in_action: action_ctx}} =
+               Exec.execute_action_with_timeout(CaptureCtxAction, %{}, %{}, 1_000)
+
+      assert is_map(action_ctx)
+    end
+  end
+end


### PR DESCRIPTION
## Description

When timeout > 0, the action runs in a spawned task with an empty OTel context, so any spans created inside the action become orphan root spans. Capture the caller's context and re-attach it in the child task.

## Type of Change

- [x1] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

<!-- If this is a breaking change, describe the impact and migration path -->

## Testing

- [x] Tests pass (`mix test`)
- [ ] Quality checks pass (`mix quality`)

There's a pre-existing issue with `mix quality` in `lua_eval.ex`.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [ ] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

