### PR TITLE
feat: add action catalog data structures

### DIFF
--- a/guides/action-catalogs.md
+++ b/guides/action-catalogs.md
@@ -1,0 +1,123 @@
+# Action Catalogs
+
+**Prerequisites**: [Actions](actions-guide.md) • [Schemas & Validation](schemas-validation.md)
+
+Action catalogs are local, value-level registries for discovering and selecting actions. They describe action-compatible modules with normalized metadata and deterministic search, without introducing an LLM dependency or a process-backed registry.
+
+Catalogs are intentionally plain data structures. Build them, pass them through your own runtime, replace them between turns, or wrap them in a higher-level package such as `jido_ai` or `jidoka`.
+
+## Local Action Compatibility
+
+A catalog entry points at a local compiled module. The module must expose the same core action shape:
+
+- `name/0`
+- `schema/0`
+- `run/2`
+
+Modules created with `use Jido.Action` satisfy this contract. Higher-level packages may also provide modules that follow the same shape, such as a local `Jidoka.Tool` wrapper.
+
+Remote catalogs are not supported. If the action code is not available locally, the catalog cannot safely describe or execute it.
+
+## Building a Catalog
+
+Build a catalog from existing actions:
+
+```elixir
+{:ok, catalog} =
+  Jido.Action.Catalog.from_modules(
+    [
+      MyApp.Actions.SearchUsers,
+      MyApp.Actions.SendEmail
+    ],
+    id: "app-actions",
+    name: "App Actions"
+  )
+```
+
+Entries are derived from action metadata and schemas:
+
+```elixir
+[entry | _] = Jido.Action.Catalog.list(catalog)
+
+entry.name
+#=> "search_users"
+
+entry.input_schema["type"]
+#=> "object"
+```
+
+## Registering Entries
+
+Register modules directly:
+
+```elixir
+catalog =
+  Jido.Action.Catalog.new!(id: "runtime-actions")
+  |> Jido.Action.Catalog.register!(MyApp.Actions.SearchUsers,
+    namespace: "accounts",
+    capabilities: ["lookup"],
+    read_only?: true
+  )
+```
+
+You can also register a prebuilt entry:
+
+```elixir
+entry =
+  Jido.Action.Catalog.Entry.new!(
+    id: "send-email",
+    module: MyApp.Actions.SendEmail,
+    name: "send_email",
+    risk: :medium
+  )
+
+catalog = Jido.Action.Catalog.register!(catalog, entry, visibility: :internal)
+```
+
+## Fetching Entries
+
+Fetch by stable entry id or unique action name:
+
+```elixir
+{:ok, entry} = Jido.Action.Catalog.fetch(catalog, "send_email")
+```
+
+If multiple entries share the same action name, name lookup returns an ambiguous result. Use stable ids for catalogs that intentionally contain multiple versions or variants of the same action.
+
+## Searching
+
+Search is deterministic and LLM-free:
+
+```elixir
+{:ok, hits} = Jido.Action.Catalog.search(catalog, "email")
+
+Enum.map(hits, & &1.entry.name)
+#=> ["send_email"]
+```
+
+Search supports exact filters and metadata filters:
+
+```elixir
+{:ok, hits} =
+  Jido.Action.Catalog.search(catalog,
+    text: "users",
+    namespace: "accounts",
+    tags: ["users"],
+    capabilities: ["lookup"],
+    filters: %{"risk" => "low"}
+  )
+```
+
+By default, search only returns public entries. Include additional visibility values explicitly:
+
+```elixir
+Jido.Action.Catalog.search(catalog, visibility: [:public, :internal])
+```
+
+An empty visibility list matches no entries.
+
+## Execution
+
+This first catalog layer does not execute actions. It selects and describes local action-compatible modules. Once a caller selects an entry, execution should still go through the normal action execution path for the calling layer, such as `Jido.Exec`, `Jido.Action.Tool`, or a higher-level runtime.
+
+Keeping execution outside the catalog keeps this layer serializable, testable, and independent of runtime policy.

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -1,10 +1,29 @@
 defmodule Jido.Action.Catalog do
   @moduledoc """
-  A plain value-level catalog of `Jido.Action` modules.
+  A plain value-level catalog of local action-compatible modules.
 
   This is intentionally not a process-backed registry. It gives callers a small,
   serializable structure for collecting action metadata and doing deterministic,
   LLM-free lookup and search.
+
+  Catalog entries point at local compiled modules. A module is action-compatible
+  when it exports `name/0`, `schema/0`, and `run/2`; it does not have to depend on
+  this package's `use Jido.Action` macro.
+
+  The catalog does not execute selected entries. Callers should route execution
+  through their own runtime policy, such as `Jido.Exec`, `Jido.Action.Tool`, or a
+  higher-level package.
+
+  ## Examples
+
+      {:ok, catalog} =
+        Jido.Action.Catalog.from_modules(
+          [MyApp.Actions.SearchUsers],
+          id: "app-actions"
+        )
+
+      {:ok, hits} = Jido.Action.Catalog.search(catalog, "users")
+      [%Jido.Action.Catalog.Hit{} | _] = hits
   """
 
   alias Jido.Action.Catalog.Entry

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -355,6 +355,14 @@ defmodule Jido.Action.Catalog do
   defp has_text?(_query), do: false
 
   defp score_entry(%Entry{} = entry, %Query{} = query) do
+    if has_text?(query) do
+      score_text_entry(entry, query)
+    else
+      %{entry: entry, score: 1.0, reason: nil, matches: %{}}
+    end
+  end
+
+  defp score_text_entry(%Entry{} = entry, %Query{} = query) do
     text = normalize_text(query.text)
     tokens = text_tokens(text)
 
@@ -383,7 +391,7 @@ defmodule Jido.Action.Catalog do
 
     %{
       entry: entry,
-      score: if(has_text?(query), do: score, else: 1.0),
+      score: score,
       reason: reason_from_matches(matches),
       matches: matches
     }

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -12,6 +12,13 @@ defmodule Jido.Action.Catalog do
   alias Jido.Action.Catalog.Query
   alias Jido.Action.Error
 
+  @filter_enum_values %{
+    schema_kind: [:empty, :nimble, :zoi, :json_schema, :unknown],
+    visibility: [:public, :internal, :hidden],
+    risk: [:low, :medium, :high],
+    source: [:module, :runtime]
+  }
+
   @schema Zoi.struct(
             __MODULE__,
             %{
@@ -106,8 +113,9 @@ defmodule Jido.Action.Catalog do
           {:ok, t()} | {:error, Exception.t()}
   def register(catalog, entry, overrides \\ [])
 
-  def register(%__MODULE__{} = catalog, %Entry{} = entry, _overrides) do
-    with {:ok, entry} <- Entry.new(Map.from_struct(entry)) do
+  def register(%__MODULE__{} = catalog, %Entry{} = entry, overrides) do
+    with {:ok, attrs} <- merge_entry_overrides(entry, overrides),
+         {:ok, entry} <- Entry.new(attrs) do
       {:ok, put_entry(catalog, entry)}
     end
   end
@@ -193,7 +201,7 @@ defmodule Jido.Action.Catalog do
     with {:ok, query} <- Query.new(query_or_attrs) do
       hits =
         catalog
-        |> list()
+        |> entries()
         |> Enum.filter(&matches_filters?(&1, query))
         |> Enum.map(&score_entry(&1, query))
         |> Enum.reject(fn %{score: score} -> score <= 0.0 and has_text?(query) end)
@@ -219,6 +227,30 @@ defmodule Jido.Action.Catalog do
   defp put_entry(%__MODULE__{} = catalog, %Entry{} = entry) do
     %{catalog | entries: Map.put(catalog.entries, entry.id, entry)}
   end
+
+  defp entries(%__MODULE__{} = catalog), do: Map.values(catalog.entries)
+
+  defp merge_entry_overrides(%Entry{} = entry, overrides) do
+    with {:ok, overrides} <- normalize_entry_overrides(overrides) do
+      {:ok, Map.merge(Map.from_struct(entry), overrides)}
+    end
+  end
+
+  defp normalize_entry_overrides(overrides) when is_list(overrides) do
+    if Keyword.keyword?(overrides) do
+      {:ok, Map.new(overrides)}
+    else
+      {:error,
+       Error.validation_error("Invalid catalog registration", %{details: :invalid_overrides})}
+    end
+  end
+
+  defp normalize_entry_overrides(%{} = overrides), do: {:ok, overrides}
+
+  defp normalize_entry_overrides(_overrides),
+    do:
+      {:error,
+       Error.validation_error("Invalid catalog registration", %{details: :invalid_overrides})}
 
   defp normalize_entries_attr(attrs) do
     entries = Map.get(attrs, :entries, Map.get(attrs, "entries", %{}))
@@ -291,12 +323,18 @@ defmodule Jido.Action.Catalog do
     Enum.all?(required, &MapSet.member?(value_set, &1))
   end
 
+  defp map_filters_match?(_entry, filters) when map_size(filters) == 0, do: true
+
   defp map_filters_match?(entry, filters) do
+    entry_attrs = Map.from_struct(entry)
+
     Enum.all?(filters, fn {key, expected} ->
-      entry
-      |> Map.from_struct()
-      |> Map.get(normalize_filter_key(key))
-      |> Kernel.==(expected)
+      key = normalize_filter_key(key)
+
+      case Map.fetch(entry_attrs, key) do
+        {:ok, actual} -> actual == normalize_filter_value(key, expected)
+        :error -> false
+      end
     end)
   end
 
@@ -307,6 +345,15 @@ defmodule Jido.Action.Catalog do
   rescue
     ArgumentError -> key
   end
+
+  defp normalize_filter_value(key, value) when is_binary(value) do
+    case Map.fetch(@filter_enum_values, key) do
+      {:ok, allowed_values} -> Enum.find(allowed_values, value, &(Atom.to_string(&1) == value))
+      :error -> value
+    end
+  end
+
+  defp normalize_filter_value(_key, value), do: value
 
   defp has_text?(%Query{text: text}) when is_binary(text), do: String.trim(text) != ""
   defp has_text?(_query), do: false
@@ -359,7 +406,7 @@ defmodule Jido.Action.Catalog do
 
     cond do
       normalized == text -> exact_score
-      String.contains?(normalized, text) -> token_score * 2
+      String.contains?(normalized, text) -> max(token_score * 2, length(tokens) * token_score)
       true -> token_match_score(normalized, tokens, token_score)
     end
   end

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -279,7 +279,6 @@ defmodule Jido.Action.Catalog do
       map_filters_match?(entry, query.filters)
   end
 
-  defp visibility_match?(_entry, []), do: true
   defp visibility_match?(entry, visibilities), do: entry.visibility in visibilities
 
   defp optional_equal?(_value, nil), do: true

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -133,8 +133,7 @@ defmodule Jido.Action.Catalog do
   def register(catalog, entry, overrides \\ [])
 
   def register(%__MODULE__{} = catalog, %Entry{} = entry, overrides) do
-    with {:ok, attrs} <- merge_entry_overrides(entry, overrides),
-         {:ok, entry} <- Entry.new(attrs) do
+    with {:ok, entry} <- Entry.apply_overrides(entry, overrides) do
       {:ok, put_entry(catalog, entry)}
     end
   end
@@ -248,28 +247,6 @@ defmodule Jido.Action.Catalog do
   end
 
   defp entries(%__MODULE__{} = catalog), do: Map.values(catalog.entries)
-
-  defp merge_entry_overrides(%Entry{} = entry, overrides) do
-    with {:ok, overrides} <- normalize_entry_overrides(overrides) do
-      {:ok, Map.merge(Map.from_struct(entry), overrides)}
-    end
-  end
-
-  defp normalize_entry_overrides(overrides) when is_list(overrides) do
-    if Keyword.keyword?(overrides) do
-      {:ok, Map.new(overrides)}
-    else
-      {:error,
-       Error.validation_error("Invalid catalog registration", %{details: :invalid_overrides})}
-    end
-  end
-
-  defp normalize_entry_overrides(%{} = overrides), do: {:ok, overrides}
-
-  defp normalize_entry_overrides(_overrides),
-    do:
-      {:error,
-       Error.validation_error("Invalid catalog registration", %{details: :invalid_overrides})}
 
   defp normalize_entries_attr(attrs) do
     entries = Map.get(attrs, :entries, Map.get(attrs, "entries", %{}))

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -49,12 +49,14 @@ defmodule Jido.Action.Catalog do
   def new(%{} = attrs) do
     attrs = Map.put_new_lazy(attrs, :id, &Uniq.UUID.uuid7/0)
 
-    case Zoi.parse(@schema, attrs) do
-      {:ok, catalog} ->
-        {:ok, catalog}
+    with {:ok, attrs} <- normalize_entries_attr(attrs) do
+      case Zoi.parse(@schema, attrs) do
+        {:ok, catalog} ->
+          {:ok, catalog}
 
-      {:error, errors} ->
-        {:error, Error.validation_error("Invalid action catalog", %{details: errors})}
+        {:error, errors} ->
+          {:error, Error.validation_error("Invalid action catalog", %{details: errors})}
+      end
     end
   end
 
@@ -105,7 +107,9 @@ defmodule Jido.Action.Catalog do
   def register(catalog, entry, overrides \\ [])
 
   def register(%__MODULE__{} = catalog, %Entry{} = entry, _overrides) do
-    {:ok, put_entry(catalog, entry)}
+    with {:ok, entry} <- Entry.new(Map.from_struct(entry)) do
+      {:ok, put_entry(catalog, entry)}
+    end
   end
 
   def register(%__MODULE__{} = catalog, module, overrides) when is_atom(module) do
@@ -215,6 +219,47 @@ defmodule Jido.Action.Catalog do
   defp put_entry(%__MODULE__{} = catalog, %Entry{} = entry) do
     %{catalog | entries: Map.put(catalog.entries, entry.id, entry)}
   end
+
+  defp normalize_entries_attr(attrs) do
+    entries = Map.get(attrs, :entries, Map.get(attrs, "entries", %{}))
+
+    with {:ok, entries} <- normalize_entries(entries) do
+      attrs =
+        attrs
+        |> Map.delete("entries")
+        |> Map.put(:entries, entries)
+
+      {:ok, attrs}
+    end
+  end
+
+  defp normalize_entries(entries) when is_map(entries) do
+    Enum.reduce_while(entries, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      case normalize_entry_value(value) do
+        {:ok, entry} ->
+          {:cont, {:ok, Map.put(acc, entry.id, entry)}}
+
+        {:error, reason} ->
+          {:halt,
+           {:error,
+            Error.validation_error("Invalid action catalog", %{
+              details: %{entries: %{key => reason}}
+            })}}
+      end
+    end)
+  end
+
+  defp normalize_entries(_entries) do
+    {:error,
+     Error.validation_error("Invalid action catalog", %{
+       details: %{entries: "must be a map of catalog entries"}
+     })}
+  end
+
+  defp normalize_entry_value(%Entry{} = entry), do: Entry.new(Map.from_struct(entry))
+  defp normalize_entry_value(%{} = attrs), do: Entry.new(attrs)
+  defp normalize_entry_value(attrs) when is_list(attrs), do: Entry.new(attrs)
+  defp normalize_entry_value(_attrs), do: {:error, :invalid_entry}
 
   defp fetch_by_name(catalog, name) do
     matches = catalog.entries |> Map.values() |> Enum.filter(&(&1.name == name))

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -1,0 +1,363 @@
+defmodule Jido.Action.Catalog do
+  @moduledoc """
+  A plain value-level catalog of `Jido.Action` modules.
+
+  This is intentionally not a process-backed registry. It gives callers a small,
+  serializable structure for collecting action metadata and doing deterministic,
+  LLM-free lookup and search.
+  """
+
+  alias Jido.Action.Catalog.Entry
+  alias Jido.Action.Catalog.Hit
+  alias Jido.Action.Catalog.Query
+  alias Jido.Action.Error
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string(description: "Catalog id"),
+              name: Zoi.string(description: "Human/catalog name") |> Zoi.optional(),
+              description: Zoi.string(description: "Catalog description") |> Zoi.default(""),
+              version: Zoi.string(description: "Catalog version") |> Zoi.optional(),
+              entries:
+                Zoi.map(description: "Map of entry id to Catalog.Entry") |> Zoi.default(%{}),
+              metadata:
+                Zoi.map(description: "Catalog-level extension metadata") |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+  @type entry_ref :: String.t() | Entry.t()
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc """
+  Returns the Zoi schema used to validate catalogs.
+  """
+  @spec schema() :: term()
+  def schema, do: @schema
+
+  @doc """
+  Builds an empty catalog.
+  """
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
+  def new(attrs \\ %{})
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    attrs = Map.put_new_lazy(attrs, :id, &Uniq.UUID.uuid7/0)
+
+    case Zoi.parse(@schema, attrs) do
+      {:ok, catalog} ->
+        {:ok, catalog}
+
+      {:error, errors} ->
+        {:error, Error.validation_error("Invalid action catalog", %{details: errors})}
+    end
+  end
+
+  def new(_attrs), do: {:error, Error.validation_error("Invalid action catalog")}
+
+  @doc """
+  Same as `new/1`, but raises on error.
+  """
+  @spec new!(map() | keyword()) :: t() | no_return()
+  def new!(attrs \\ %{}) do
+    case new(attrs) do
+      {:ok, catalog} -> catalog
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Builds a catalog from action modules.
+  """
+  @spec from_modules([module()], map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
+  def from_modules(modules, attrs \\ []) when is_list(modules) do
+    with {:ok, catalog} <- new(attrs) do
+      Enum.reduce_while(modules, {:ok, catalog}, fn module, {:ok, acc} ->
+        case register(acc, module) do
+          {:ok, updated} -> {:cont, {:ok, updated}}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+    end
+  end
+
+  @doc """
+  Same as `from_modules/2`, but raises on error.
+  """
+  @spec from_modules!([module()], map() | keyword()) :: t() | no_return()
+  def from_modules!(modules, attrs \\ []) do
+    case from_modules(modules, attrs) do
+      {:ok, catalog} -> catalog
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Registers an action module or prebuilt entry in a catalog.
+  """
+  @spec register(t(), module() | Entry.t(), map() | keyword()) ::
+          {:ok, t()} | {:error, Exception.t()}
+  def register(catalog, entry, overrides \\ [])
+
+  def register(%__MODULE__{} = catalog, %Entry{} = entry, _overrides) do
+    {:ok, put_entry(catalog, entry)}
+  end
+
+  def register(%__MODULE__{} = catalog, module, overrides) when is_atom(module) do
+    with {:ok, entry} <- Entry.from_module(module, overrides) do
+      {:ok, put_entry(catalog, entry)}
+    end
+  end
+
+  def register(_catalog, _entry, _overrides),
+    do: {:error, Error.validation_error("Invalid catalog registration")}
+
+  @doc """
+  Same as `register/3`, but raises on error.
+  """
+  @spec register!(t(), module() | Entry.t(), map() | keyword()) :: t() | no_return()
+  def register!(catalog, entry, overrides \\ []) do
+    case register(catalog, entry, overrides) do
+      {:ok, updated} -> updated
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Returns entries sorted by action name and id.
+  """
+  @spec list(t()) :: [Entry.t()]
+  def list(%__MODULE__{} = catalog) do
+    catalog.entries
+    |> Map.values()
+    |> Enum.sort_by(&{&1.name, &1.id})
+  end
+
+  @doc """
+  Fetches an entry by id or unique action name.
+  """
+  @spec fetch(t(), String.t()) :: {:ok, Entry.t()} | {:error, term()}
+  def fetch(%__MODULE__{} = catalog, id_or_name) when is_binary(id_or_name) do
+    case Map.fetch(catalog.entries, id_or_name) do
+      {:ok, entry} ->
+        {:ok, entry}
+
+      :error ->
+        fetch_by_name(catalog, id_or_name)
+    end
+  end
+
+  @doc """
+  Same as `fetch/2`, but raises on error.
+  """
+  @spec fetch!(t(), String.t()) :: Entry.t() | no_return()
+  def fetch!(catalog, id_or_name) do
+    case fetch(catalog, id_or_name) do
+      {:ok, entry} ->
+        entry
+
+      {:error, reason} ->
+        raise Error.validation_error("Catalog entry not found", %{reason: reason})
+    end
+  end
+
+  @doc """
+  Removes an entry by id, unique action name, or entry value.
+  """
+  @spec unregister(t(), entry_ref()) :: {:ok, t()} | {:error, term()}
+  def unregister(%__MODULE__{} = catalog, %Entry{} = entry) do
+    {:ok, %{catalog | entries: Map.delete(catalog.entries, entry.id)}}
+  end
+
+  def unregister(%__MODULE__{} = catalog, id_or_name) when is_binary(id_or_name) do
+    with {:ok, entry} <- fetch(catalog, id_or_name) do
+      unregister(catalog, entry)
+    end
+  end
+
+  @doc """
+  Searches entries with deterministic lexical scoring.
+  """
+  @spec search(t(), Query.t() | map() | keyword() | String.t()) ::
+          {:ok, [Hit.t()]} | {:error, Exception.t()}
+  def search(%__MODULE__{} = catalog, query_or_attrs) do
+    with {:ok, query} <- Query.new(query_or_attrs) do
+      hits =
+        catalog
+        |> list()
+        |> Enum.filter(&matches_filters?(&1, query))
+        |> Enum.map(&score_entry(&1, query))
+        |> Enum.reject(fn %{score: score} -> score <= 0.0 and has_text?(query) end)
+        |> Enum.sort_by(fn %{score: score, entry: entry} -> {-score, entry.name, entry.id} end)
+        |> Enum.take(query.limit)
+        |> Enum.map(&Hit.new!/1)
+
+      {:ok, hits}
+    end
+  end
+
+  @doc """
+  Same as `search/2`, but raises on error.
+  """
+  @spec search!(t(), Query.t() | map() | keyword() | String.t()) :: [Hit.t()] | no_return()
+  def search!(catalog, query_or_attrs) do
+    case search(catalog, query_or_attrs) do
+      {:ok, hits} -> hits
+      {:error, error} -> raise error
+    end
+  end
+
+  defp put_entry(%__MODULE__{} = catalog, %Entry{} = entry) do
+    %{catalog | entries: Map.put(catalog.entries, entry.id, entry)}
+  end
+
+  defp fetch_by_name(catalog, name) do
+    matches = catalog.entries |> Map.values() |> Enum.filter(&(&1.name == name))
+
+    case matches do
+      [entry] -> {:ok, entry}
+      [] -> {:error, :not_found}
+      entries -> {:error, {:ambiguous, name, Enum.map(entries, & &1.id)}}
+    end
+  end
+
+  defp matches_filters?(%Entry{} = entry, %Query{} = query) do
+    visibility_match?(entry, query.visibility) and
+      optional_equal?(entry.namespace, query.namespace) and
+      contains_all?(entry.tags, query.tags) and
+      contains_all?(entry.capabilities, query.capabilities) and
+      map_filters_match?(entry, query.filters)
+  end
+
+  defp visibility_match?(_entry, []), do: true
+  defp visibility_match?(entry, visibilities), do: entry.visibility in visibilities
+
+  defp optional_equal?(_value, nil), do: true
+  defp optional_equal?(value, expected), do: value == expected
+
+  defp contains_all?(_values, []), do: true
+
+  defp contains_all?(values, required) do
+    value_set = MapSet.new(values)
+    Enum.all?(required, &MapSet.member?(value_set, &1))
+  end
+
+  defp map_filters_match?(entry, filters) do
+    Enum.all?(filters, fn {key, expected} ->
+      entry
+      |> Map.from_struct()
+      |> Map.get(normalize_filter_key(key))
+      |> Kernel.==(expected)
+    end)
+  end
+
+  defp normalize_filter_key(key) when is_atom(key), do: key
+
+  defp normalize_filter_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
+
+  defp has_text?(%Query{text: text}) when is_binary(text), do: String.trim(text) != ""
+  defp has_text?(_query), do: false
+
+  defp score_entry(%Entry{} = entry, %Query{} = query) do
+    text = normalize_text(query.text)
+    tokens = text_tokens(text)
+
+    {score, matches} =
+      [
+        {:id, entry.id, 100.0, 20.0},
+        {:name, entry.name, 100.0, 15.0},
+        {:title, entry.title, 25.0, 8.0},
+        {:summary, entry.summary, 20.0, 6.0},
+        {:description, entry.description, 15.0, 5.0},
+        {:category, entry.category, 12.0, 4.0},
+        {:tags, entry.tags, 20.0, 8.0},
+        {:capabilities, entry.capabilities, 20.0, 8.0},
+        {:keywords, entry.keywords, 20.0, 8.0},
+        {:schema, schema_search_text(entry), 8.0, 2.0}
+      ]
+      |> Enum.reduce({0.0, %{}}, fn {field, value, exact_score, token_score}, {score, matches} ->
+        field_score = field_score(value, text, tokens, exact_score, token_score)
+
+        if field_score > 0 do
+          {score + field_score, Map.put(matches, field, field_score)}
+        else
+          {score, matches}
+        end
+      end)
+
+    %{
+      entry: entry,
+      score: if(has_text?(query), do: score, else: 1.0),
+      reason: reason_from_matches(matches),
+      matches: matches
+    }
+  end
+
+  defp field_score(_value, "", _tokens, _exact_score, _token_score), do: 0.0
+
+  defp field_score(values, text, tokens, exact_score, token_score) when is_list(values) do
+    values
+    |> Enum.map(&field_score(&1, text, tokens, exact_score, token_score))
+    |> Enum.sum()
+  end
+
+  defp field_score(value, text, tokens, exact_score, token_score) when is_binary(value) do
+    normalized = normalize_text(value)
+
+    cond do
+      normalized == text -> exact_score
+      String.contains?(normalized, text) -> token_score * 2
+      true -> token_match_score(normalized, tokens, token_score)
+    end
+  end
+
+  defp field_score(_value, _text, _tokens, _exact_score, _token_score), do: 0.0
+
+  defp token_match_score(_value, [], _token_score), do: 0.0
+
+  defp token_match_score(value, tokens, token_score) do
+    matches = Enum.count(tokens, &String.contains?(value, &1))
+    matches * token_score
+  end
+
+  defp schema_search_text(entry) do
+    [entry.input_schema, entry.output_schema]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map_join(" ", &inspect/1)
+  end
+
+  defp normalize_text(nil), do: ""
+
+  defp normalize_text(value) do
+    value
+    |> to_string()
+    |> String.downcase()
+    |> String.trim()
+  end
+
+  defp text_tokens(""), do: []
+
+  defp text_tokens(text) do
+    text
+    |> String.split(~r/[^a-z0-9_]+/, trim: true)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp reason_from_matches(matches) when map_size(matches) == 0, do: nil
+
+  defp reason_from_matches(matches) do
+    matches
+    |> Map.keys()
+    |> Enum.map(&to_string/1)
+    |> Enum.join(", ")
+  end
+end

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -195,6 +195,8 @@ defmodule Jido.Action.Catalog.Entry do
       entry
       |> Map.from_struct()
       |> Map.merge(overrides)
+      |> refresh_overridden_id(entry, overrides)
+      |> refresh_derived_schema_kind(overrides)
       |> new()
     end
   end
@@ -317,6 +319,19 @@ defmodule Jido.Action.Catalog.Entry do
           Map.get(attrs, :version)
         )
       )
+    end
+  end
+
+  defp refresh_overridden_id(attrs, %__MODULE__{} = entry, overrides) do
+    cond do
+      Map.has_key?(overrides, :id) or Map.has_key?(overrides, "id") ->
+        attrs
+
+      entry.id == stable_id(entry.module, entry.name, entry.version) ->
+        refresh_derived_id(attrs, entry.module, overrides)
+
+      true ->
+        attrs
     end
   end
 

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -4,6 +4,10 @@ defmodule Jido.Action.Catalog.Entry do
 
   Entries are plain values. They are intended for inspection, filtering, search,
   documentation, and later projection into higher-level runtimes.
+
+  A module is action-compatible when it is available locally and exports
+  `name/0`, `schema/0`, and `run/2`. Catalogs do not support remote entries whose
+  implementation is not loaded in the current runtime.
   """
 
   alias Jido.Action.Error

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -9,11 +9,18 @@ defmodule Jido.Action.Catalog.Entry do
   alias Jido.Action.Error
   alias Jido.Action.Schema
 
+  @schema_kind_values [:empty, :nimble, :zoi, :json_schema, :unknown]
+  @visibility_values [:public, :internal, :hidden]
+  @risk_values [:low, :medium, :high]
+  @source_values [:module, :runtime, :remote]
+
   @schema Zoi.struct(
             __MODULE__,
             %{
               id: Zoi.string(description: "Stable catalog entry id"),
-              module: Zoi.atom(description: "Concrete Jido.Action module"),
+              module:
+                Zoi.atom(description: "Concrete Jido.Action module")
+                |> Zoi.refine({__MODULE__, :validate_action_module, []}),
               name: Zoi.string(description: "Machine-friendly action name"),
               title: Zoi.string(description: "Short human label") |> Zoi.optional(),
               description:
@@ -32,16 +39,20 @@ defmodule Jido.Action.Catalog.Entry do
               input_schema: Zoi.any(description: "Normalized input schema") |> Zoi.optional(),
               output_schema: Zoi.any(description: "Normalized output schema") |> Zoi.optional(),
               schema_kind:
-                Zoi.atom(description: "Input schema source/format") |> Zoi.default(:empty),
+                Zoi.enum(@schema_kind_values, description: "Input schema source/format")
+                |> Zoi.default(:empty),
               keywords:
                 Zoi.list(Zoi.string(), description: "Explicit search keywords") |> Zoi.default([]),
               examples:
                 Zoi.list(Zoi.map(), description: "Small input/output examples") |> Zoi.default([]),
               visibility:
-                Zoi.atom(description: "Visibility: :public | :internal | :hidden")
+                Zoi.enum(@visibility_values,
+                  description: "Visibility: :public | :internal | :hidden"
+                )
                 |> Zoi.default(:public),
               risk:
-                Zoi.atom(description: "Risk level: :low | :medium | :high") |> Zoi.default(:low),
+                Zoi.enum(@risk_values, description: "Risk level: :low | :medium | :high")
+                |> Zoi.default(:low),
               read_only?:
                 Zoi.boolean(description: "Whether execution is read-only") |> Zoi.default(false),
               requires_confirmation?:
@@ -55,7 +66,9 @@ defmodule Jido.Action.Catalog.Entry do
                 |> Zoi.min(0)
                 |> Zoi.optional(),
               source:
-                Zoi.atom(description: "Registration source: :module | :runtime | :remote")
+                Zoi.enum(@source_values,
+                  description: "Registration source: :module | :runtime | :remote"
+                )
                 |> Zoi.default(:module),
               metadata: Zoi.map(description: "Arbitrary extension metadata") |> Zoi.default(%{})
             },
@@ -86,7 +99,7 @@ defmodule Jido.Action.Catalog.Entry do
       |> drop_nil_values()
 
     case Zoi.parse(@schema, attrs) do
-      {:ok, entry} -> {:ok, entry}
+      {:ok, entry} -> {:ok, normalize_entry_schemas(entry)}
       {:error, errors} -> {:error, validation_error("Invalid catalog entry", errors)}
     end
   end
@@ -111,12 +124,16 @@ defmodule Jido.Action.Catalog.Entry do
   """
   @spec from_module(module(), map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
   def from_module(module, overrides \\ []) when is_atom(module) do
-    overrides = normalize_attrs(overrides)
+    overrides =
+      overrides
+      |> normalize_attrs()
+      |> normalize_attr_aliases()
 
-    with :ok <- validate_action_module(module),
+    with :ok <- ensure_action_module(module),
          {:ok, attrs} <- module_attrs(module) do
       attrs
       |> Map.merge(overrides)
+      |> refresh_derived_id(module, overrides)
       |> new()
     end
   end
@@ -132,27 +149,42 @@ defmodule Jido.Action.Catalog.Entry do
     end
   end
 
-  defp validate_action_module(module) do
+  @doc false
+  @spec validate_action_module(term(), keyword()) :: :ok | {:error, String.t()}
+  def validate_action_module(module, _opts \\ [])
+
+  def validate_action_module(module, _opts) when not is_atom(module) or is_nil(module),
+    do: {:error, "must be a module atom"}
+
+  def validate_action_module(module, _opts) do
     case Code.ensure_compiled(module) do
       {:module, _} ->
         cond do
+          not action_behaviour?(module) ->
+            {:error, "must use Jido.Action"}
+
           not function_exported?(module, :name, 0) ->
-            {:error,
-             validation_error("Invalid catalog action module", %{
-               module: module,
-               reason: :missing_name
-             })}
+            {:error, "must export name/0"}
 
           not function_exported?(module, :schema, 0) ->
-            {:error,
-             validation_error("Invalid catalog action module", %{
-               module: module,
-               reason: :missing_schema
-             })}
+            {:error, "must export schema/0"}
+
+          not function_exported?(module, :run, 2) ->
+            {:error, "must export run/2"}
 
           true ->
             :ok
         end
+
+      {:error, reason} ->
+        {:error, "could not compile module: #{inspect(reason)}"}
+    end
+  end
+
+  defp ensure_action_module(module) do
+    case validate_action_module(module) do
+      :ok ->
+        :ok
 
       {:error, reason} ->
         {:error,
@@ -214,6 +246,8 @@ defmodule Jido.Action.Catalog.Entry do
   defp stringify_json_schema(value) when is_list(value),
     do: Enum.map(value, &stringify_json_schema/1)
 
+  defp stringify_json_schema(value) when is_boolean(value), do: value
+  defp stringify_json_schema(nil), do: nil
   defp stringify_json_schema(value) when is_atom(value), do: Atom.to_string(value)
   defp stringify_json_schema(value), do: value
 
@@ -223,10 +257,28 @@ defmodule Jido.Action.Catalog.Entry do
   defp stable_id(module, name, nil), do: "#{inspect(module)}:#{name}"
   defp stable_id(module, name, version), do: "#{inspect(module)}:#{name}@#{version}"
 
+  defp refresh_derived_id(attrs, module, overrides) do
+    if Map.has_key?(overrides, :id) or Map.has_key?(overrides, "id") do
+      attrs
+    else
+      attrs
+      |> Map.put(
+        :id,
+        stable_id(
+          Map.get(attrs, :module, module),
+          Map.get(attrs, :name),
+          Map.get(attrs, :version)
+        )
+      )
+    end
+  end
+
   defp normalize_attr_aliases(attrs) do
     attrs
     |> maybe_rename(:vsn, :version)
+    |> maybe_rename("vsn", :version)
     |> maybe_rename(:schema, :input_schema)
+    |> maybe_rename("schema", :input_schema)
   end
 
   defp maybe_rename(attrs, from, to) do
@@ -244,6 +296,29 @@ defmodule Jido.Action.Catalog.Entry do
   defp normalize_attrs(attrs) when is_list(attrs), do: Map.new(attrs)
   defp normalize_attrs(%{} = attrs), do: attrs
   defp normalize_attrs(_attrs), do: %{}
+
+  defp normalize_entry_schemas(%__MODULE__{} = entry) do
+    %{
+      entry
+      | input_schema: normalize_schema(entry.input_schema),
+        output_schema: normalize_schema(entry.output_schema)
+    }
+  end
+
+  defp action_behaviour?(module) do
+    module
+    |> module_behaviours()
+    |> Enum.member?(Jido.Action)
+  end
+
+  defp module_behaviours(module) do
+    attributes = module.module_info(:attributes)
+
+    attributes
+    |> Keyword.get_values(:behaviour)
+    |> Kernel.++(Keyword.get_values(attributes, :behavior))
+    |> List.flatten()
+  end
 
   defp drop_nil_values(attrs) do
     Map.reject(attrs, fn {_key, value} -> is_nil(value) end)

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -1,0 +1,255 @@
+defmodule Jido.Action.Catalog.Entry do
+  @moduledoc """
+  Normalized metadata for one `Jido.Action` module in an action catalog.
+
+  Entries are plain values. They are intended for inspection, filtering, search,
+  documentation, and later projection into higher-level runtimes.
+  """
+
+  alias Jido.Action.Error
+  alias Jido.Action.Schema
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              id: Zoi.string(description: "Stable catalog entry id"),
+              module: Zoi.atom(description: "Concrete Jido.Action module"),
+              name: Zoi.string(description: "Machine-friendly action name"),
+              title: Zoi.string(description: "Short human label") |> Zoi.optional(),
+              description:
+                Zoi.string(description: "Human-readable action description") |> Zoi.default(""),
+              summary:
+                Zoi.string(description: "One-line search/display summary") |> Zoi.optional(),
+              namespace:
+                Zoi.string(description: "Logical namespace, e.g. billing.crm")
+                |> Zoi.optional(),
+              package: Zoi.string(description: "Owning package/application") |> Zoi.optional(),
+              version: Zoi.string(description: "Action or metadata version") |> Zoi.optional(),
+              category: Zoi.string(description: "Primary category") |> Zoi.optional(),
+              tags: Zoi.list(Zoi.string(), description: "Search/filter tags") |> Zoi.default([]),
+              capabilities:
+                Zoi.list(Zoi.string(), description: "Capability labels") |> Zoi.default([]),
+              input_schema: Zoi.any(description: "Normalized input schema") |> Zoi.optional(),
+              output_schema: Zoi.any(description: "Normalized output schema") |> Zoi.optional(),
+              schema_kind:
+                Zoi.atom(description: "Input schema source/format") |> Zoi.default(:empty),
+              keywords:
+                Zoi.list(Zoi.string(), description: "Explicit search keywords") |> Zoi.default([]),
+              examples:
+                Zoi.list(Zoi.map(), description: "Small input/output examples") |> Zoi.default([]),
+              visibility:
+                Zoi.atom(description: "Visibility: :public | :internal | :hidden")
+                |> Zoi.default(:public),
+              risk:
+                Zoi.atom(description: "Risk level: :low | :medium | :high") |> Zoi.default(:low),
+              read_only?:
+                Zoi.boolean(description: "Whether execution is read-only") |> Zoi.default(false),
+              requires_confirmation?:
+                Zoi.boolean(description: "Whether execution should require confirmation")
+                |> Zoi.default(false),
+              scopes:
+                Zoi.list(Zoi.string(), description: "Required auth/policy scopes")
+                |> Zoi.default([]),
+              timeout:
+                Zoi.integer(description: "Default execution timeout in ms")
+                |> Zoi.min(0)
+                |> Zoi.optional(),
+              source:
+                Zoi.atom(description: "Registration source: :module | :runtime | :remote")
+                |> Zoi.default(:module),
+              metadata: Zoi.map(description: "Arbitrary extension metadata") |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc """
+  Returns the Zoi schema used to validate catalog entries.
+  """
+  @spec schema() :: term()
+  def schema, do: @schema
+
+  @doc """
+  Builds a catalog entry from raw attributes.
+  """
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    attrs =
+      attrs
+      |> normalize_attr_aliases()
+      |> drop_nil_values()
+
+    case Zoi.parse(@schema, attrs) do
+      {:ok, entry} -> {:ok, entry}
+      {:error, errors} -> {:error, validation_error("Invalid catalog entry", errors)}
+    end
+  end
+
+  def new(_attrs), do: {:error, validation_error("Invalid catalog entry", :invalid_attrs)}
+
+  @doc """
+  Same as `new/1`, but raises on error.
+  """
+  @spec new!(map() | keyword()) :: t() | no_return()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, entry} -> entry
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Builds a catalog entry from a `Jido.Action` module.
+
+  Optional attributes override the module-derived metadata.
+  """
+  @spec from_module(module(), map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
+  def from_module(module, overrides \\ []) when is_atom(module) do
+    overrides = normalize_attrs(overrides)
+
+    with :ok <- validate_action_module(module),
+         {:ok, attrs} <- module_attrs(module) do
+      attrs
+      |> Map.merge(overrides)
+      |> new()
+    end
+  end
+
+  @doc """
+  Same as `from_module/2`, but raises on error.
+  """
+  @spec from_module!(module(), map() | keyword()) :: t() | no_return()
+  def from_module!(module, overrides \\ []) do
+    case from_module(module, overrides) do
+      {:ok, entry} -> entry
+      {:error, error} -> raise error
+    end
+  end
+
+  defp validate_action_module(module) do
+    case Code.ensure_compiled(module) do
+      {:module, _} ->
+        cond do
+          not function_exported?(module, :name, 0) ->
+            {:error,
+             validation_error("Invalid catalog action module", %{
+               module: module,
+               reason: :missing_name
+             })}
+
+          not function_exported?(module, :schema, 0) ->
+            {:error,
+             validation_error("Invalid catalog action module", %{
+               module: module,
+               reason: :missing_schema
+             })}
+
+          true ->
+            :ok
+        end
+
+      {:error, reason} ->
+        {:error,
+         validation_error("Invalid catalog action module", %{module: module, reason: reason})}
+    end
+  end
+
+  defp module_attrs(module) do
+    input_schema = module.schema()
+    output_schema = safe_call(module, :output_schema, [])
+    version = safe_call(module, :vsn, nil)
+    name = module.name()
+
+    attrs =
+      %{
+        id: stable_id(module, name, version),
+        module: module,
+        name: name,
+        description: safe_call(module, :description, "") || "",
+        category: safe_call(module, :category, nil),
+        tags: safe_call(module, :tags, []) || [],
+        version: version,
+        input_schema: normalize_schema(input_schema),
+        output_schema: normalize_schema(output_schema),
+        schema_kind: Schema.schema_type(input_schema),
+        source: :module
+      }
+      |> drop_nil_values()
+
+    {:ok, attrs}
+  rescue
+    exception ->
+      {:error,
+       validation_error("Invalid catalog action metadata", %{
+         module: module,
+         exception: exception
+       })}
+  end
+
+  defp safe_call(module, function, default) do
+    if function_exported?(module, function, 0), do: apply(module, function, []), else: default
+  end
+
+  defp normalize_schema(nil), do: nil
+
+  defp normalize_schema(schema) do
+    Schema.to_json_schema(schema, strict: true)
+    |> stringify_json_schema()
+  rescue
+    _ -> schema
+  end
+
+  defp stringify_json_schema(value) when is_map(value) do
+    Map.new(value, fn {key, nested} ->
+      {stringify_json_schema_key(key), stringify_json_schema(nested)}
+    end)
+  end
+
+  defp stringify_json_schema(value) when is_list(value),
+    do: Enum.map(value, &stringify_json_schema/1)
+
+  defp stringify_json_schema(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify_json_schema(value), do: value
+
+  defp stringify_json_schema_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp stringify_json_schema_key(key), do: key
+
+  defp stable_id(module, name, nil), do: "#{inspect(module)}:#{name}"
+  defp stable_id(module, name, version), do: "#{inspect(module)}:#{name}@#{version}"
+
+  defp normalize_attr_aliases(attrs) do
+    attrs
+    |> maybe_rename(:vsn, :version)
+    |> maybe_rename(:schema, :input_schema)
+  end
+
+  defp maybe_rename(attrs, from, to) do
+    case Map.fetch(attrs, from) do
+      {:ok, value} ->
+        attrs
+        |> Map.delete(from)
+        |> Map.put_new(to, value)
+
+      :error ->
+        attrs
+    end
+  end
+
+  defp normalize_attrs(attrs) when is_list(attrs), do: Map.new(attrs)
+  defp normalize_attrs(%{} = attrs), do: attrs
+  defp normalize_attrs(_attrs), do: %{}
+
+  defp drop_nil_values(attrs) do
+    Map.reject(attrs, fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp validation_error(message, details) do
+    Error.validation_error(message, %{details: details})
+  end
+end

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -189,6 +189,17 @@ defmodule Jido.Action.Catalog.Entry do
   end
 
   @doc false
+  @spec apply_overrides(t(), map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
+  def apply_overrides(%__MODULE__{} = entry, overrides) do
+    with {:ok, overrides} <- normalize_overrides(overrides) do
+      entry
+      |> Map.from_struct()
+      |> Map.merge(overrides)
+      |> new()
+    end
+  end
+
+  @doc false
   @spec validate_action_module(term(), keyword()) :: :ok | {:error, String.t()}
   def validate_action_module(module, _opts \\ [])
 

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -1,6 +1,6 @@
 defmodule Jido.Action.Catalog.Entry do
   @moduledoc """
-  Normalized metadata for one `Jido.Action` module in an action catalog.
+  Normalized metadata for one local action-compatible module in an action catalog.
 
   Entries are plain values. They are intended for inspection, filtering, search,
   documentation, and later projection into higher-level runtimes.
@@ -12,7 +12,7 @@ defmodule Jido.Action.Catalog.Entry do
   @schema_kind_values [:empty, :nimble, :zoi, :json_schema, :unknown]
   @visibility_values [:public, :internal, :hidden]
   @risk_values [:low, :medium, :high]
-  @source_values [:module, :runtime, :remote]
+  @source_values [:module, :runtime]
   @string_key_fields [
     :id,
     :module,
@@ -52,7 +52,7 @@ defmodule Jido.Action.Catalog.Entry do
             %{
               id: Zoi.string(description: "Stable catalog entry id"),
               module:
-                Zoi.atom(description: "Concrete Jido.Action module")
+                Zoi.atom(description: "Concrete local action-compatible module")
                 |> Zoi.refine({__MODULE__, :validate_action_module, []}),
               name: Zoi.string(description: "Machine-friendly action name"),
               title: Zoi.string(description: "Short human label") |> Zoi.optional(),
@@ -100,7 +100,7 @@ defmodule Jido.Action.Catalog.Entry do
                 |> Zoi.optional(),
               source:
                 Zoi.enum(@source_values,
-                  description: "Registration source: :module | :runtime | :remote"
+                  description: "Registration source: :module | :runtime"
                 )
                 |> Zoi.default(:module),
               metadata: Zoi.map(description: "Arbitrary extension metadata") |> Zoi.default(%{})
@@ -151,7 +151,7 @@ defmodule Jido.Action.Catalog.Entry do
   end
 
   @doc """
-  Builds a catalog entry from a `Jido.Action` module.
+  Builds a catalog entry from a local action-compatible module.
 
   Optional attributes override the module-derived metadata.
   """
@@ -195,9 +195,6 @@ defmodule Jido.Action.Catalog.Entry do
     case Code.ensure_compiled(module) do
       {:module, _} ->
         cond do
-          not action_behaviour?(module) ->
-            {:error, "must use Jido.Action"}
-
           not function_exported?(module, :name, 0) ->
             {:error, "must export name/0"}
 
@@ -360,6 +357,7 @@ defmodule Jido.Action.Catalog.Entry do
     attrs
     |> normalize_known_string_keys()
     |> normalize_attr_aliases()
+    |> normalize_module_value()
     |> normalize_enum_values()
   end
 
@@ -384,27 +382,37 @@ defmodule Jido.Action.Catalog.Entry do
 
   defp normalize_enum_value(value, _allowed_values), do: value
 
+  defp normalize_module_value(%{module: module} = attrs) when is_binary(module) do
+    case existing_module_atom(module) do
+      {:ok, module} -> Map.put(attrs, :module, module)
+      :error -> attrs
+    end
+  end
+
+  defp normalize_module_value(attrs), do: attrs
+
+  defp existing_module_atom(module) do
+    candidates =
+      case String.starts_with?(module, "Elixir.") do
+        true -> [module]
+        false -> [module, "Elixir." <> module]
+      end
+
+    Enum.find_value(candidates, :error, fn candidate ->
+      try do
+        {:ok, String.to_existing_atom(candidate)}
+      rescue
+        ArgumentError -> false
+      end
+    end)
+  end
+
   defp normalize_entry_schemas(%__MODULE__{} = entry) do
     %{
       entry
       | input_schema: normalize_schema(entry.input_schema),
         output_schema: normalize_schema(entry.output_schema)
     }
-  end
-
-  defp action_behaviour?(module) do
-    module
-    |> module_behaviours()
-    |> Enum.member?(Jido.Action)
-  end
-
-  defp module_behaviours(module) do
-    attributes = module.module_info(:attributes)
-
-    attributes
-    |> Keyword.get_values(:behaviour)
-    |> Kernel.++(Keyword.get_values(attributes, :behavior))
-    |> List.flatten()
   end
 
   defp drop_nil_values(attrs) do

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -13,6 +13,39 @@ defmodule Jido.Action.Catalog.Entry do
   @visibility_values [:public, :internal, :hidden]
   @risk_values [:low, :medium, :high]
   @source_values [:module, :runtime, :remote]
+  @string_key_fields [
+    :id,
+    :module,
+    :name,
+    :title,
+    :description,
+    :summary,
+    :namespace,
+    :package,
+    :version,
+    :category,
+    :tags,
+    :capabilities,
+    :input_schema,
+    :output_schema,
+    :schema_kind,
+    :keywords,
+    :examples,
+    :visibility,
+    :risk,
+    :read_only?,
+    :requires_confirmation?,
+    :scopes,
+    :timeout,
+    :source,
+    :metadata
+  ]
+  @enum_fields %{
+    schema_kind: @schema_kind_values,
+    visibility: @visibility_values,
+    risk: @risk_values,
+    source: @source_values
+  }
 
   @schema Zoi.struct(
             __MODULE__,
@@ -95,7 +128,7 @@ defmodule Jido.Action.Catalog.Entry do
   def new(%{} = attrs) do
     attrs =
       attrs
-      |> normalize_attr_aliases()
+      |> normalize_attr_map()
       |> drop_nil_values()
 
     case Zoi.parse(@schema, attrs) do
@@ -123,20 +156,22 @@ defmodule Jido.Action.Catalog.Entry do
   Optional attributes override the module-derived metadata.
   """
   @spec from_module(module(), map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
-  def from_module(module, overrides \\ []) when is_atom(module) do
-    overrides =
-      overrides
-      |> normalize_attrs()
-      |> normalize_attr_aliases()
+  def from_module(module, overrides \\ [])
 
-    with :ok <- ensure_action_module(module),
+  def from_module(module, overrides) when is_atom(module) do
+    with {:ok, overrides} <- normalize_overrides(overrides),
+         :ok <- ensure_action_module(module),
          {:ok, attrs} <- module_attrs(module) do
       attrs
       |> Map.merge(overrides)
       |> refresh_derived_id(module, overrides)
+      |> refresh_derived_schema_kind(overrides)
       |> new()
     end
   end
+
+  def from_module(_module, _overrides),
+    do: {:error, validation_error("Invalid catalog action module", :invalid_module)}
 
   @doc """
   Same as `from_module/2`, but raises on error.
@@ -293,9 +328,61 @@ defmodule Jido.Action.Catalog.Entry do
     end
   end
 
-  defp normalize_attrs(attrs) when is_list(attrs), do: Map.new(attrs)
-  defp normalize_attrs(%{} = attrs), do: attrs
-  defp normalize_attrs(_attrs), do: %{}
+  defp refresh_derived_schema_kind(attrs, overrides) do
+    if (Map.has_key?(overrides, :input_schema) or Map.has_key?(overrides, "input_schema")) and
+         not Map.has_key?(overrides, :schema_kind) and not Map.has_key?(overrides, "schema_kind") do
+      Map.put(attrs, :schema_kind, Schema.schema_type(Map.get(attrs, :input_schema)))
+    else
+      attrs
+    end
+  end
+
+  defp normalize_overrides(overrides) do
+    with {:ok, overrides} <- attrs_to_map(overrides) do
+      {:ok, normalize_attr_map(overrides)}
+    end
+  end
+
+  defp attrs_to_map(attrs) when is_list(attrs) do
+    if Keyword.keyword?(attrs) do
+      {:ok, Map.new(attrs)}
+    else
+      {:error, validation_error("Invalid catalog entry overrides", :invalid_overrides)}
+    end
+  end
+
+  defp attrs_to_map(%{} = attrs), do: {:ok, attrs}
+
+  defp attrs_to_map(_attrs),
+    do: {:error, validation_error("Invalid catalog entry overrides", :invalid_overrides)}
+
+  defp normalize_attr_map(attrs) do
+    attrs
+    |> normalize_known_string_keys()
+    |> normalize_attr_aliases()
+    |> normalize_enum_values()
+  end
+
+  defp normalize_known_string_keys(attrs) do
+    Enum.reduce(@string_key_fields, attrs, fn key, acc ->
+      maybe_rename(acc, Atom.to_string(key), key)
+    end)
+  end
+
+  defp normalize_enum_values(attrs) do
+    Enum.reduce(@enum_fields, attrs, fn {field, allowed_values}, acc ->
+      case Map.fetch(acc, field) do
+        {:ok, value} -> Map.put(acc, field, normalize_enum_value(value, allowed_values))
+        :error -> acc
+      end
+    end)
+  end
+
+  defp normalize_enum_value(value, allowed_values) when is_binary(value) do
+    Enum.find(allowed_values, value, &(Atom.to_string(&1) == value))
+  end
+
+  defp normalize_enum_value(value, _allowed_values), do: value
 
   defp normalize_entry_schemas(%__MODULE__{} = entry) do
     %{

--- a/lib/jido_action/catalog/hit.ex
+++ b/lib/jido_action/catalog/hit.ex
@@ -1,0 +1,60 @@
+defmodule Jido.Action.Catalog.Hit do
+  @moduledoc """
+  Ranked search hit returned from an action catalog query.
+  """
+
+  alias Jido.Action.Error
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              entry: Zoi.any(description: "Catalog entry"),
+              score: Zoi.float(description: "Deterministic lexical score") |> Zoi.default(0.0),
+              reason: Zoi.string(description: "Short match reason") |> Zoi.optional(),
+              matches: Zoi.map(description: "Matched fields") |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc """
+  Returns the Zoi schema used to validate catalog hits.
+  """
+  @spec schema() :: term()
+  def schema, do: @schema
+
+  @doc """
+  Builds a catalog hit.
+  """
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    attrs = Map.reject(attrs, fn {_key, value} -> is_nil(value) end)
+
+    case Zoi.parse(@schema, attrs) do
+      {:ok, hit} ->
+        {:ok, hit}
+
+      {:error, errors} ->
+        {:error, Error.validation_error("Invalid catalog hit", %{details: errors})}
+    end
+  end
+
+  def new(_attrs), do: {:error, Error.validation_error("Invalid catalog hit")}
+
+  @doc """
+  Same as `new/1`, but raises on error.
+  """
+  @spec new!(map() | keyword()) :: t() | no_return()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, hit} -> hit
+      {:error, error} -> raise error
+    end
+  end
+end

--- a/lib/jido_action/catalog/query.ex
+++ b/lib/jido_action/catalog/query.ex
@@ -1,0 +1,70 @@
+defmodule Jido.Action.Catalog.Query do
+  @moduledoc """
+  Query value for filtering and searching an action catalog.
+  """
+
+  alias Jido.Action.Error
+
+  @schema Zoi.struct(
+            __MODULE__,
+            %{
+              text: Zoi.string(description: "Search text") |> Zoi.optional(),
+              namespace: Zoi.string(description: "Namespace filter") |> Zoi.optional(),
+              tags: Zoi.list(Zoi.string(), description: "Required tags") |> Zoi.default([]),
+              capabilities:
+                Zoi.list(Zoi.string(), description: "Required capabilities") |> Zoi.default([]),
+              visibility:
+                Zoi.list(Zoi.atom(), description: "Allowed visibility values")
+                |> Zoi.default([:public]),
+              limit:
+                Zoi.integer(description: "Maximum hits to return")
+                |> Zoi.min(1)
+                |> Zoi.default(10),
+              filters: Zoi.map(description: "Additional exact-match filters") |> Zoi.default(%{}),
+              metadata: Zoi.map(description: "Arbitrary query metadata") |> Zoi.default(%{})
+            },
+            coerce: true
+          )
+
+  @type t :: unquote(Zoi.type_spec(@schema))
+
+  @enforce_keys Zoi.Struct.enforce_keys(@schema)
+  defstruct Zoi.Struct.struct_fields(@schema)
+
+  @doc """
+  Returns the Zoi schema used to validate catalog queries.
+  """
+  @spec schema() :: term()
+  def schema, do: @schema
+
+  @doc """
+  Builds a catalog query.
+  """
+  @spec new(map() | keyword() | String.t() | t()) :: {:ok, t()} | {:error, Exception.t()}
+  def new(%__MODULE__{} = query), do: {:ok, query}
+  def new(text) when is_binary(text), do: new(%{text: text})
+  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(%{} = attrs) do
+    case Zoi.parse(@schema, attrs) do
+      {:ok, query} ->
+        {:ok, query}
+
+      {:error, errors} ->
+        {:error, Error.validation_error("Invalid catalog query", %{details: errors})}
+    end
+  end
+
+  def new(_attrs), do: {:error, Error.validation_error("Invalid catalog query")}
+
+  @doc """
+  Same as `new/1`, but raises on error.
+  """
+  @spec new!(map() | keyword() | String.t() | t()) :: t() | no_return()
+  def new!(attrs) do
+    case new(attrs) do
+      {:ok, query} -> query
+      {:error, error} -> raise error
+    end
+  end
+end

--- a/lib/jido_action/catalog/query.ex
+++ b/lib/jido_action/catalog/query.ex
@@ -6,6 +6,16 @@ defmodule Jido.Action.Catalog.Query do
   alias Jido.Action.Error
 
   @visibility_values [:public, :internal, :hidden]
+  @string_key_fields [
+    :text,
+    :namespace,
+    :tags,
+    :capabilities,
+    :visibility,
+    :limit,
+    :filters,
+    :metadata
+  ]
 
   @schema Zoi.struct(
             __MODULE__,
@@ -51,6 +61,8 @@ defmodule Jido.Action.Catalog.Query do
   def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
 
   def new(%{} = attrs) do
+    attrs = normalize_attr_map(attrs)
+
     case Zoi.parse(@schema, attrs) do
       {:ok, query} ->
         {:ok, query}
@@ -61,6 +73,46 @@ defmodule Jido.Action.Catalog.Query do
   end
 
   def new(_attrs), do: {:error, Error.validation_error("Invalid catalog query")}
+
+  defp normalize_attr_map(attrs) do
+    attrs
+    |> normalize_known_string_keys()
+    |> normalize_visibility()
+  end
+
+  defp normalize_known_string_keys(attrs) do
+    Enum.reduce(@string_key_fields, attrs, fn key, acc ->
+      maybe_rename(acc, Atom.to_string(key), key)
+    end)
+  end
+
+  defp maybe_rename(attrs, from, to) do
+    case Map.fetch(attrs, from) do
+      {:ok, value} ->
+        attrs
+        |> Map.delete(from)
+        |> Map.put_new(to, value)
+
+      :error ->
+        attrs
+    end
+  end
+
+  defp normalize_visibility(%{visibility: values} = attrs) when is_list(values) do
+    Map.put(attrs, :visibility, Enum.map(values, &normalize_visibility_value/1))
+  end
+
+  defp normalize_visibility(%{visibility: value} = attrs) do
+    Map.put(attrs, :visibility, [normalize_visibility_value(value)])
+  end
+
+  defp normalize_visibility(attrs), do: attrs
+
+  defp normalize_visibility_value(value) when is_binary(value) do
+    Enum.find(@visibility_values, value, &(Atom.to_string(&1) == value))
+  end
+
+  defp normalize_visibility_value(value), do: value
 
   @doc """
   Same as `new/1`, but raises on error.

--- a/lib/jido_action/catalog/query.ex
+++ b/lib/jido_action/catalog/query.ex
@@ -5,6 +5,8 @@ defmodule Jido.Action.Catalog.Query do
 
   alias Jido.Action.Error
 
+  @visibility_values [:public, :internal, :hidden]
+
   @schema Zoi.struct(
             __MODULE__,
             %{
@@ -14,7 +16,10 @@ defmodule Jido.Action.Catalog.Query do
               capabilities:
                 Zoi.list(Zoi.string(), description: "Required capabilities") |> Zoi.default([]),
               visibility:
-                Zoi.list(Zoi.atom(), description: "Allowed visibility values")
+                Zoi.list(
+                  Zoi.enum(@visibility_values),
+                  description: "Allowed visibility values"
+                )
                 |> Zoi.default([:public]),
               limit:
                 Zoi.integer(description: "Maximum hits to return")

--- a/mix.exs
+++ b/mix.exs
@@ -134,6 +134,10 @@ defmodule JidoAction.MixProject do
       groups_for_modules: [
         Core: [
           Jido.Action,
+          Jido.Action.Catalog,
+          Jido.Action.Catalog.Entry,
+          Jido.Action.Catalog.Hit,
+          Jido.Action.Catalog.Query,
           Jido.Action.Error,
           Jido.Action.Tool,
           Jido.Action.Util

--- a/mix.exs
+++ b/mix.exs
@@ -82,6 +82,7 @@ defmodule JidoAction.MixProject do
         ],
         "Core Concepts": [
           "guides/actions-guide.md",
+          "guides/action-catalogs.md",
           "guides/schemas-validation.md",
           "guides/execution-engine.md",
           "guides/instructions-plans.md",
@@ -109,6 +110,7 @@ defmodule JidoAction.MixProject do
         {"guides/your-second-action.md", title: "Your Second Action"},
         # Core Concepts
         {"guides/actions-guide.md", title: "Actions"},
+        {"guides/action-catalogs.md", title: "Action Catalogs"},
         {"guides/schemas-validation.md", title: "Schemas & Validation"},
         {"guides/execution-engine.md", title: "Execution Engine"},
         {"guides/instructions-plans.md", title: "Instructions & Plans"},

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -42,6 +42,12 @@ defmodule Jido.Action.CatalogTest do
     def run(params, _context), do: {:ok, params}
   end
 
+  defmodule NotAnAction do
+    def name, do: "not_an_action"
+    def schema, do: []
+    def run(params, _context), do: {:ok, params}
+  end
+
   describe "Entry" do
     test "builds normalized metadata from an action module" do
       assert {:ok, entry} =
@@ -65,7 +71,9 @@ defmodule Jido.Action.CatalogTest do
       assert entry.schema_kind == :zoi
       assert entry.id == "#{inspect(SearchUsers)}:search_users@1.0.0"
       assert entry.input_schema["type"] == "object"
+      assert entry.input_schema["additionalProperties"] == false
       assert entry.output_schema["type"] == "object"
+      assert entry.output_schema["additionalProperties"] == false
     end
 
     test "supports raw attribute construction" do
@@ -84,6 +92,47 @@ defmodule Jido.Action.CatalogTest do
       assert entry.risk == :medium
       assert entry.metadata == %{owner: "ops"}
     end
+
+    test "rejects non-action modules" do
+      assert {:error, _error} = Entry.from_module(NotAnAction)
+
+      assert {:error, _error} =
+               Entry.new(id: "fake", module: NotAnAction, name: "not_an_action")
+    end
+
+    test "normalizes aliases before applying module overrides" do
+      assert {:ok, entry} =
+               Entry.from_module(SearchUsers,
+                 vsn: "2.0.0",
+                 schema:
+                   Zoi.object(%{
+                     override: Zoi.string(description: "Override value")
+                   })
+               )
+
+      assert entry.version == "2.0.0"
+      assert entry.id == "#{inspect(SearchUsers)}:search_users@2.0.0"
+      assert Map.has_key?(entry.input_schema["properties"], "override")
+      refute Map.has_key?(entry.input_schema["properties"], "query")
+    end
+
+    test "rejects unsupported enum values" do
+      assert {:error, _error} =
+               Entry.new(
+                 id: "custom",
+                 module: SendEmail,
+                 name: "custom_email",
+                 visibility: :private
+               )
+
+      assert {:error, _error} =
+               Entry.new(
+                 id: "custom",
+                 module: SendEmail,
+                 name: "custom_email",
+                 risk: :critical
+               )
+    end
   end
 
   describe "Catalog" do
@@ -97,6 +146,23 @@ defmodule Jido.Action.CatalogTest do
       assert catalog.id == "app-actions"
       assert catalog.name == "App Actions"
       assert Enum.map(Catalog.list(catalog), & &1.name) == ["search_users", "send_email"]
+    end
+
+    test "validates constructor entries" do
+      entry_attrs = %{
+        id: "email",
+        module: SendEmail,
+        name: "send_email"
+      }
+
+      assert {:ok, catalog} =
+               Catalog.new(id: "test", entries: %{"ignored-key" => entry_attrs})
+
+      assert Map.keys(catalog.entries) == ["email"]
+      assert [%Entry{name: "send_email"}] = Catalog.list(catalog)
+
+      assert {:error, _error} =
+               Catalog.new(id: "test", entries: %{"invalid" => "not-entry"})
     end
 
     test "registers, fetches, and unregisters entries by id or name" do
@@ -182,6 +248,8 @@ defmodule Jido.Action.CatalogTest do
       assert query.text == "users"
       assert query.visibility == [:public]
       assert query.limit == 10
+
+      assert {:error, _error} = Query.new(visibility: [:private])
 
       entry = Entry.new!(id: "entry", module: SearchUsers, name: "search_users")
       assert {:ok, hit} = Hit.new(entry: entry, score: 1.5, matches: %{name: 1.5})

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -244,6 +244,27 @@ defmodule Jido.Action.CatalogTest do
       assert updated_entry.risk == :medium
     end
 
+    test "registers prebuilt entries with serialized map overrides" do
+      entry = Entry.new!(id: "email", module: SendEmail, name: "send_email")
+
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(entry, %{
+          "id" => "email-v2",
+          "visibility" => "internal",
+          "risk" => "medium",
+          "source" => "runtime",
+          "vsn" => "2.0.0"
+        })
+
+      assert {:error, :not_found} = Catalog.fetch(catalog, "email")
+      assert {:ok, updated_entry} = Catalog.fetch(catalog, "email-v2")
+      assert updated_entry.visibility == :internal
+      assert updated_entry.risk == :medium
+      assert updated_entry.source == :runtime
+      assert updated_entry.version == "2.0.0"
+    end
+
     test "reports ambiguous name lookups" do
       first = Entry.new!(id: "first", module: SearchUsers, name: "duplicate")
       second = Entry.new!(id: "second", module: SendEmail, name: "duplicate")

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -405,6 +405,25 @@ defmodule Jido.Action.CatalogTest do
       assert Enum.map(hits, & &1.entry.name) == ["search_users", "send_email"]
     end
 
+    test "filter-only search returns neutral hits without match metadata" do
+      entry = %Entry{
+        id: "expensive",
+        module: CompatibleTool,
+        name: "expensive",
+        input_schema: %{"description" => "expensive schema"},
+        output_schema: %{"description" => "expensive output"},
+        tags: ["expensive"]
+      }
+
+      catalog = %Catalog{id: "test", entries: %{entry.id => entry}}
+
+      assert {:ok, [hit]} = Catalog.search(catalog, tags: ["expensive"])
+      assert hit.entry.id == "expensive"
+      assert hit.score == 1.0
+      assert hit.reason == nil
+      assert hit.matches == %{}
+    end
+
     test "empty visibility filter matches no entries" do
       catalog =
         Catalog.new!(id: "test")

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -1,0 +1,192 @@
+defmodule Jido.Action.CatalogTest do
+  use JidoTest.ActionCase, async: true
+
+  alias Jido.Action.Catalog
+  alias Jido.Action.Catalog.Entry
+  alias Jido.Action.Catalog.Hit
+  alias Jido.Action.Catalog.Query
+
+  defmodule SearchUsers do
+    use Jido.Action,
+      name: "search_users",
+      description: "Search user accounts by name or email",
+      category: "users",
+      tags: ["users", "search"],
+      vsn: "1.0.0",
+      schema:
+        Zoi.object(%{
+          query: Zoi.string(description: "Search query"),
+          limit: Zoi.integer(description: "Maximum result count") |> Zoi.default(10)
+        }),
+      output_schema:
+        Zoi.object(%{
+          users: Zoi.list(Zoi.map(), description: "Matched users")
+        })
+
+    @impl true
+    def run(_params, _context), do: {:ok, %{users: []}}
+  end
+
+  defmodule SendEmail do
+    use Jido.Action,
+      name: "send_email",
+      description: "Send an email message",
+      category: "messaging",
+      tags: ["email", "message"],
+      schema: [
+        to: [type: :string, required: true, doc: "Recipient address"],
+        subject: [type: :string, required: true, doc: "Message subject"]
+      ]
+
+    @impl true
+    def run(params, _context), do: {:ok, params}
+  end
+
+  describe "Entry" do
+    test "builds normalized metadata from an action module" do
+      assert {:ok, entry} =
+               Entry.from_module(SearchUsers,
+                 namespace: "accounts",
+                 capabilities: ["lookup"],
+                 read_only?: true,
+                 keywords: ["people"]
+               )
+
+      assert entry.module == SearchUsers
+      assert entry.name == "search_users"
+      assert entry.description == "Search user accounts by name or email"
+      assert entry.category == "users"
+      assert entry.tags == ["users", "search"]
+      assert entry.version == "1.0.0"
+      assert entry.namespace == "accounts"
+      assert entry.capabilities == ["lookup"]
+      assert entry.read_only? == true
+      assert entry.keywords == ["people"]
+      assert entry.schema_kind == :zoi
+      assert entry.id == "#{inspect(SearchUsers)}:search_users@1.0.0"
+      assert entry.input_schema["type"] == "object"
+      assert entry.output_schema["type"] == "object"
+    end
+
+    test "supports raw attribute construction" do
+      assert {:ok, entry} =
+               Entry.new(%{
+                 id: "custom",
+                 module: SendEmail,
+                 name: "custom_email",
+                 visibility: :internal,
+                 risk: :medium,
+                 metadata: %{owner: "ops"}
+               })
+
+      assert entry.id == "custom"
+      assert entry.visibility == :internal
+      assert entry.risk == :medium
+      assert entry.metadata == %{owner: "ops"}
+    end
+  end
+
+  describe "Catalog" do
+    test "builds from existing action modules and lists entries deterministically" do
+      assert {:ok, catalog} =
+               Catalog.from_modules([SendEmail, SearchUsers],
+                 id: "app-actions",
+                 name: "App Actions"
+               )
+
+      assert catalog.id == "app-actions"
+      assert catalog.name == "App Actions"
+      assert Enum.map(Catalog.list(catalog), & &1.name) == ["search_users", "send_email"]
+    end
+
+    test "registers, fetches, and unregisters entries by id or name" do
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(SearchUsers)
+        |> Catalog.register!(SendEmail)
+
+      assert {:ok, search_entry} =
+               Catalog.fetch(catalog, "#{inspect(SearchUsers)}:search_users@1.0.0")
+
+      assert search_entry.name == "search_users"
+
+      assert {:ok, email_entry} = Catalog.fetch(catalog, "send_email")
+      assert email_entry.module == SendEmail
+
+      assert {:ok, updated} = Catalog.unregister(catalog, "send_email")
+      assert {:error, :not_found} = Catalog.fetch(updated, "send_email")
+      assert {:ok, _entry} = Catalog.fetch(updated, "search_users")
+    end
+
+    test "reports ambiguous name lookups" do
+      first = Entry.new!(id: "first", module: SearchUsers, name: "duplicate")
+      second = Entry.new!(id: "second", module: SendEmail, name: "duplicate")
+
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(first)
+        |> Catalog.register!(second)
+
+      assert {:error, {:ambiguous, "duplicate", ids}} = Catalog.fetch(catalog, "duplicate")
+      assert Enum.sort(ids) == ["first", "second"]
+    end
+
+    test "searches entries with lexical ranking and filters" do
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(SearchUsers,
+          namespace: "accounts",
+          capabilities: ["lookup"],
+          read_only?: true
+        )
+        |> Catalog.register!(SendEmail,
+          namespace: "messaging",
+          capabilities: ["notify"],
+          risk: :medium
+        )
+
+      assert {:ok, [hit | _]} = Catalog.search(catalog, text: "email")
+      assert %Hit{} = hit
+      assert hit.entry.name == "send_email"
+      assert hit.score > 0
+      assert map_size(hit.matches) > 0
+
+      assert {:ok, [accounts_hit]} =
+               Catalog.search(catalog,
+                 namespace: "accounts",
+                 tags: ["users"],
+                 capabilities: ["lookup"],
+                 filters: %{read_only?: true}
+               )
+
+      assert accounts_hit.entry.name == "search_users"
+    end
+
+    test "search defaults to public entries and can include internal entries" do
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(SearchUsers)
+        |> Catalog.register!(SendEmail, visibility: :internal)
+
+      assert {:ok, hits} = Catalog.search(catalog, %{})
+      assert Enum.map(hits, & &1.entry.name) == ["search_users"]
+
+      assert {:ok, hits} = Catalog.search(catalog, visibility: [:public, :internal])
+      assert Enum.map(hits, & &1.entry.name) == ["search_users", "send_email"]
+    end
+  end
+
+  describe "Query and Hit" do
+    test "constructs plain query and hit values" do
+      assert {:ok, query} = Query.new("users")
+      assert query.text == "users"
+      assert query.visibility == [:public]
+      assert query.limit == 10
+
+      entry = Entry.new!(id: "entry", module: SearchUsers, name: "search_users")
+      assert {:ok, hit} = Hit.new(entry: entry, score: 1.5, matches: %{name: 1.5})
+      assert hit.entry == entry
+      assert hit.score == 1.5
+    end
+  end
+end

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -93,6 +93,23 @@ defmodule Jido.Action.CatalogTest do
       assert entry.metadata == %{owner: "ops"}
     end
 
+    test "supports known string keys and string enum values" do
+      assert {:ok, entry} =
+               Entry.new(%{
+                 "id" => "custom",
+                 "module" => SendEmail,
+                 "name" => "custom_email",
+                 "visibility" => "internal",
+                 "risk" => "medium",
+                 "source" => "runtime"
+               })
+
+      assert entry.id == "custom"
+      assert entry.visibility == :internal
+      assert entry.risk == :medium
+      assert entry.source == :runtime
+    end
+
     test "rejects non-action modules" do
       assert {:error, _error} = Entry.from_module(NotAnAction)
 
@@ -104,16 +121,25 @@ defmodule Jido.Action.CatalogTest do
       assert {:ok, entry} =
                Entry.from_module(SearchUsers,
                  vsn: "2.0.0",
-                 schema:
-                   Zoi.object(%{
-                     override: Zoi.string(description: "Override value")
-                   })
+                 schema: [
+                   override: [
+                     type: :string,
+                     required: true,
+                     doc: "Override value"
+                   ]
+                 ]
                )
 
       assert entry.version == "2.0.0"
       assert entry.id == "#{inspect(SearchUsers)}:search_users@2.0.0"
+      assert entry.schema_kind == :nimble
       assert Map.has_key?(entry.input_schema["properties"], "override")
       refute Map.has_key?(entry.input_schema["properties"], "query")
+    end
+
+    test "rejects invalid module override attrs" do
+      assert {:error, _error} = Entry.from_module(SearchUsers, :bad_overrides)
+      assert {:error, _error} = Entry.from_module(SearchUsers, [:bad_override])
     end
 
     test "rejects unsupported enum values" do
@@ -240,6 +266,17 @@ defmodule Jido.Action.CatalogTest do
       assert {:ok, hits} = Catalog.search(catalog, visibility: [:public, :internal])
       assert Enum.map(hits, & &1.entry.name) == ["search_users", "send_email"]
     end
+
+    test "empty visibility filter matches no entries" do
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(SearchUsers)
+        |> Catalog.register!(SendEmail, visibility: :hidden)
+
+      assert {:ok, []} = Catalog.search(catalog, visibility: [])
+      assert {:ok, hits} = Catalog.search(catalog, visibility: [:hidden])
+      assert Enum.map(hits, & &1.entry.name) == ["send_email"]
+    end
   end
 
   describe "Query and Hit" do
@@ -250,6 +287,9 @@ defmodule Jido.Action.CatalogTest do
       assert query.limit == 10
 
       assert {:error, _error} = Query.new(visibility: [:private])
+
+      assert {:ok, query} = Query.new(%{"visibility" => ["public", "internal"]})
+      assert query.visibility == [:public, :internal]
 
       entry = Entry.new!(id: "entry", module: SearchUsers, name: "search_users")
       assert {:ok, hit} = Hit.new(entry: entry, score: 1.5, matches: %{name: 1.5})

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -254,7 +254,14 @@ defmodule Jido.Action.CatalogTest do
           "visibility" => "internal",
           "risk" => "medium",
           "source" => "runtime",
-          "vsn" => "2.0.0"
+          "vsn" => "2.0.0",
+          "schema" => [
+            body: [
+              type: :string,
+              required: true,
+              doc: "Message body"
+            ]
+          ]
         })
 
       assert {:error, :not_found} = Catalog.fetch(catalog, "email")
@@ -262,6 +269,51 @@ defmodule Jido.Action.CatalogTest do
       assert updated_entry.visibility == :internal
       assert updated_entry.risk == :medium
       assert updated_entry.source == :runtime
+      assert updated_entry.version == "2.0.0"
+      assert updated_entry.schema_kind == :nimble
+      assert Map.has_key?(updated_entry.input_schema["properties"], "body")
+    end
+
+    test "refreshes derived metadata when registering prebuilt entries with overrides" do
+      entry = Entry.from_module!(SearchUsers)
+      updated_id = "#{inspect(SearchUsers)}:search_users@2.0.0"
+
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(entry,
+          vsn: "2.0.0",
+          schema: [
+            override: [
+              type: :string,
+              required: true,
+              doc: "Override value"
+            ]
+          ]
+        )
+
+      assert {:error, :not_found} = Catalog.fetch(catalog, entry.id)
+      assert {:ok, updated_entry} = Catalog.fetch(catalog, updated_id)
+      assert updated_entry.version == "2.0.0"
+      assert updated_entry.schema_kind == :nimble
+      assert Map.has_key?(updated_entry.input_schema["properties"], "override")
+      refute Map.has_key?(updated_entry.input_schema["properties"], "query")
+    end
+
+    test "preserves custom entry ids when registering prebuilt entries with overrides" do
+      entry =
+        Entry.new!(
+          id: "custom-email",
+          module: SendEmail,
+          name: "send_email",
+          version: "1.0.0"
+        )
+
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(entry, vsn: "2.0.0")
+
+      assert {:ok, updated_entry} = Catalog.fetch(catalog, "custom-email")
+      assert updated_entry.id == "custom-email"
       assert updated_entry.version == "2.0.0"
     end
 

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -42,10 +42,15 @@ defmodule Jido.Action.CatalogTest do
     def run(params, _context), do: {:ok, params}
   end
 
-  defmodule NotAnAction do
-    def name, do: "not_an_action"
+  defmodule CompatibleTool do
+    def name, do: "compatible_tool"
     def schema, do: []
     def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule MissingRun do
+    def name, do: "missing_run"
+    def schema, do: []
   end
 
   describe "Entry" do
@@ -97,7 +102,7 @@ defmodule Jido.Action.CatalogTest do
       assert {:ok, entry} =
                Entry.new(%{
                  "id" => "custom",
-                 "module" => SendEmail,
+                 "module" => inspect(SendEmail),
                  "name" => "custom_email",
                  "visibility" => "internal",
                  "risk" => "medium",
@@ -105,16 +110,25 @@ defmodule Jido.Action.CatalogTest do
                })
 
       assert entry.id == "custom"
+      assert entry.module == SendEmail
       assert entry.visibility == :internal
       assert entry.risk == :medium
       assert entry.source == :runtime
     end
 
-    test "rejects non-action modules" do
-      assert {:error, _error} = Entry.from_module(NotAnAction)
+    test "supports local action-compatible modules" do
+      assert {:ok, entry} = Entry.from_module(CompatibleTool)
+
+      assert entry.module == CompatibleTool
+      assert entry.name == "compatible_tool"
+      assert entry.schema_kind == :empty
+    end
+
+    test "rejects incompatible local modules" do
+      assert {:error, _error} = Entry.from_module(MissingRun)
 
       assert {:error, _error} =
-               Entry.new(id: "fake", module: NotAnAction, name: "not_an_action")
+               Entry.new(id: "fake", module: MissingRun, name: "missing_run")
     end
 
     test "normalizes aliases before applying module overrides" do
@@ -157,6 +171,14 @@ defmodule Jido.Action.CatalogTest do
                  module: SendEmail,
                  name: "custom_email",
                  risk: :critical
+               )
+
+      assert {:error, _error} =
+               Entry.new(
+                 id: "custom",
+                 module: SendEmail,
+                 name: "custom_email",
+                 source: :remote
                )
     end
   end
@@ -210,6 +232,18 @@ defmodule Jido.Action.CatalogTest do
       assert {:ok, _entry} = Catalog.fetch(updated, "search_users")
     end
 
+    test "registers prebuilt entries with overrides" do
+      entry = Entry.new!(id: "email", module: SendEmail, name: "send_email")
+
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(entry, visibility: :internal, risk: :medium)
+
+      assert {:ok, updated_entry} = Catalog.fetch(catalog, "email")
+      assert updated_entry.visibility == :internal
+      assert updated_entry.risk == :medium
+    end
+
     test "reports ambiguous name lookups" do
       first = Entry.new!(id: "first", module: SearchUsers, name: "duplicate")
       second = Entry.new!(id: "second", module: SendEmail, name: "duplicate")
@@ -252,6 +286,37 @@ defmodule Jido.Action.CatalogTest do
                )
 
       assert accounts_hit.entry.name == "search_users"
+
+      assert {:ok, [risk_hit]} = Catalog.search(catalog, filters: %{"risk" => "medium"})
+      assert risk_hit.entry.name == "send_email"
+
+      assert {:ok, []} = Catalog.search(catalog, filters: %{"unknown" => nil})
+    end
+
+    test "phrase matches are not penalized below scattered token matches" do
+      phrase_entry =
+        Entry.new!(
+          id: "phrase",
+          module: CompatibleTool,
+          name: "phrase",
+          description: "Delete user account"
+        )
+
+      scattered_entry =
+        Entry.new!(
+          id: "scattered",
+          module: CompatibleTool,
+          name: "scattered",
+          description: "Delete stale records from the user table and archive the account"
+        )
+
+      catalog =
+        Catalog.new!(id: "test")
+        |> Catalog.register!(phrase_entry)
+        |> Catalog.register!(scattered_entry)
+
+      assert {:ok, [first_hit | _]} = Catalog.search(catalog, "delete user account")
+      assert first_hit.entry.id == "phrase"
     end
 
     test "search defaults to public entries and can include internal entries" do


### PR DESCRIPTION
## Summary
- add Zoi-backed `Jido.Action.Catalog`, `Entry`, `Query`, and `Hit` data structures
- support building catalog entries from existing action modules with JSON-friendly schema metadata
- add pure value-level helpers for register/list/fetch/unregister/search

## Notes
- first pass for feedback only: no process-backed registry, persistence, execution dispatch, or supervisor integration

## Tests
- `mix test`
- `mix q`

Refs #170