### PR TITLE
fix: harden action error JSON encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
+## [Unreleased]
+
+### Bug Fixes:
+
+* normalize `Jido.Action.Error` structs during JSON encoding and tolerate malformed struct-shaped error maps
+  so downstream tool runners return sanitized envelopes instead of crashing
+
 ## [v2.2.1](https://github.com/agentjido/jido_action/compare/v2.2.0...v2.2.1) (2026-04-03)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
-## [Unreleased]
-
-### Bug Fixes:
-
-* normalize `Jido.Action.Error` structs during JSON encoding and tolerate malformed struct-shaped error maps
-  so downstream tool runners return sanitized envelopes instead of crashing
-
 ## [v2.2.1](https://github.com/agentjido/jido_action/compare/v2.2.0...v2.2.1) (2026-04-03)
 
 

--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -341,64 +341,89 @@ defmodule Jido.Action.Error do
     }
   end
 
-  def to_map(%InvalidInputError{} = error) do
+  def to_map(%InvalidInputError{
+        message: message,
+        field: field,
+        value: value,
+        details: details
+      }) do
     %{
       type: :validation_error,
-      message: normalize_message(error.message),
+      message: normalize_message(message),
       details:
-        error.details
+        details
         |> normalize_details()
-        |> maybe_put(:field, error.field)
-        |> maybe_put(:value, Sanitizer.sanitize(error.value)),
+        |> maybe_put(:field, field)
+        |> maybe_put(:value, Sanitizer.sanitize(value)),
       retryable?: false
     }
   end
 
-  def to_map(%ExecutionFailureError{} = error) do
+  def to_map(%ExecutionFailureError{message: message, details: details}) do
     %{
       type: :execution_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
-      retryable?: normalize_retryable(error.details, :execution_error)
+      message: normalize_message(message),
+      details: normalize_details(details),
+      retryable?: normalize_retryable(details, :execution_error)
     }
   end
 
-  def to_map(%TimeoutError{} = error) do
+  def to_map(%TimeoutError{message: message, timeout: timeout, details: details}) do
     %{
       type: :timeout,
-      message: normalize_message(error.message),
+      message: normalize_message(message),
       details:
-        error.details
+        details
         |> normalize_details()
-        |> maybe_put(:timeout, error.timeout),
+        |> maybe_put(:timeout, timeout),
       retryable?: true
     }
   end
 
-  def to_map(%ConfigurationError{} = error) do
+  def to_map(%ConfigurationError{message: message, details: details}) do
     %{
       type: :configuration_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
+      message: normalize_message(message),
+      details: normalize_details(details),
       retryable?: false
     }
   end
 
-  def to_map(%InternalError{} = error) do
+  def to_map(%InternalError{message: message, details: details}) do
     %{
       type: :internal_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
+      message: normalize_message(message),
+      details: normalize_details(details),
       retryable?: false
     }
   end
 
-  def to_map(%Internal.UnknownError{} = error) do
+  def to_map(%Internal.UnknownError{message: message, details: details}) do
     %{
       type: :internal_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
+      message: normalize_message(message),
+      details: normalize_details(details),
       retryable?: false
+    }
+  end
+
+  def to_map(%{__struct__: module} = error)
+      when is_atom(module) and
+             module in [
+               InvalidInputError,
+               ExecutionFailureError,
+               TimeoutError,
+               ConfigurationError,
+               InternalError,
+               Internal.UnknownError
+             ] do
+    type = pseudo_struct_type(module)
+
+    %{
+      type: type,
+      message: normalize_message(pseudo_struct_message(module, Map.get(error, :message))),
+      details: normalize_pseudo_struct_details(error),
+      retryable?: normalize_retryable(error, type)
     }
   end
 
@@ -554,13 +579,29 @@ defmodule Jido.Action.Error do
 
   defp normalize_details(_details), do: %{}
 
+  defp normalize_pseudo_struct_details(error) when is_map(error) do
+    base_details =
+      error
+      |> Map.get(:details, %{})
+      |> normalize_details()
+
+    extra_details =
+      error
+      |> Map.drop([:message, :details, :__struct__, :__exception__])
+      |> normalize_details()
+
+    Map.merge(base_details, extra_details)
+  end
+
   defp extract_message_details(%_{} = error) do
     error
     |> Map.from_struct()
     |> Map.drop([:__exception__, :message])
   end
 
-  defp extract_message_details(%{} = error), do: Map.delete(error, :message)
+  defp extract_message_details(%{} = error) do
+    Map.drop(error, [:message, :__struct__, :__exception__])
+  end
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
@@ -616,6 +657,21 @@ defmodule Jido.Action.Error do
 
   defp extract_retry_value(_), do: nil
 
+  defp pseudo_struct_type(InvalidInputError), do: :validation_error
+  defp pseudo_struct_type(ExecutionFailureError), do: :execution_error
+  defp pseudo_struct_type(TimeoutError), do: :timeout
+  defp pseudo_struct_type(ConfigurationError), do: :configuration_error
+  defp pseudo_struct_type(InternalError), do: :internal_error
+  defp pseudo_struct_type(Internal.UnknownError), do: :internal_error
+
+  defp pseudo_struct_message(_module, message) when not is_nil(message), do: message
+  defp pseudo_struct_message(InvalidInputError, nil), do: "Invalid input"
+  defp pseudo_struct_message(ExecutionFailureError, nil), do: "Execution failed"
+  defp pseudo_struct_message(TimeoutError, nil), do: "Action timed out"
+  defp pseudo_struct_message(ConfigurationError, nil), do: "Configuration error"
+  defp pseudo_struct_message(InternalError, nil), do: "Internal error"
+  defp pseudo_struct_message(Internal.UnknownError, nil), do: "Unknown error"
+
   defp safe_inspect(value) do
     inspect(value)
   rescue
@@ -623,5 +679,21 @@ defmodule Jido.Action.Error do
       value
       |> Sanitizer.sanitize()
       |> inspect()
+  end
+end
+
+defimpl Jason.Encoder,
+  for: [
+    Jido.Action.Error.InvalidInputError,
+    Jido.Action.Error.ExecutionFailureError,
+    Jido.Action.Error.TimeoutError,
+    Jido.Action.Error.ConfigurationError,
+    Jido.Action.Error.InternalError,
+    Jido.Action.Error.Internal.UnknownError
+  ] do
+  def encode(error, opts) when is_map(error) do
+    error
+    |> Jido.Action.Error.to_map()
+    |> Jason.Encode.map(opts)
   end
 end

--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -147,7 +147,6 @@ defmodule Jido.Action.Error do
   # Define specific error structs inline
   defmodule InvalidInputError do
     @moduledoc "Error for invalid input parameters"
-    @derive {Jason.Encoder, only: [:message, :field, :value]}
     defexception [:message, :field, :value, :details]
 
     @type t :: %__MODULE__{
@@ -172,7 +171,6 @@ defmodule Jido.Action.Error do
 
   defmodule ExecutionFailureError do
     @moduledoc "Error for runtime execution failures"
-    @derive {Jason.Encoder, only: [:message]}
     defexception [:message, :details]
 
     @type t :: %__MODULE__{
@@ -191,7 +189,6 @@ defmodule Jido.Action.Error do
 
   defmodule TimeoutError do
     @moduledoc "Error for action timeouts"
-    @derive {Jason.Encoder, only: [:message, :timeout]}
     defexception [:message, :timeout, :details]
 
     @type t :: %__MODULE__{
@@ -212,7 +209,6 @@ defmodule Jido.Action.Error do
 
   defmodule ConfigurationError do
     @moduledoc "Error for configuration issues"
-    @derive {Jason.Encoder, only: [:message]}
     defexception [:message, :details]
 
     @type t :: %__MODULE__{
@@ -231,7 +227,6 @@ defmodule Jido.Action.Error do
 
   defmodule InternalError do
     @moduledoc "Error for unexpected internal failures"
-    @derive {Jason.Encoder, only: [:message]}
     defexception [:message, :details]
 
     @type t :: %__MODULE__{

--- a/test/jido_action/error_test.exs
+++ b/test/jido_action/error_test.exs
@@ -394,46 +394,60 @@ defmodule Jido.Action.ErrorTest do
     end
   end
 
-  describe "Jason.Encoder for error structs" do
-    test "InvalidInputError is directly JSON-encodable" do
+  describe "Jason encoding" do
+    test "encodes InvalidInputError through normalized generic maps" do
       error = Error.validation_error("bad input", field: :name, value: 123)
-      assert {:ok, json} = Jason.encode(error)
-      decoded = Jason.decode!(json)
+
+      decoded = error |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["type"] == "validation_error"
       assert decoded["message"] == "bad input"
-      assert decoded["field"] == "name"
-      # details excluded — may contain non-serializable terms
-      refute Map.has_key?(decoded, "details")
+      assert decoded["retryable?"] == false
+      assert decoded["details"] == %{"field" => "name", "value" => 123}
     end
 
-    test "ExecutionFailureError is directly JSON-encodable" do
-      error = Error.execution_error("boom", %{stacktrace: [{Enum, :map, 2, []}]})
-      assert {:ok, json} = Jason.encode(error)
-      decoded = Jason.decode!(json)
+    test "encodes action error structs through normalized generic maps" do
+      error =
+        Error.execution_error("boom", %{
+          reason: %Reason{message: "nested", field: :transport, meta: {:retry, 2}}
+        })
+
+      decoded = error |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["type"] == "execution_error"
       assert decoded["message"] == "boom"
-      # details excluded — contains stacktrace tuples
-      refute Map.has_key?(decoded, "details")
+      assert decoded["retryable?"] == true
+      assert decoded["details"]["reason"]["__struct__"] =~ "Reason"
+      assert decoded["details"]["reason"]["meta"] == ["retry", 2]
     end
 
-    test "TimeoutError is directly JSON-encodable" do
+    test "encodes TimeoutError through normalized generic maps" do
       error = Error.timeout_error("timed out", timeout: 5000)
-      assert {:ok, json} = Jason.encode(error)
-      decoded = Jason.decode!(json)
+
+      decoded = error |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded["type"] == "timeout"
       assert decoded["message"] == "timed out"
-      assert decoded["timeout"] == 5000
+      assert decoded["retryable?"] == true
+      assert decoded["details"] == %{"timeout" => 5000}
     end
 
-    test "ConfigurationError is directly JSON-encodable" do
-      error = Error.config_error("missing key", %{key: :api_url})
-      assert {:ok, json} = Jason.encode(error)
-      decoded = Jason.decode!(json)
-      assert decoded["message"] == "missing key"
-    end
+    test "encodes malformed execution failure maps without crashing" do
+      malformed = %{
+        __struct__: Error.ExecutionFailureError,
+        __exception__: true,
+        details: %{},
+        tool_name: "list_directory"
+      }
 
-    test "InternalError is directly JSON-encodable" do
-      error = Error.internal_error("unexpected", %{reason: :unknown})
-      assert {:ok, json} = Jason.encode(error)
-      decoded = Jason.decode!(json)
-      assert decoded["message"] == "unexpected"
+      decoded = malformed |> Jason.encode!() |> Jason.decode!()
+
+      assert decoded == %{
+               "type" => "execution_error",
+               "message" => "Execution failed",
+               "details" => %{"tool_name" => "list_directory"},
+               "retryable?" => true
+             }
     end
   end
 


### PR DESCRIPTION
## Summary
- encode Jido.Action.Error structs via Error.to_map/1 before JSON serialization
- tolerate malformed struct-shaped error maps so downstream tool runners return sanitized envelopes instead of crashing
- add regression coverage for both valid action errors and the malformed ExecutionFailureError shape from #157

## Testing
- mix test

Fixes #157