### PR TITLE
fix: recursively convert nested Zoi tool params

### DIFF
--- a/lib/jido_action/tool.ex
+++ b/lib/jido_action/tool.ex
@@ -102,6 +102,9 @@ defmodule Jido.Action.Tool do
       :json_schema ->
         convert_params_using_json_schema(params, schema)
 
+      :zoi ->
+        convert_params_using_zoi_schema(params, schema)
+
       _ ->
         schema_keys = Schema.known_keys(schema)
         convert_params_using_known_keys(params, schema, schema_keys)
@@ -129,6 +132,10 @@ defmodule Jido.Action.Tool do
   end
 
   defp convert_params_using_key_pairs(params, schema, key_pairs) do
+    convert_params_using_key_pairs(params, schema, key_pairs, &convert_value_with_schema/3)
+  end
+
+  defp convert_params_using_key_pairs(params, schema, key_pairs, convert_value) do
     {known_converted, unknown_params} =
       Enum.reduce(key_pairs, {%{}, params}, fn {key, string_key}, {known_acc, rest} ->
         {atom_value, rest} = Map.pop(rest, key, :__missing__)
@@ -148,12 +155,78 @@ defmodule Jido.Action.Tool do
             {known_acc, rest}
 
           _ ->
-            converted_value = convert_value_with_schema(schema, key, value)
+            converted_value = convert_value.(schema, key, value)
             {Map.put(known_acc, key, converted_value), rest}
         end
       end)
 
     Map.merge(unknown_params, known_converted)
+  end
+
+  defp convert_params_using_zoi_schema(params, schema) do
+    params
+    |> convert_params_using_json_object_schema(Schema.to_json_schema(schema))
+  end
+
+  defp convert_params_using_json_object_schema(params, schema) when is_map(params) do
+    case json_schema_properties(schema) do
+      properties when is_map(properties) ->
+        convert_params_using_json_object_properties(params, properties)
+
+      _ ->
+        params
+    end
+  end
+
+  defp convert_params_using_json_object_properties(params, properties) do
+    key_pairs = Map.keys(properties) |> Enum.map(&{&1, to_string(&1)})
+
+    convert_params_using_key_pairs(params, properties, key_pairs, fn properties, key, value ->
+      properties
+      |> Map.fetch!(key)
+      |> convert_json_schema_value(value)
+    end)
+  end
+
+  defp convert_json_schema_value(schema, value) when is_map(value) do
+    cond do
+      json_schema_type(schema) in [:object, "object"] ->
+        convert_params_using_json_object_schema(value, schema)
+
+      schemas = json_schema_composite_schemas(schema) ->
+        Enum.reduce(schemas, value, &convert_json_schema_value/2)
+
+      true ->
+        value
+    end
+  end
+
+  defp convert_json_schema_value(schema, value) when is_list(value) do
+    case {json_schema_type(schema), json_schema_items(schema)} do
+      {type, item_schema} when type in [:array, "array"] and is_map(item_schema) ->
+        Enum.map(value, &convert_json_schema_value(item_schema, &1))
+
+      _ ->
+        value
+    end
+  end
+
+  defp convert_json_schema_value(_schema, value), do: value
+
+  defp json_schema_type(schema), do: Map.get(schema, :type) || Map.get(schema, "type")
+
+  defp json_schema_properties(schema),
+    do: Map.get(schema, :properties) || Map.get(schema, "properties")
+
+  defp json_schema_items(schema), do: Map.get(schema, :items) || Map.get(schema, "items")
+
+  defp json_schema_composite_schemas(schema) do
+    Enum.find_value([:allOf, "allOf", :anyOf, "anyOf", :oneOf, "oneOf"], fn key ->
+      case Map.get(schema, key) do
+        schemas when is_list(schemas) -> schemas
+        _ -> nil
+      end
+    end)
   end
 
   defp convert_value_with_schema(schema, key, value) when is_list(schema) do

--- a/test/jido_action/exec_tool_test.exs
+++ b/test/jido_action/exec_tool_test.exs
@@ -237,6 +237,93 @@ defmodule Jido.Action.ToolTest do
                count: 2
              }
     end
+
+    test "recursively converts string keys for nested Zoi map fields" do
+      schema =
+        Zoi.map(%{
+          attributes:
+            Zoi.map(%{
+              title: Zoi.string() |> Zoi.optional(),
+              description: Zoi.string() |> Zoi.optional() |> Zoi.default("")
+            }),
+          relationships:
+            Zoi.map(%{
+              workspace:
+                Zoi.map(%{
+                  data:
+                    Zoi.map(%{
+                      id: Zoi.uuid(),
+                      type: Zoi.string() |> Zoi.default("workspace")
+                    })
+                })
+            })
+        })
+
+      params = %{
+        "attributes" => %{
+          "title" => "Example",
+          "description" => "Nested keys are converted"
+        },
+        "relationships" => %{
+          "workspace" => %{
+            "data" => %{
+              "id" => "550e8400-e29b-41d4-a716-446655440000",
+              "type" => "workspace"
+            }
+          }
+        }
+      }
+
+      result = Tool.convert_params_using_schema(params, schema)
+
+      assert result == %{
+               attributes: %{
+                 title: "Example",
+                 description: "Nested keys are converted"
+               },
+               relationships: %{
+                 workspace: %{
+                   data: %{
+                     id: "550e8400-e29b-41d4-a716-446655440000",
+                     type: "workspace"
+                   }
+                 }
+               }
+             }
+
+      assert {:ok, _parsed} = Zoi.parse(schema, result)
+    end
+
+    test "recursively converts Zoi map fields inside lists" do
+      schema =
+        Zoi.map(%{
+          items:
+            Zoi.list(
+              Zoi.map(%{
+                id: Zoi.string(),
+                metadata: Zoi.map(%{rank: Zoi.integer()})
+              })
+            )
+        })
+
+      params = %{
+        "items" => [
+          %{"id" => "one", "metadata" => %{"rank" => 1}},
+          %{"id" => "two", "metadata" => %{"rank" => 2}}
+        ]
+      }
+
+      result = Tool.convert_params_using_schema(params, schema)
+
+      assert result == %{
+               items: [
+                 %{id: "one", metadata: %{rank: 1}},
+                 %{id: "two", metadata: %{rank: 2}}
+               ]
+             }
+
+      assert {:ok, _parsed} = Zoi.parse(schema, result)
+    end
   end
 
   describe "build_parameters_schema/1" do


### PR DESCRIPTION
## Summary
- Fixes #162 by recursively normalizing Zoi tool-call params through nested maps and list elements
- Uses Zoi's public JSON Schema output to drive key normalization instead of pattern matching on Zoi internal types
- Preserves atom-over-string precedence and unknown-key preservation behavior
- Adds regression coverage for deeply nested Zoi maps and nested maps inside lists

## Verification
- mix test test/jido_action/exec_tool_test.exs test/jido_action/zoi_schema_test.exs test/jido_action/atom_safety_test.exs test/jido_action/json_schema_map_test.exs test/jido_action/json_schema_bridge_test.exs
- mix test
- mix q