### PR TITLE
feat: add canonical catalog merge

### DIFF
--- a/guides/action-catalogs.md
+++ b/guides/action-catalogs.md
@@ -84,6 +84,23 @@ Fetch by stable entry id or unique action name:
 
 If multiple entries share the same action name, name lookup returns an ambiguous result. Use stable ids for catalogs that intentionally contain multiple versions or variants of the same action.
 
+## Merging Catalogs
+
+Merge catalogs when different layers contribute local actions:
+
+```elixir
+{:ok, merged} =
+  Jido.Action.Catalog.merge(
+    base_catalog,
+    runtime_catalog,
+    id: "app-runtime-actions"
+  )
+```
+
+Merging is canonical and idempotent. Duplicate entry ids are accepted only when the entries are exactly equal. If two different entries use the same id, merge returns an error instead of choosing a side.
+
+When you do not pass an `:id`, the merged catalog id is derived from the sorted merged entry ids, so compatible merges are order-independent.
+
 ## Searching
 
 Search is deterministic and LLM-free:

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -146,9 +146,8 @@ defmodule Jido.Action.Catalog do
   def merge(%__MODULE__{} = left, %__MODULE__{} = right, attrs) do
     with {:ok, attrs} <- normalize_merge_attrs(attrs),
          {:ok, entries} <- merge_entries(left.entries, right.entries) do
-      attrs
-      |> Map.put_new(:id, canonical_merge_id(entries))
-      |> Map.put(:entries, entries)
+      left
+      |> merged_catalog_attrs(right, entries, attrs)
       |> new()
     end
   end
@@ -302,7 +301,16 @@ defmodule Jido.Action.Catalog do
     if Map.has_key?(attrs, :entries) or Map.has_key?(attrs, "entries") do
       {:error, Error.validation_error("Invalid catalog merge", %{details: :entries_not_allowed})}
     else
-      {:ok, normalize_merge_attr_keys(attrs)}
+      attrs = normalize_merge_attr_keys(attrs)
+
+      case unknown_merge_attr_keys(attrs) do
+        [] ->
+          {:ok, attrs}
+
+        keys ->
+          {:error,
+           Error.validation_error("Invalid catalog merge", %{details: {:unknown_attrs, keys}})}
+      end
     end
   end
 
@@ -323,6 +331,48 @@ defmodule Jido.Action.Catalog do
           acc
       end
     end)
+  end
+
+  defp unknown_merge_attr_keys(attrs) do
+    attrs
+    |> Map.keys()
+    |> Enum.reject(&(&1 in @merge_attr_fields))
+  end
+
+  defp merged_catalog_attrs(%__MODULE__{} = left, %__MODULE__{} = right, entries, attrs) do
+    attrs
+    |> put_merge_id(left, right, entries)
+    |> put_shared_merge_attr(:name, left, right)
+    |> put_shared_merge_attr(:description, left, right)
+    |> put_shared_merge_attr(:version, left, right)
+    |> put_shared_merge_attr(:metadata, left, right)
+    |> Map.put(:entries, entries)
+  end
+
+  defp put_merge_id(attrs, left, right, entries) do
+    cond do
+      Map.has_key?(attrs, :id) ->
+        attrs
+
+      left.id == right.id ->
+        Map.put(attrs, :id, left.id)
+
+      true ->
+        Map.put(attrs, :id, canonical_merge_id(entries))
+    end
+  end
+
+  defp put_shared_merge_attr(attrs, key, left, right) do
+    cond do
+      Map.has_key?(attrs, key) ->
+        attrs
+
+      not is_nil(Map.fetch!(left, key)) and Map.fetch!(left, key) == Map.fetch!(right, key) ->
+        Map.put(attrs, key, Map.fetch!(left, key))
+
+      true ->
+        attrs
+    end
   end
 
   defp merge_entries(left_entries, right_entries) do

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -37,6 +37,7 @@ defmodule Jido.Action.Catalog do
     risk: [:low, :medium, :high],
     source: [:module, :runtime]
   }
+  @merge_attr_fields [:id, :name, :description, :version, :metadata]
 
   @schema Zoi.struct(
             __MODULE__,
@@ -55,6 +56,7 @@ defmodule Jido.Action.Catalog do
 
   @type t :: unquote(Zoi.type_spec(@schema))
   @type entry_ref :: String.t() | Entry.t()
+  @type merge_attrs :: map() | keyword()
 
   @enforce_keys Zoi.Struct.enforce_keys(@schema)
   defstruct Zoi.Struct.struct_fields(@schema)
@@ -120,6 +122,46 @@ defmodule Jido.Action.Catalog do
   @spec from_modules!([module()], map() | keyword()) :: t() | no_return()
   def from_modules!(modules, attrs \\ []) do
     case from_modules(modules, attrs) do
+      {:ok, catalog} -> catalog
+      {:error, error} -> raise error
+    end
+  end
+
+  @doc """
+  Merges two catalogs into a canonical catalog.
+
+  Entry ids are the merge key. Duplicate ids are accepted only when both entries
+  are exactly equal; conflicting entries return an error instead of choosing a
+  side. When no `:id` is supplied, the merged catalog id is deterministically
+  derived from the sorted merged entry ids, making compatible merges
+  order-independent and idempotent.
+
+  Optional attributes such as `:id`, `:name`, `:description`, `:version`, and
+  `:metadata` are applied to the merged catalog. The merged entries always come
+  from the input catalogs.
+  """
+  @spec merge(t(), t(), merge_attrs()) :: {:ok, t()} | {:error, Exception.t()}
+  def merge(left, right, attrs \\ [])
+
+  def merge(%__MODULE__{} = left, %__MODULE__{} = right, attrs) do
+    with {:ok, attrs} <- normalize_merge_attrs(attrs),
+         {:ok, entries} <- merge_entries(left.entries, right.entries) do
+      attrs
+      |> Map.put_new(:id, canonical_merge_id(entries))
+      |> Map.put(:entries, entries)
+      |> new()
+    end
+  end
+
+  def merge(_left, _right, _attrs),
+    do: {:error, Error.validation_error("Invalid catalog merge")}
+
+  @doc """
+  Same as `merge/3`, but raises on error.
+  """
+  @spec merge!(t(), t(), merge_attrs()) :: t() | no_return()
+  def merge!(left, right, attrs \\ []) do
+    case merge(left, right, attrs) do
       {:ok, catalog} -> catalog
       {:error, error} -> raise error
     end
@@ -247,6 +289,72 @@ defmodule Jido.Action.Catalog do
   end
 
   defp entries(%__MODULE__{} = catalog), do: Map.values(catalog.entries)
+
+  defp normalize_merge_attrs(attrs) when is_list(attrs) do
+    if Keyword.keyword?(attrs) do
+      attrs |> Map.new() |> normalize_merge_attrs()
+    else
+      {:error, Error.validation_error("Invalid catalog merge", %{details: :invalid_attrs})}
+    end
+  end
+
+  defp normalize_merge_attrs(%{} = attrs) do
+    if Map.has_key?(attrs, :entries) or Map.has_key?(attrs, "entries") do
+      {:error, Error.validation_error("Invalid catalog merge", %{details: :entries_not_allowed})}
+    else
+      {:ok, normalize_merge_attr_keys(attrs)}
+    end
+  end
+
+  defp normalize_merge_attrs(_attrs),
+    do: {:error, Error.validation_error("Invalid catalog merge", %{details: :invalid_attrs})}
+
+  defp normalize_merge_attr_keys(attrs) do
+    Enum.reduce(@merge_attr_fields, attrs, fn key, acc ->
+      merge_attr_key = Atom.to_string(key)
+
+      case Map.fetch(acc, merge_attr_key) do
+        {:ok, value} ->
+          acc
+          |> Map.delete(merge_attr_key)
+          |> Map.put_new(key, value)
+
+        :error ->
+          acc
+      end
+    end)
+  end
+
+  defp merge_entries(left_entries, right_entries) do
+    Enum.reduce_while(right_entries, {:ok, left_entries}, fn {id, right_entry}, {:ok, acc} ->
+      case Map.fetch(acc, id) do
+        {:ok, ^right_entry} ->
+          {:cont, {:ok, acc}}
+
+        {:ok, left_entry} ->
+          {:halt,
+           {:error,
+            Error.validation_error("Conflicting catalog entries", %{
+              details: %{id: id, left: left_entry, right: right_entry}
+            })}}
+
+        :error ->
+          {:cont, {:ok, Map.put(acc, id, right_entry)}}
+      end
+    end)
+  end
+
+  defp canonical_merge_id(entries) do
+    digest =
+      entries
+      |> Map.keys()
+      |> Enum.sort()
+      |> Enum.join(<<0>>)
+      |> :erlang.md5()
+      |> Base.encode16(case: :lower)
+
+    "catalog:#{digest}"
+  end
 
   defp normalize_entries_attr(attrs) do
     entries = Map.get(attrs, :entries, Map.get(attrs, "entries", %{}))

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -212,6 +212,19 @@ defmodule Jido.Action.CatalogTest do
       assert Catalog.merge!(left_first, email) == left_first
     end
 
+    test "merge preserves identical catalog attrs" do
+      catalog =
+        Catalog.from_modules!([SearchUsers],
+          id: "users",
+          name: "Users",
+          description: "User actions",
+          version: "1.0.0",
+          metadata: %{owner: "accounts"}
+        )
+
+      assert Catalog.merge!(catalog, catalog) == catalog
+    end
+
     test "merges catalogs with explicit result attributes" do
       users = Catalog.from_modules!([SearchUsers], id: "users")
       email = Catalog.from_modules!([SendEmail], id: "email")
@@ -248,6 +261,7 @@ defmodule Jido.Action.CatalogTest do
 
       assert {:error, _error} = Catalog.merge(users, email, :bad_attrs)
       assert {:error, _error} = Catalog.merge(users, email, entries: %{})
+      assert {:error, _error} = Catalog.merge(users, email, unknown: true)
     end
 
     test "validates constructor entries" do

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -196,6 +196,60 @@ defmodule Jido.Action.CatalogTest do
       assert Enum.map(Catalog.list(catalog), & &1.name) == ["search_users", "send_email"]
     end
 
+    test "merges catalogs canonically and idempotently" do
+      users = Catalog.from_modules!([SearchUsers], id: "users")
+      email = Catalog.from_modules!([SendEmail], id: "email")
+
+      assert {:ok, left_first} = Catalog.merge(users, email)
+      assert {:ok, right_first} = Catalog.merge(email, users)
+
+      assert left_first == right_first
+      assert left_first.id == right_first.id
+      assert left_first.id =~ ~r/^catalog:[0-9a-f]{32}$/
+      assert Enum.map(Catalog.list(left_first), & &1.name) == ["search_users", "send_email"]
+
+      assert Catalog.merge!(left_first, users) == left_first
+      assert Catalog.merge!(left_first, email) == left_first
+    end
+
+    test "merges catalogs with explicit result attributes" do
+      users = Catalog.from_modules!([SearchUsers], id: "users")
+      email = Catalog.from_modules!([SendEmail], id: "email")
+
+      merged =
+        Catalog.merge!(users, email, %{
+          "id" => "runtime-tools",
+          "name" => "Runtime Tools",
+          "metadata" => %{owner: "runtime"}
+        })
+
+      assert merged.id == "runtime-tools"
+      assert merged.name == "Runtime Tools"
+      assert merged.metadata == %{owner: "runtime"}
+      assert Enum.map(Catalog.list(merged), & &1.name) == ["search_users", "send_email"]
+    end
+
+    test "merge accepts identical duplicate entries and rejects conflicting duplicate ids" do
+      first = Entry.new!(id: "same", module: SearchUsers, name: "same")
+      duplicate = Entry.new!(id: "same", module: SearchUsers, name: "same")
+      conflict = Entry.new!(id: "same", module: SendEmail, name: "same")
+
+      first_catalog = Catalog.new!(id: "first") |> Catalog.register!(first)
+      duplicate_catalog = Catalog.new!(id: "duplicate") |> Catalog.register!(duplicate)
+      conflict_catalog = Catalog.new!(id: "conflict") |> Catalog.register!(conflict)
+
+      assert Catalog.merge!(first_catalog, duplicate_catalog).entries == first_catalog.entries
+      assert {:error, _error} = Catalog.merge(first_catalog, conflict_catalog)
+    end
+
+    test "merge rejects invalid result attrs" do
+      users = Catalog.from_modules!([SearchUsers], id: "users")
+      email = Catalog.from_modules!([SendEmail], id: "email")
+
+      assert {:error, _error} = Catalog.merge(users, email, :bad_attrs)
+      assert {:error, _error} = Catalog.merge(users, email, entries: %{})
+    end
+
     test "validates constructor entries" do
       entry_attrs = %{
         id: "email",


### PR DESCRIPTION
## Summary
- Add Catalog.merge/2,3 and Catalog.merge!/2,3
- Make compatible merges canonical and idempotent by accepting identical duplicate entries and rejecting conflicting duplicate entry ids
- Derive a deterministic merged catalog id from sorted merged entry ids unless callers provide result attrs
- Document catalog merging and add focused regression coverage

## Verification
- mix test test/jido_action/catalog_test.exs
- mix test
- mix q
- mix docs