### PR TITLE
fix: preserve runtime context across supervised execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
-## Unreleased
-
-### Bug Fixes:
-
-* exec: preserve runtime context across supervised execution boundaries
-
 ## [v2.2.1](https://github.com/agentjido/jido_action/compare/v2.2.0...v2.2.1) (2026-04-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
+## Unreleased
+
+### Bug Fixes:
+
+* exec: preserve runtime context across supervised execution boundaries
+
 ## [v2.2.1](https://github.com/agentjido/jido_action/compare/v2.2.0...v2.2.1) (2026-04-03)
 
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ async_ref = Jido.Exec.run_async(MyApp.Actions.GreetUser, %{name: "Bob"})
 
 - `run_async/4` executes under `Task.Supervisor` (global or instance-scoped via `jido:`).
 - `async_ref` is mailbox-bound to the process that started the async call; await/cancel from that same process.
+- Runtime context propagators configured globally or per execution are captured before supervised task boundaries and reattached inside async, timeout, compensation, and async-chain workers.
 - `await/2` timeout kills the task and drains monitor/result mailbox residue before returning.
 - `cancel/1` sends `:shutdown`, waits a bounded grace period, and flushes monitor/result residue.
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -22,7 +22,13 @@ config :jido_action,
   default_backoff: 250,         # Initial backoff in milliseconds (exponential, capped at 30s)
 
   # Execution logging threshold
-  default_log_level: :info
+  default_log_level: :info,
+
+  # Optional runtime-context propagation across supervised execution
+  observability: [
+    context_propagators: [],
+    context_propagator_failure_mode: :warn
+  ]
 ```
 
 ### Environment-Specific Configuration
@@ -135,12 +141,57 @@ Override settings when executing actions:
 - `:backoff` - Initial backoff time in ms, doubles with each retry (default: 250, capped at 30s)
 - `:log_level` - Override Jido's execution log threshold for this call. Accepts `Logger.levels()`. Global Logger config still applies underneath.
 - `:telemetry` - Telemetry mode: `:full` (default) or `:silent`
+- `:context_propagators` - Context propagator modules captured before supervised task boundaries and reattached inside child processes
+- `:context_propagator_failure_mode` - `:warn` (default) to log and skip failures, or `:strict` to raise
 
 Execution log level precedence is:
 
 1. `opts[:log_level]`
 2. `config :jido_action, default_log_level: ...`
 3. built-in `:info`
+
+### Observability Context Propagation
+
+`Jido.Exec` can preserve process-local runtime context when execution crosses `Task.Supervisor`
+boundaries for timeout handling, `run_async/4`, compensation, and async chains.
+
+Configure propagators globally:
+
+```elixir
+config :jido_action,
+  observability: [
+    context_propagators: [MyApp.Observability.ContextPropagator],
+    context_propagator_failure_mode: :warn
+  ]
+```
+
+Or override them per execution:
+
+```elixir
+Jido.Exec.run(
+  MyApp.Actions.ProcessData,
+  %{data: "input"},
+  %{},
+  timeout: 5_000,
+  context_propagators: [MyApp.Observability.ContextPropagator],
+  context_propagator_failure_mode: :strict
+)
+```
+
+Each propagator module must implement:
+
+```elixir
+defmodule MyApp.Observability.ContextPropagator do
+  @behaviour Jido.Exec.ContextPropagator
+
+  def capture(), do: ...
+  def attach(captured), do: ...
+  def detach(attached), do: :ok
+end
+```
+
+This keeps `jido_action` observability-agnostic while allowing adapter packages such as
+OpenTelemetry bridges to preserve tracing context across supervised execution.
 
 ### Configuration Access
 
@@ -434,6 +485,7 @@ end
 | `:default_timeout` | non-negative integer | 30000 | Default action timeout in milliseconds (invalid values warn + fallback) |
 | `:default_max_retries` | non-negative integer | 1 | Default number of retry attempts (invalid values warn + fallback) |
 | `:default_backoff` | non-negative integer | 250 | Initial backoff time in ms (exponential, invalid values warn + fallback) |
+| `:observability` | keyword list | `[]` | Runtime context propagation config (`:context_propagators`, `:context_propagator_failure_mode`) |
 
 ### Action Compensation Config
 
@@ -456,6 +508,8 @@ Passed to `Jido.Exec.run/4`:
 | `:backoff` | integer | 250 | Initial backoff in ms |
 | `:log_level` | atom | `config(:jido_action, :default_log_level)` or `:info` | Jido execution log threshold override |
 | `:telemetry` | atom | :full | `:full` or `:silent` |
+| `:context_propagators` | list(module) | `config(:jido_action, :observability)[:context_propagators]` | Runtime context propagators captured before supervised execution |
+| `:context_propagator_failure_mode` | atom | `:warn` | `:warn` to skip failures, `:strict` to raise |
 | `:jido` | atom | nil | Instance name for multi-tenant isolation |
 
 ## Best Practices

--- a/guides/execution-engine.md
+++ b/guides/execution-engine.md
@@ -76,6 +76,7 @@ async_ref = Jido.Exec.run_async(
 - `Jido.Exec.run_async/4` starts work under `Task.Supervisor`; with `jido: MyApp.Jido`, it routes to `MyApp.Jido.TaskSupervisor`.
 - The returned `async_ref` is tied to the caller mailbox that initiated `run_async/4`.
   Await/cancel from the same process to avoid waiting on messages that were delivered elsewhere.
+- Runtime context propagators configured through `config :jido_action, :observability` or per-execution opts are captured before supervised task boundaries and reattached inside async, timeout, compensation, and async-chain workers.
 - `Jido.Exec.await/2` performs deterministic cleanup:
   - waits for result or monitor `:DOWN`
   - on timeout, terminates the task

--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -43,6 +43,7 @@ defmodule Jido.Exec do
   alias Jido.Action.Util
   alias Jido.Exec.Async
   alias Jido.Exec.Compensation
+  alias Jido.Exec.Propagation
   alias Jido.Exec.Retry
   alias Jido.Exec.Supervisors
   alias Jido.Exec.Telemetry
@@ -112,6 +113,8 @@ defmodule Jido.Exec do
     - `:backoff` - Initial backoff time in milliseconds, doubles with each retry (configurable via `:jido_action, :default_backoff`).
     - `:log_level` - Override the Jido execution log threshold for this specific action. Accepts #{inspect(Logger.levels())}. Global Logger config still applies.
     - `:telemetry` - `:full` (default) or `:silent` for action span emission.
+    - `:context_propagators` - Runtime context propagator modules captured before supervised execution and reattached inside supervised tasks.
+    - `:context_propagator_failure_mode` - `:warn` (default) to skip failing propagators or `:strict` to raise when propagation callbacks fail.
     - `:error_normalization` - Deprecated compatibility shim. Accepted and ignored; canonical structured execution error normalization is always used.
     - `:jido` - Optional instance name for isolation. Routes execution through instance-scoped supervisors (e.g., `MyApp.Jido.TaskSupervisor`).
 
@@ -488,6 +491,7 @@ defmodule Jido.Exec do
 
       # Resolve supervisor based on jido: option (defaults to global)
       task_sup = Supervisors.task_supervisor(opts)
+      propagation = Propagation.capture(opts)
 
       parent = self()
       ref = make_ref()
@@ -499,7 +503,11 @@ defmodule Jido.Exec do
           # Use the parent's group leader to ensure IO is properly captured
           Process.group_leader(self(), current_gl)
 
-          result = execute_action(action, params, context, opts)
+          result =
+            Propagation.with_attached(propagation, fn ->
+              execute_action(action, params, context, opts)
+            end)
+
           send(parent, {:execute_action_result, ref, result})
         end)
 

--- a/lib/jido_action/exec/async.ex
+++ b/lib/jido_action/exec/async.ex
@@ -8,6 +8,7 @@ defmodule Jido.Exec.Async do
   use Private
 
   alias Jido.Action.Error
+  alias Jido.Exec.Propagation
   alias Jido.Exec.Supervisors
 
   require Logger
@@ -86,15 +87,18 @@ defmodule Jido.Exec.Async do
 
     # Resolve supervisor based on jido: option (defaults to global)
     task_sup = Supervisors.task_supervisor(opts)
+    propagation = Propagation.capture(opts)
 
     # Start the task under the resolved TaskSupervisor.
     # If the supervisor is not running, this will raise an error.
     {:ok, pid} =
       Task.Supervisor.start_child(task_sup, fn ->
-        Process.put(@async_owner_key, owner)
-        result = Jido.Exec.run(action, params, context, opts)
-        send(owner, {:action_async_result, ref, result})
-        result
+        Propagation.with_attached(propagation, fn ->
+          Process.put(@async_owner_key, owner)
+          result = Jido.Exec.run(action, params, context, opts)
+          send(owner, {:action_async_result, ref, result})
+          result
+        end)
       end)
 
     # Persist monitor_ref in async_ref so await can demonitor/flush deterministically.

--- a/lib/jido_action/exec/async.ex
+++ b/lib/jido_action/exec/async.ex
@@ -39,7 +39,7 @@ defmodule Jido.Exec.Async do
   @type action :: module()
   @type params :: map()
   @type context :: map()
-  @type run_opts :: [timeout: non_neg_integer(), jido: atom()]
+  @type run_opts :: Jido.Exec.run_opts()
   @type async_ref :: %{
           required(:ref) => reference(),
           required(:pid) => pid(),

--- a/lib/jido_action/exec/chain.ex
+++ b/lib/jido_action/exec/chain.ex
@@ -20,6 +20,7 @@ defmodule Jido.Exec.Chain do
   alias Jido.Action.Error
   alias Jido.Action.Util
   alias Jido.Exec
+  alias Jido.Exec.Propagation
   alias Jido.Exec.Supervisors
 
   @type chain_action :: module() | {module(), keyword()}
@@ -65,7 +66,11 @@ defmodule Jido.Exec.Chain do
 
     if async do
       task_sup = Supervisors.task_supervisor(opts)
-      Task.Supervisor.async_nolink(task_sup, chain_fun)
+      propagation = Propagation.capture(opts)
+
+      Task.Supervisor.async_nolink(task_sup, fn ->
+        Propagation.with_attached(propagation, chain_fun)
+      end)
     else
       chain_fun.()
     end

--- a/lib/jido_action/exec/compensation.ex
+++ b/lib/jido_action/exec/compensation.ex
@@ -16,7 +16,7 @@ defmodule Jido.Exec.Compensation do
   @type action :: module()
   @type params :: map()
   @type context :: map()
-  @type run_opts :: [timeout: non_neg_integer()]
+  @type run_opts :: Jido.Exec.run_opts()
   @type exec_result ::
           {:ok, map()}
           | {:ok, map(), any()}

--- a/lib/jido_action/exec/compensation.ex
+++ b/lib/jido_action/exec/compensation.ex
@@ -9,6 +9,7 @@ defmodule Jido.Exec.Compensation do
   use Private
 
   alias Jido.Action.Error
+  alias Jido.Exec.Propagation
   alias Jido.Exec.Supervisors
   alias Jido.Exec.Telemetry
 
@@ -106,18 +107,31 @@ defmodule Jido.Exec.Compensation do
 
       current_gl = Process.group_leader()
       task_sup = Supervisors.task_supervisor(opts)
+      propagation = Propagation.capture(opts)
       parent = self()
       ref = make_ref()
 
       compensation_run_opts =
         opts
-        |> Keyword.take([:timeout, :backoff, :telemetry, :jido])
+        |> Keyword.take([
+          :timeout,
+          :backoff,
+          :telemetry,
+          :jido,
+          :context_propagators,
+          :context_propagator_failure_mode
+        ])
         |> Keyword.put(:compensation_timeout, timeout)
 
       {:ok, pid} =
         Task.Supervisor.start_child(task_sup, fn ->
           Process.group_leader(self(), current_gl)
-          result = action.on_error(params, error, context, compensation_run_opts)
+
+          result =
+            Propagation.with_attached(propagation, fn ->
+              action.on_error(params, error, context, compensation_run_opts)
+            end)
+
           send(parent, {:compensation_result, ref, result})
         end)
 

--- a/lib/jido_action/exec/context_propagator.ex
+++ b/lib/jido_action/exec/context_propagator.ex
@@ -1,0 +1,37 @@
+defmodule Jido.Exec.ContextPropagator do
+  @moduledoc """
+  Behaviour for propagating process-local runtime context across supervised work.
+
+  Implementations can capture ambient caller state in `capture/0`, attach it in a
+  child process with `attach/1`, and clean up in `detach/1`.
+
+  This is intentionally backend-agnostic so packages such as `jido_otel` can
+  bridge tracing context without `jido_action` depending on a specific
+  observability library.
+  """
+
+  @typedoc """
+  Opaque context captured in the parent process.
+  """
+  @type captured_ctx :: term()
+
+  @typedoc """
+  Opaque token returned by `attach/1` and passed to `detach/1`.
+  """
+  @type attached_ctx :: term()
+
+  @doc """
+  Captures process-local runtime context in the caller process.
+  """
+  @callback capture() :: captured_ctx()
+
+  @doc """
+  Attaches previously captured context in the child process.
+  """
+  @callback attach(captured_ctx()) :: attached_ctx()
+
+  @doc """
+  Cleans up any state created by `attach/1`.
+  """
+  @callback detach(attached_ctx()) :: :ok
+end

--- a/lib/jido_action/exec/noop_context_propagator.ex
+++ b/lib/jido_action/exec/noop_context_propagator.ex
@@ -1,0 +1,16 @@
+defmodule Jido.Exec.NoopContextPropagator do
+  @moduledoc """
+  Default no-op implementation of `Jido.Exec.ContextPropagator`.
+  """
+
+  @behaviour Jido.Exec.ContextPropagator
+
+  @impl true
+  def capture, do: nil
+
+  @impl true
+  def attach(_captured_ctx), do: nil
+
+  @impl true
+  def detach(_attached_ctx), do: :ok
+end

--- a/lib/jido_action/exec/propagation.ex
+++ b/lib/jido_action/exec/propagation.ex
@@ -11,6 +11,7 @@ defmodule Jido.Exec.Propagation do
 
   @type failure_mode :: :warn | :strict
   @type propagator :: module()
+  @type failure :: {Exception.t(), Exception.stacktrace()}
   @type snapshot_entry :: {propagator(), term()}
 
   @type t :: %__MODULE__{
@@ -32,16 +33,13 @@ defmodule Jido.Exec.Propagation do
     failure_mode = failure_mode(opts)
     propagators = context_propagators(opts)
 
-    entries =
-      Enum.reduce(propagators, [], fn propagator, acc ->
-        case invoke(:capture, propagator, [], failure_mode) do
-          {:ok, captured_ctx} -> [{propagator, captured_ctx} | acc]
-          :skip -> acc
-        end
-      end)
-      |> Enum.reverse()
+    case capture_entries(propagators, failure_mode) do
+      {:ok, entries} ->
+        %__MODULE__{entries: entries, failure_mode: failure_mode}
 
-    %__MODULE__{entries: entries, failure_mode: failure_mode}
+      {:error, failure} ->
+        reraise_failure(failure)
+    end
   end
 
   @doc """
@@ -49,24 +47,17 @@ defmodule Jido.Exec.Propagation do
   """
   @spec with_attached(t(), (-> result)) :: result when result: term()
   def with_attached(%__MODULE__{} = snapshot, fun) when is_function(fun, 0) do
-    attached =
-      Enum.reduce(snapshot.entries, [], fn {propagator, captured_ctx}, acc ->
-        case invoke(:attach, propagator, [captured_ctx], snapshot.failure_mode) do
-          {:ok, attached_ctx} -> [{propagator, attached_ctx} | acc]
-          :skip -> acc
+    case attach_entries(snapshot.entries, snapshot.failure_mode) do
+      {:ok, attached} ->
+        try do
+          fun.()
+        after
+          detach_all(attached, snapshot.failure_mode)
         end
-      end)
 
-    try do
-      fun.()
-    after
-      Enum.each(attached, fn {propagator, attached_ctx} ->
-        case invoke(:detach, propagator, [attached_ctx], snapshot.failure_mode) do
-          {:ok, :ok} -> :ok
-          {:ok, _other} -> :ok
-          :skip -> :ok
-        end
-      end)
+      {:error, failure, attached} ->
+        detach_all(attached, snapshot.failure_mode)
+        reraise_failure(failure)
     end
   end
 
@@ -109,6 +100,58 @@ defmodule Jido.Exec.Propagation do
   defp normalize_failure_mode(mode) when mode in [:warn, :strict], do: mode
   defp normalize_failure_mode(_invalid), do: @default_failure_mode
 
+  defp capture_entries(propagators, failure_mode) do
+    propagators
+    |> Enum.reduce_while({:ok, []}, fn propagator, {:ok, acc} ->
+      case invoke(:capture, propagator, [], failure_mode) do
+        {:ok, captured_ctx} ->
+          {:cont, {:ok, [{propagator, captured_ctx} | acc]}}
+
+        :skip ->
+          {:cont, {:ok, acc}}
+
+        {:error, failure} ->
+          {:halt, {:error, failure}}
+      end
+    end)
+    |> case do
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
+      {:error, failure} -> {:error, failure}
+    end
+  end
+
+  defp attach_entries(entries, failure_mode) do
+    Enum.reduce_while(entries, {:ok, []}, fn {propagator, captured_ctx}, {:ok, attached} ->
+      case invoke(:attach, propagator, [captured_ctx], failure_mode) do
+        {:ok, attached_ctx} ->
+          {:cont, {:ok, [{propagator, attached_ctx} | attached]}}
+
+        :skip ->
+          {:cont, {:ok, attached}}
+
+        {:error, failure} ->
+          {:halt, {:error, failure, attached}}
+      end
+    end)
+  end
+
+  defp detach_all(attached, failure_mode) do
+    case Enum.reduce(attached, nil, fn {propagator, attached_ctx}, first_failure ->
+           next_failure =
+             case invoke(:detach, propagator, [attached_ctx], failure_mode) do
+               {:ok, :ok} -> nil
+               {:ok, _other} -> nil
+               :skip -> nil
+               {:error, failure} -> failure
+             end
+
+           first_failure || next_failure
+         end) do
+      nil -> :ok
+      failure -> reraise_failure(failure)
+    end
+  end
+
   defp invoke(callback, propagator, args, failure_mode) do
     if function_exported?(propagator, callback, length(args)) do
       try do
@@ -140,14 +183,23 @@ defmodule Jido.Exec.Propagation do
   end
 
   defp handle_failure(propagator, callback, failure, :strict) do
-    raise RuntimeError,
-          "Jido.Exec context propagator #{callback}/#{failure_arity(callback)} failed " <>
-            "(propagator=#{inspect(propagator)}, failure_mode=:strict): #{format_failure(failure)}"
+    exception =
+      RuntimeError.exception(
+        "Jido.Exec context propagator #{callback}/#{failure_arity(callback)} failed " <>
+          "(propagator=#{inspect(propagator)}, failure_mode=:strict): #{format_failure(failure)}"
+      )
+
+    {:error, {exception, failure_stacktrace(failure)}}
   end
 
   defp failure_arity(:capture), do: 0
   defp failure_arity(:attach), do: 1
   defp failure_arity(:detach), do: 1
+
+  defp reraise_failure({exception, []}), do: raise(exception)
+  defp reraise_failure({exception, stacktrace}), do: reraise(exception, stacktrace)
+
+  defp failure_stacktrace({_kind, _reason, stacktrace}), do: stacktrace
 
   defp format_failure({:error, %RuntimeError{message: "missing callback"}, _stacktrace}) do
     "callback not implemented"

--- a/lib/jido_action/exec/propagation.ex
+++ b/lib/jido_action/exec/propagation.ex
@@ -1,0 +1,158 @@
+defmodule Jido.Exec.Propagation do
+  @moduledoc """
+  Resolves and applies runtime-context propagators across supervised execution.
+
+  `jido_action` uses this helper to preserve ambient process-local state when it
+  crosses `Task.Supervisor` boundaries for timeouts, async execution,
+  compensation, and async chains.
+  """
+
+  require Logger
+
+  @type failure_mode :: :warn | :strict
+  @type propagator :: module()
+  @type snapshot_entry :: {propagator(), term()}
+
+  @type t :: %__MODULE__{
+          entries: [snapshot_entry()],
+          failure_mode: failure_mode()
+        }
+
+  defstruct entries: [],
+            failure_mode: :warn
+
+  @observability_key :observability
+  @default_failure_mode :warn
+
+  @doc """
+  Captures the configured runtime-context propagators for the current process.
+  """
+  @spec capture(keyword()) :: t()
+  def capture(opts \\ []) when is_list(opts) do
+    failure_mode = failure_mode(opts)
+    propagators = context_propagators(opts)
+
+    entries =
+      Enum.reduce(propagators, [], fn propagator, acc ->
+        case invoke(:capture, propagator, [], failure_mode) do
+          {:ok, captured_ctx} -> [{propagator, captured_ctx} | acc]
+          :skip -> acc
+        end
+      end)
+      |> Enum.reverse()
+
+    %__MODULE__{entries: entries, failure_mode: failure_mode}
+  end
+
+  @doc """
+  Attaches a captured snapshot while executing `fun`.
+  """
+  @spec with_attached(t(), (-> result)) :: result when result: term()
+  def with_attached(%__MODULE__{} = snapshot, fun) when is_function(fun, 0) do
+    attached =
+      Enum.reduce(snapshot.entries, [], fn {propagator, captured_ctx}, acc ->
+        case invoke(:attach, propagator, [captured_ctx], snapshot.failure_mode) do
+          {:ok, attached_ctx} -> [{propagator, attached_ctx} | acc]
+          :skip -> acc
+        end
+      end)
+
+    try do
+      fun.()
+    after
+      Enum.each(attached, fn {propagator, attached_ctx} ->
+        case invoke(:detach, propagator, [attached_ctx], snapshot.failure_mode) do
+          {:ok, :ok} -> :ok
+          {:ok, _other} -> :ok
+          :skip -> :ok
+        end
+      end)
+    end
+  end
+
+  @doc """
+  Resolves the configured context propagator modules.
+  """
+  @spec context_propagators(keyword()) :: [propagator()]
+  def context_propagators(opts \\ []) when is_list(opts) do
+    opts
+    |> Keyword.get_lazy(:context_propagators, fn ->
+      :jido_action
+      |> Application.get_env(@observability_key, [])
+      |> Keyword.get(:context_propagators, [])
+    end)
+    |> normalize_context_propagators()
+  end
+
+  @doc """
+  Resolves the effective failure mode for propagator callbacks.
+  """
+  @spec failure_mode(keyword()) :: failure_mode()
+  def failure_mode(opts \\ []) when is_list(opts) do
+    opts
+    |> Keyword.get_lazy(:context_propagator_failure_mode, fn ->
+      :jido_action
+      |> Application.get_env(@observability_key, [])
+      |> Keyword.get(:context_propagator_failure_mode, @default_failure_mode)
+    end)
+    |> normalize_failure_mode()
+  end
+
+  defp normalize_context_propagators(propagators) when is_list(propagators) do
+    propagators
+    |> Enum.filter(&is_atom/1)
+    |> Enum.uniq()
+  end
+
+  defp normalize_context_propagators(_), do: []
+
+  defp normalize_failure_mode(mode) when mode in [:warn, :strict], do: mode
+  defp normalize_failure_mode(_invalid), do: @default_failure_mode
+
+  defp invoke(callback, propagator, args, failure_mode) do
+    if function_exported?(propagator, callback, length(args)) do
+      try do
+        {:ok, apply(propagator, callback, args)}
+      rescue
+        error ->
+          handle_failure(propagator, callback, {:error, error, __STACKTRACE__}, failure_mode)
+      catch
+        kind, reason ->
+          handle_failure(propagator, callback, {kind, reason, __STACKTRACE__}, failure_mode)
+      end
+    else
+      handle_failure(
+        propagator,
+        callback,
+        {:error, RuntimeError.exception("missing callback"), []},
+        failure_mode
+      )
+    end
+  end
+
+  defp handle_failure(propagator, callback, failure, :warn) do
+    Logger.warning(
+      "Jido.Exec context propagator #{callback}/#{failure_arity(callback)} failed " <>
+        "(propagator=#{inspect(propagator)}, failure_mode=:warn): #{format_failure(failure)}"
+    )
+
+    :skip
+  end
+
+  defp handle_failure(propagator, callback, failure, :strict) do
+    raise RuntimeError,
+          "Jido.Exec context propagator #{callback}/#{failure_arity(callback)} failed " <>
+            "(propagator=#{inspect(propagator)}, failure_mode=:strict): #{format_failure(failure)}"
+  end
+
+  defp failure_arity(:capture), do: 0
+  defp failure_arity(:attach), do: 1
+  defp failure_arity(:detach), do: 1
+
+  defp format_failure({:error, %RuntimeError{message: "missing callback"}, _stacktrace}) do
+    "callback not implemented"
+  end
+
+  defp format_failure({:error, error, _stacktrace}), do: inspect(error)
+  defp format_failure({kind, reason, _stacktrace}), do: inspect({kind, reason})
+end

--- a/test/jido_action/exec/propagation_test.exs
+++ b/test/jido_action/exec/propagation_test.exs
@@ -54,6 +54,32 @@ defmodule JidoTest.Exec.PropagationTest do
     def detach(_value), do: :ok
   end
 
+  defmodule ExplodingAttachPropagator do
+    @behaviour Jido.Exec.ContextPropagator
+
+    @impl true
+    def capture, do: :captured
+
+    @impl true
+    def attach(_value), do: raise("attach exploded")
+
+    @impl true
+    def detach(_value), do: :ok
+  end
+
+  defmodule ExplodingDetachPropagator do
+    @behaviour Jido.Exec.ContextPropagator
+
+    @impl true
+    def capture, do: :captured
+
+    @impl true
+    def attach(value), do: value
+
+    @impl true
+    def detach(_value), do: raise("detach exploded")
+  end
+
   defmodule ReportingAction do
     use Jido.Action,
       name: "propagation_reporting_action",
@@ -116,6 +142,47 @@ defmodule JidoTest.Exec.PropagationTest do
                  assert Process.get(@prop_key) == "parent-trace"
                  :ok
                end)
+
+      assert Process.get(@prop_key) == "worker-existing"
+    end
+
+    test "strict mode detaches already attached propagators when a later attach fails" do
+      Process.put(@prop_key, "parent-trace")
+
+      snapshot =
+        Propagation.capture(
+          context_propagators: [ProcessDictionaryPropagator, ExplodingAttachPropagator],
+          context_propagator_failure_mode: :strict
+        )
+
+      Process.put(@prop_key, "worker-existing")
+
+      assert_raise RuntimeError, ~r/context propagator attach\/1 failed/, fn ->
+        Propagation.with_attached(snapshot, fn ->
+          flunk("strict attach failure should abort before invoking the callback")
+        end)
+      end
+
+      assert Process.get(@prop_key) == "worker-existing"
+    end
+
+    test "strict mode continues detaching earlier propagators after a detach failure" do
+      Process.put(@prop_key, "parent-trace")
+
+      snapshot =
+        Propagation.capture(
+          context_propagators: [ProcessDictionaryPropagator, ExplodingDetachPropagator],
+          context_propagator_failure_mode: :strict
+        )
+
+      Process.put(@prop_key, "worker-existing")
+
+      assert_raise RuntimeError, ~r/context propagator detach\/1 failed/, fn ->
+        Propagation.with_attached(snapshot, fn ->
+          assert Process.get(@prop_key) == "parent-trace"
+          :ok
+        end)
+      end
 
       assert Process.get(@prop_key) == "worker-existing"
     end

--- a/test/jido_action/exec/propagation_test.exs
+++ b/test/jido_action/exec/propagation_test.exs
@@ -1,0 +1,249 @@
+defmodule JidoTest.Exec.PropagationTest do
+  use JidoTest.ActionCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Jido.Action.Error
+  alias Jido.Exec
+  alias Jido.Exec.Chain
+  alias Jido.Exec.Propagation
+
+  @prop_key :jido_test_runtime_context
+
+  defmodule ProcessDictionaryPropagator do
+    @behaviour Jido.Exec.ContextPropagator
+
+    @prop_key :jido_test_runtime_context
+
+    @impl true
+    def capture, do: Process.get(@prop_key)
+
+    @impl true
+    def attach(value) do
+      previous = Process.get(@prop_key)
+
+      case value do
+        nil -> Process.delete(@prop_key)
+        _value -> Process.put(@prop_key, value)
+      end
+
+      previous
+    end
+
+    @impl true
+    def detach(previous) do
+      case previous do
+        nil -> Process.delete(@prop_key)
+        _value -> Process.put(@prop_key, previous)
+      end
+
+      :ok
+    end
+  end
+
+  defmodule ExplodingCapturePropagator do
+    @behaviour Jido.Exec.ContextPropagator
+
+    @impl true
+    def capture, do: raise("capture exploded")
+
+    @impl true
+    def attach(value), do: value
+
+    @impl true
+    def detach(_value), do: :ok
+  end
+
+  defmodule ReportingAction do
+    use Jido.Action,
+      name: "propagation_reporting_action",
+      description: "Reports the currently attached runtime context"
+
+    @prop_key :jido_test_runtime_context
+
+    @impl true
+    def run(%{label: label, test_pid: test_pid}, _context) do
+      value = Process.get(@prop_key)
+      send(test_pid, {:propagated_context, label, value, self()})
+      {:ok, %{label: label, propagated: value}}
+    end
+  end
+
+  defmodule CompensationReportingAction do
+    use Jido.Action,
+      name: "propagation_compensation_action",
+      description: "Reports propagated runtime context during compensation",
+      compensation: [enabled: true, timeout: 100]
+
+    @prop_key :jido_test_runtime_context
+
+    @impl true
+    def run(_params, _context) do
+      {:error, Error.execution_error("compensation trigger")}
+    end
+
+    @impl true
+    def on_error(%{test_pid: test_pid}, _error, _context, _opts) do
+      value = Process.get(@prop_key)
+      send(test_pid, {:compensation_context, value, self()})
+      {:ok, %{compensation_context: %{propagated: value}}}
+    end
+  end
+
+  setup do
+    original_observability = Application.get_env(:jido_action, :observability)
+
+    on_exit(fn ->
+      restore_observability_env(original_observability)
+      Process.delete(@prop_key)
+    end)
+
+    Process.delete(@prop_key)
+    :ok
+  end
+
+  describe "Propagation.with_attached/2" do
+    test "restores the previous process-local value after the callback returns" do
+      Process.put(@prop_key, "parent-trace")
+
+      snapshot =
+        Propagation.capture(context_propagators: [ProcessDictionaryPropagator])
+
+      Process.put(@prop_key, "worker-existing")
+
+      assert :ok =
+               Propagation.with_attached(snapshot, fn ->
+                 assert Process.get(@prop_key) == "parent-trace"
+                 :ok
+               end)
+
+      assert Process.get(@prop_key) == "worker-existing"
+    end
+  end
+
+  describe "supervised execution boundaries" do
+    test "propagates runtime context into timeout-supervised action execution" do
+      Process.put(@prop_key, "timeout-trace")
+
+      assert {:ok, %{propagated: "timeout-trace"}} =
+               Exec.run(
+                 ReportingAction,
+                 %{label: :timeout, test_pid: self()},
+                 %{},
+                 timeout: 100,
+                 context_propagators: [ProcessDictionaryPropagator]
+               )
+
+      assert_receive {:propagated_context, :timeout, "timeout-trace", action_pid}
+      refute action_pid == self()
+    end
+
+    test "propagates runtime context across async wrapper and nested timeout execution" do
+      Process.put(@prop_key, "async-trace")
+
+      async_ref =
+        Exec.run_async(
+          ReportingAction,
+          %{label: :async, test_pid: self()},
+          %{},
+          timeout: 100,
+          context_propagators: [ProcessDictionaryPropagator]
+        )
+
+      assert_receive {:propagated_context, :async, "async-trace", action_pid}
+      refute action_pid == self()
+      refute action_pid == async_ref.pid
+      assert {:ok, %{propagated: "async-trace"}} = Exec.await(async_ref, 1_000)
+    end
+
+    test "propagates runtime context into compensation callbacks" do
+      Process.put(@prop_key, "comp-trace")
+
+      assert {:error, %Jido.Action.Error.ExecutionFailureError{} = error} =
+               Exec.run(
+                 CompensationReportingAction,
+                 %{test_pid: self()},
+                 %{},
+                 timeout: 100,
+                 context_propagators: [ProcessDictionaryPropagator]
+               )
+
+      assert_receive {:compensation_context, "comp-trace", compensation_pid}
+      refute compensation_pid == self()
+      assert error.details.compensation_context == %{propagated: "comp-trace"}
+    end
+
+    test "propagates runtime context into async chain execution" do
+      Process.put(@prop_key, "chain-trace")
+
+      task =
+        Chain.chain(
+          [ReportingAction],
+          %{label: :chain, test_pid: self()},
+          async: true,
+          timeout: 100,
+          context_propagators: [ProcessDictionaryPropagator]
+        )
+
+      assert %Task{} = task
+      assert_receive {:propagated_context, :chain, "chain-trace", action_pid}
+      refute action_pid == self()
+      refute action_pid == task.pid
+      assert {:ok, %{propagated: "chain-trace"}} = Task.await(task, 1_000)
+    end
+  end
+
+  describe "configuration resolution" do
+    test "uses application observability config when execution opts omit propagators" do
+      Application.put_env(:jido_action, :observability,
+        context_propagators: [ProcessDictionaryPropagator],
+        context_propagator_failure_mode: :warn
+      )
+
+      Process.put(@prop_key, "config-trace")
+
+      assert {:ok, %{propagated: "config-trace"}} =
+               Exec.run(ReportingAction, %{label: :config, test_pid: self()}, %{}, timeout: 100)
+
+      assert_receive {:propagated_context, :config, "config-trace", _action_pid}
+    end
+  end
+
+  describe "propagator failure modes" do
+    test "warn mode logs and skips failing propagators while preserving healthy ones" do
+      Process.put(@prop_key, "warn-trace")
+
+      log =
+        capture_log(fn ->
+          snapshot =
+            Propagation.capture(
+              context_propagators: [ExplodingCapturePropagator, ProcessDictionaryPropagator],
+              context_propagator_failure_mode: :warn
+            )
+
+          assert :ok =
+                   Propagation.with_attached(snapshot, fn ->
+                     assert Process.get(@prop_key) == "warn-trace"
+                     :ok
+                   end)
+        end)
+
+      assert log =~ "context propagator capture/0 failed"
+      assert log =~ "ExplodingCapturePropagator"
+    end
+
+    test "strict mode raises when a propagator callback fails" do
+      assert_raise RuntimeError, ~r/context propagator capture\/0 failed/, fn ->
+        Propagation.capture(
+          context_propagators: [ExplodingCapturePropagator],
+          context_propagator_failure_mode: :strict
+        )
+      end
+    end
+  end
+
+  defp restore_observability_env(nil), do: Application.delete_env(:jido_action, :observability)
+
+  defp restore_observability_env(config),
+    do: Application.put_env(:jido_action, :observability, config)
+end


### PR DESCRIPTION
## Summary
- add a generic `Jido.Exec.ContextPropagator` contract plus a propagation helper in `jido_action`
- capture and reattach runtime context across timeout, async, compensation, and async-chain supervision boundaries
- document the new `:observability` / per-execution propagation options and add focused regression coverage

## Why
PR #155 identifies a real issue: process-local tracing context is lost when execution crosses `Task.Supervisor` boundaries, which can orphan downstream spans.

This PR supersedes #155 by fixing the underlying supervision-boundary problem in a backend-agnostic way instead of adding OpenTelemetry-specific calls to `jido_action`.

## Design
- `jido_action` stays observability-agnostic
- adapter packages can register `context_propagators` globally or per execution
- propagation callbacks can run in `:warn` or `:strict` mode
- the captured snapshot is pinned before the supervised child starts and detached after execution

## Validation
- `mix compile --warnings-as-errors`
- `mix test`
