### PR TITLE
ci: test github-actions platform resolver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v4
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@fix/workflow-platform-job-context
     secrets: inherit
     with:
       otp_versions: '["27", "28"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   ci:
     name: CI
-    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@fix/workflow-platform-job-context
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@fix/v4-workflow-platform-job-context
     secrets: inherit
     with:
       otp_versions: '["27", "28"]'


### PR DESCRIPTION
Temporary validation PR for agentjido/github-actions#8.\n\nThis points the main-branch CI caller at agentjido/github-actions@fix/workflow-platform-job-context so the normal pull_request CI can validate the reusable workflow resolver before moving v4/v5 tags. This PR is not intended to merge.