### PR TITLE
refactor: fix ex_slop findings

### DIFF
--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -632,10 +632,8 @@ defmodule Jido.Action.Error do
 
   defp extract_retry_hint(_), do: nil
 
-  defp extract_nested_reason(%{} = map) do
-    Map.get(map, :reason)
-  end
-
+  defp extract_nested_reason(%{reason: reason}), do: reason
+  defp extract_nested_reason(%{"reason" => reason}), do: reason
   defp extract_nested_reason(_), do: nil
 
   defp extract_retry_value(%{} = map) do

--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -633,7 +633,7 @@ defmodule Jido.Action.Error do
   defp extract_retry_hint(_), do: nil
 
   defp extract_nested_reason(%{} = map) do
-    Map.get(map, :reason) || Map.get(map, "reason")
+    Map.get(map, :reason)
   end
 
   defp extract_nested_reason(_), do: nil

--- a/lib/jido_action/schema.ex
+++ b/lib/jido_action/schema.ex
@@ -220,10 +220,7 @@ defmodule Jido.Action.Schema do
   end
 
   defp validate_zoi(schema, data) do
-    case Zoi.parse(schema, data) do
-      {:ok, validated} -> {:ok, validated}
-      {:error, errors} -> {:error, errors}
-    end
+    Zoi.parse(schema, data)
   end
 
   defp extract_zoi_keys(%{__struct__: Zoi.Types.Map, fields: fields}) when is_map(fields) do

--- a/lib/jido_plan.ex
+++ b/lib/jido_plan.ex
@@ -459,10 +459,7 @@ defmodule Jido.Plan do
       rec_stack = MapSet.put(rec_stack, vertex)
       neighbors = Multigraph.out_neighbors(graph, vertex)
 
-      case dfs_neighbors(graph, neighbors, visited, rec_stack, [vertex | path]) do
-        {:cycle, cycle_path} -> {:cycle, cycle_path}
-        {:ok, final_visited} -> {:ok, final_visited}
-      end
+      dfs_neighbors(graph, neighbors, visited, rec_stack, [vertex | path])
     end
   end
 

--- a/test/jido_action/error_test.exs
+++ b/test/jido_action/error_test.exs
@@ -463,6 +463,7 @@ defmodule Jido.Action.ErrorTest do
       refute Error.retryable?(Error.validation_error("invalid"))
       refute Error.retryable?(Error.config_error("bad config"))
       refute Error.retryable?(%{details: %{retry: false}})
+      refute Error.retryable?(%{details: %{"reason" => %{"retry" => false}}})
       refute Error.retryable?(:badarg)
     end
   end


### PR DESCRIPTION
## Summary

Code quality fixes found with [`ex_slop`](https://hex.pm/packages/ex_slop). 3 issues across 3 files.

- Remove identity `case` blocks in schema `validate_zoi` and plan `dfs_neighbors`
- Remove DualKeyAccess in error `extract_nested_reason`

## Testing

- [x] Tests pass (`mix test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)