### PR TITLE
refactor: harden action catalog contract

### DIFF
--- a/guides/action-catalogs.md
+++ b/guides/action-catalogs.md
@@ -2,9 +2,18 @@
 
 **Prerequisites**: [Actions](actions-guide.md) • [Schemas & Validation](schemas-validation.md)
 
-Action catalogs are local, value-level registries for discovering and selecting actions. They describe action-compatible modules with normalized metadata and deterministic search, without introducing an LLM dependency or a process-backed registry.
+Action catalogs are local, value-level data contracts for describing available
+actions. They normalize action-compatible modules into stable metadata entries
+and provide deterministic helper functions for lookup, merge, and lexical
+search without introducing an LLM dependency or a process-backed registry.
 
-Catalogs are intentionally plain data structures. Build them, pass them through your own runtime, replace them between turns, or wrap them in a higher-level package such as `jido_ai` or `jidoka`.
+Catalogs are intentionally plain data structures. Build them, pass them through
+your own runtime, replace them between turns, or wrap them in a higher-level
+package such as `jido_ai` or `jidoka`.
+
+Catalog search and filters operate only on local catalog data. They do not
+authorize, route, project, or execute actions. Runtime policy belongs in the
+caller or in a higher-level package.
 
 ## Local Action Compatibility
 
@@ -17,6 +26,20 @@ A catalog entry points at a local compiled module. The module must expose the sa
 Modules created with `use Jido.Action` satisfy this contract. Higher-level packages may also provide modules that follow the same shape, such as a local `Jidoka.Tool` wrapper.
 
 Remote catalogs are not supported. If the action code is not available locally, the catalog cannot safely describe or execute it.
+
+## Entry Metadata
+
+Catalog entries preserve the released action catalog shape. Some fields describe
+the action module itself, such as `name`, `description`, `category`, `tags`,
+`version`, `input_schema`, and `output_schema`.
+
+Other fields, such as `visibility`, `risk`, `read_only?`,
+`requires_confirmation?`, `scopes`, `capabilities`, `keywords`, and `examples`,
+are descriptive hints for callers. The catalog stores and filters those values,
+but it does not enforce their meaning.
+
+Use `metadata` for caller-owned extensions that do not belong in the shared
+catalog contract.
 
 ## Building a Catalog
 
@@ -125,7 +148,8 @@ Search supports exact filters and metadata filters:
   )
 ```
 
-By default, search only returns public entries. Include additional visibility values explicitly:
+By default, search only returns public entries. This is a catalog-data default,
+not an authorization decision. Include additional visibility values explicitly:
 
 ```elixir
 Jido.Action.Catalog.search(catalog, visibility: [:public, :internal])
@@ -135,6 +159,10 @@ An empty visibility list matches no entries.
 
 ## Execution
 
-This first catalog layer does not execute actions. It selects and describes local action-compatible modules. Once a caller selects an entry, execution should still go through the normal action execution path for the calling layer, such as `Jido.Exec`, `Jido.Action.Tool`, or a higher-level runtime.
+This first catalog layer does not execute actions. It describes local
+action-compatible modules and provides pure data helpers. Once a caller selects
+an entry, execution should still go through the normal action execution path for
+the calling layer, such as `Jido.Exec`, `Jido.Action.Tool`, or a higher-level
+runtime.
 
 Keeping execution outside the catalog keeps this layer serializable, testable, and independent of runtime policy.

--- a/lib/jido_action/catalog.ex
+++ b/lib/jido_action/catalog.ex
@@ -2,16 +2,19 @@ defmodule Jido.Action.Catalog do
   @moduledoc """
   A plain value-level catalog of local action-compatible modules.
 
-  This is intentionally not a process-backed registry. It gives callers a small,
-  serializable structure for collecting action metadata and doing deterministic,
-  LLM-free lookup and search.
+  This module defines the foundational catalog data contract for action
+  metadata. It gives callers a small, serializable structure for collecting
+  action entries plus pure helper functions for deterministic lookup, merge, and
+  lexical search.
 
   Catalog entries point at local compiled modules. A module is action-compatible
   when it exports `name/0`, `schema/0`, and `run/2`; it does not have to depend on
   this package's `use Jido.Action` macro.
 
-  The catalog does not execute selected entries. Callers should route execution
-  through their own runtime policy, such as `Jido.Exec`, `Jido.Action.Tool`, or a
+  A catalog is not a process-backed registry, policy engine, remote capability
+  source, or execution layer. Search and filtering are local data operations;
+  they do not authorize or run actions. Callers should route execution through
+  their own runtime policy, such as `Jido.Exec`, `Jido.Action.Tool`, or a
   higher-level package.
 
   ## Examples
@@ -72,10 +75,15 @@ defmodule Jido.Action.Catalog do
   """
   @spec new(map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
   def new(attrs \\ %{})
-  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(attrs) when is_list(attrs) do
+    with {:ok, attrs} <- attrs_to_map(attrs, "Invalid action catalog", :invalid_attrs) do
+      new(attrs)
+    end
+  end
 
   def new(%{} = attrs) do
-    attrs = Map.put_new_lazy(attrs, :id, &Uniq.UUID.uuid7/0)
+    attrs = put_default_id(attrs)
 
     with {:ok, attrs} <- normalize_entries_attr(attrs) do
       case Zoi.parse(@schema, attrs) do
@@ -319,17 +327,7 @@ defmodule Jido.Action.Catalog do
 
   defp normalize_merge_attr_keys(attrs) do
     Enum.reduce(@merge_attr_fields, attrs, fn key, acc ->
-      merge_attr_key = Atom.to_string(key)
-
-      case Map.fetch(acc, merge_attr_key) do
-        {:ok, value} ->
-          acc
-          |> Map.delete(merge_attr_key)
-          |> Map.put_new(key, value)
-
-        :error ->
-          acc
-      end
+      maybe_rename(acc, Atom.to_string(key), key)
     end)
   end
 
@@ -337,6 +335,34 @@ defmodule Jido.Action.Catalog do
     attrs
     |> Map.keys()
     |> Enum.reject(&(&1 in @merge_attr_fields))
+  end
+
+  defp put_default_id(attrs) do
+    if Map.has_key?(attrs, :id) or Map.has_key?(attrs, "id") do
+      attrs
+    else
+      Map.put(attrs, :id, Uniq.UUID.uuid7())
+    end
+  end
+
+  defp maybe_rename(attrs, from, to) do
+    case Map.fetch(attrs, from) do
+      {:ok, value} ->
+        attrs
+        |> Map.delete(from)
+        |> Map.put_new(to, value)
+
+      :error ->
+        attrs
+    end
+  end
+
+  defp attrs_to_map(attrs, message, details) when is_list(attrs) do
+    if Keyword.keyword?(attrs) do
+      {:ok, Map.new(attrs)}
+    else
+      {:error, Error.validation_error(message, %{details: details})}
+    end
   end
 
   defp merged_catalog_attrs(%__MODULE__{} = left, %__MODULE__{} = right, entries, attrs) do

--- a/lib/jido_action/catalog/entry.ex
+++ b/lib/jido_action/catalog/entry.ex
@@ -2,8 +2,13 @@ defmodule Jido.Action.Catalog.Entry do
   @moduledoc """
   Normalized metadata for one local action-compatible module in an action catalog.
 
-  Entries are plain values. They are intended for inspection, filtering, search,
-  documentation, and later projection into higher-level runtimes.
+  Entries are plain values. They provide a consistent data shape for action
+  metadata, schemas, descriptive hints, documentation, and later projection into
+  higher-level runtimes.
+
+  Fields such as `:visibility`, `:risk`, `:read_only?`, and `:scopes` are
+  descriptive metadata only. The catalog layer does not enforce policy or
+  execute actions.
 
   A module is action-compatible when it is available locally and exports
   `name/0`, `schema/0`, and `run/2`. Catalogs do not support remote entries whose
@@ -17,46 +22,24 @@ defmodule Jido.Action.Catalog.Entry do
   @visibility_values [:public, :internal, :hidden]
   @risk_values [:low, :medium, :high]
   @source_values [:module, :runtime]
-  @string_key_fields [
-    :id,
-    :module,
-    :name,
-    :title,
-    :description,
-    :summary,
-    :namespace,
-    :package,
-    :version,
-    :category,
-    :tags,
-    :capabilities,
-    :input_schema,
-    :output_schema,
-    :schema_kind,
-    :keywords,
-    :examples,
-    :visibility,
-    :risk,
-    :read_only?,
-    :requires_confirmation?,
-    :scopes,
-    :timeout,
-    :source,
-    :metadata
-  ]
-  @enum_fields %{
-    schema_kind: @schema_kind_values,
-    visibility: @visibility_values,
-    risk: @risk_values,
-    source: @source_values
-  }
+  @schema_kind_enum Enum.map(@schema_kind_values, &{&1, Atom.to_string(&1)})
+  @visibility_enum Enum.map(@visibility_values, &{&1, Atom.to_string(&1)})
+  @risk_enum Enum.map(@risk_values, &{&1, Atom.to_string(&1)})
+  @source_enum Enum.map(@source_values, &{&1, Atom.to_string(&1)})
 
   @schema Zoi.struct(
             __MODULE__,
             %{
               id: Zoi.string(description: "Stable catalog entry id"),
               module:
-                Zoi.atom(description: "Concrete local action-compatible module")
+                Zoi.union(
+                  [
+                    Zoi.atom(),
+                    Zoi.string()
+                  ],
+                  description: "Concrete local action-compatible module"
+                )
+                |> Zoi.transform({__MODULE__, :normalize_action_module, []})
                 |> Zoi.refine({__MODULE__, :validate_action_module, []}),
               name: Zoi.string(description: "Machine-friendly action name"),
               title: Zoi.string(description: "Short human label") |> Zoi.optional(),
@@ -76,19 +59,26 @@ defmodule Jido.Action.Catalog.Entry do
               input_schema: Zoi.any(description: "Normalized input schema") |> Zoi.optional(),
               output_schema: Zoi.any(description: "Normalized output schema") |> Zoi.optional(),
               schema_kind:
-                Zoi.enum(@schema_kind_values, description: "Input schema source/format")
+                Zoi.enum(@schema_kind_enum,
+                  description: "Input schema source/format",
+                  coerce: true
+                )
                 |> Zoi.default(:empty),
               keywords:
                 Zoi.list(Zoi.string(), description: "Explicit search keywords") |> Zoi.default([]),
               examples:
                 Zoi.list(Zoi.map(), description: "Small input/output examples") |> Zoi.default([]),
               visibility:
-                Zoi.enum(@visibility_values,
-                  description: "Visibility: :public | :internal | :hidden"
+                Zoi.enum(@visibility_enum,
+                  description: "Visibility: :public | :internal | :hidden",
+                  coerce: true
                 )
                 |> Zoi.default(:public),
               risk:
-                Zoi.enum(@risk_values, description: "Risk level: :low | :medium | :high")
+                Zoi.enum(@risk_enum,
+                  description: "Risk level: :low | :medium | :high",
+                  coerce: true
+                )
                 |> Zoi.default(:low),
               read_only?:
                 Zoi.boolean(description: "Whether execution is read-only") |> Zoi.default(false),
@@ -103,8 +93,9 @@ defmodule Jido.Action.Catalog.Entry do
                 |> Zoi.min(0)
                 |> Zoi.optional(),
               source:
-                Zoi.enum(@source_values,
-                  description: "Registration source: :module | :runtime"
+                Zoi.enum(@source_enum,
+                  description: "Registration source: :module | :runtime",
+                  coerce: true
                 )
                 |> Zoi.default(:module),
               metadata: Zoi.map(description: "Arbitrary extension metadata") |> Zoi.default(%{})
@@ -127,12 +118,17 @@ defmodule Jido.Action.Catalog.Entry do
   Builds a catalog entry from raw attributes.
   """
   @spec new(map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
-  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(attrs) when is_list(attrs) do
+    with {:ok, attrs} <- attrs_to_map(attrs, "Invalid catalog entry", :invalid_attrs) do
+      new(attrs)
+    end
+  end
 
   def new(%{} = attrs) do
     attrs =
       attrs
-      |> normalize_attr_map()
+      |> normalize_attr_aliases()
       |> drop_nil_values()
 
     case Zoi.parse(@schema, attrs) do
@@ -187,6 +183,19 @@ defmodule Jido.Action.Catalog.Entry do
       {:error, error} -> raise error
     end
   end
+
+  @doc false
+  @spec normalize_action_module(term(), keyword()) :: {:ok, term()}
+  def normalize_action_module(module, _opts \\ [])
+
+  def normalize_action_module(module, _opts) when is_binary(module) do
+    case existing_module_atom(module) do
+      {:ok, module} -> {:ok, module}
+      :error -> {:ok, module}
+    end
+  end
+
+  def normalize_action_module(module, _opts), do: {:ok, module}
 
   @doc false
   @spec apply_overrides(t(), map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
@@ -314,9 +323,9 @@ defmodule Jido.Action.Catalog.Entry do
       |> Map.put(
         :id,
         stable_id(
-          Map.get(attrs, :module, module),
-          Map.get(attrs, :name),
-          Map.get(attrs, :version)
+          attr(attrs, :module) || module,
+          attr(attrs, :name),
+          attr(attrs, :version)
         )
       )
     end
@@ -356,9 +365,8 @@ defmodule Jido.Action.Catalog.Entry do
   end
 
   defp refresh_derived_schema_kind(attrs, overrides) do
-    if (Map.has_key?(overrides, :input_schema) or Map.has_key?(overrides, "input_schema")) and
-         not Map.has_key?(overrides, :schema_kind) and not Map.has_key?(overrides, "schema_kind") do
-      Map.put(attrs, :schema_kind, Schema.schema_type(Map.get(attrs, :input_schema)))
+    if attr?(overrides, :input_schema) and not attr?(overrides, :schema_kind) do
+      Map.put(attrs, :schema_kind, Schema.schema_type(attr(attrs, :input_schema)))
     else
       attrs
     end
@@ -366,60 +374,26 @@ defmodule Jido.Action.Catalog.Entry do
 
   defp normalize_overrides(overrides) do
     with {:ok, overrides} <- attrs_to_map(overrides) do
-      {:ok, normalize_attr_map(overrides)}
+      {:ok, normalize_attr_aliases(overrides)}
     end
   end
 
-  defp attrs_to_map(attrs) when is_list(attrs) do
+  defp attrs_to_map(attrs) do
+    attrs_to_map(attrs, "Invalid catalog entry overrides", :invalid_overrides)
+  end
+
+  defp attrs_to_map(attrs, message, details) when is_list(attrs) do
     if Keyword.keyword?(attrs) do
       {:ok, Map.new(attrs)}
     else
-      {:error, validation_error("Invalid catalog entry overrides", :invalid_overrides)}
+      {:error, validation_error(message, details)}
     end
   end
 
-  defp attrs_to_map(%{} = attrs), do: {:ok, attrs}
+  defp attrs_to_map(%{} = attrs, _message, _details), do: {:ok, attrs}
 
-  defp attrs_to_map(_attrs),
-    do: {:error, validation_error("Invalid catalog entry overrides", :invalid_overrides)}
-
-  defp normalize_attr_map(attrs) do
-    attrs
-    |> normalize_known_string_keys()
-    |> normalize_attr_aliases()
-    |> normalize_module_value()
-    |> normalize_enum_values()
-  end
-
-  defp normalize_known_string_keys(attrs) do
-    Enum.reduce(@string_key_fields, attrs, fn key, acc ->
-      maybe_rename(acc, Atom.to_string(key), key)
-    end)
-  end
-
-  defp normalize_enum_values(attrs) do
-    Enum.reduce(@enum_fields, attrs, fn {field, allowed_values}, acc ->
-      case Map.fetch(acc, field) do
-        {:ok, value} -> Map.put(acc, field, normalize_enum_value(value, allowed_values))
-        :error -> acc
-      end
-    end)
-  end
-
-  defp normalize_enum_value(value, allowed_values) when is_binary(value) do
-    Enum.find(allowed_values, value, &(Atom.to_string(&1) == value))
-  end
-
-  defp normalize_enum_value(value, _allowed_values), do: value
-
-  defp normalize_module_value(%{module: module} = attrs) when is_binary(module) do
-    case existing_module_atom(module) do
-      {:ok, module} -> Map.put(attrs, :module, module)
-      :error -> attrs
-    end
-  end
-
-  defp normalize_module_value(attrs), do: attrs
+  defp attrs_to_map(_attrs, message, details),
+    do: {:error, validation_error(message, details)}
 
   defp existing_module_atom(module) do
     candidates =
@@ -435,6 +409,14 @@ defmodule Jido.Action.Catalog.Entry do
         ArgumentError -> false
       end
     end)
+  end
+
+  defp attr(attrs, key) do
+    Map.get(attrs, key, Map.get(attrs, Atom.to_string(key)))
+  end
+
+  defp attr?(attrs, key) do
+    Map.has_key?(attrs, key) or Map.has_key?(attrs, Atom.to_string(key))
   end
 
   defp normalize_entry_schemas(%__MODULE__{} = entry) do

--- a/lib/jido_action/catalog/hit.ex
+++ b/lib/jido_action/catalog/hit.ex
@@ -1,6 +1,9 @@
 defmodule Jido.Action.Catalog.Hit do
   @moduledoc """
   Ranked search hit returned from an action catalog query.
+
+  Hits are plain result values for local catalog search. A hit does not authorize
+  or execute the referenced entry.
   """
 
   alias Jido.Action.Error
@@ -31,7 +34,12 @@ defmodule Jido.Action.Catalog.Hit do
   Builds a catalog hit.
   """
   @spec new(map() | keyword()) :: {:ok, t()} | {:error, Exception.t()}
-  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(attrs) when is_list(attrs) do
+    with {:ok, attrs} <- attrs_to_map(attrs) do
+      new(attrs)
+    end
+  end
 
   def new(%{} = attrs) do
     attrs = Map.reject(attrs, fn {_key, value} -> is_nil(value) end)
@@ -46,6 +54,14 @@ defmodule Jido.Action.Catalog.Hit do
   end
 
   def new(_attrs), do: {:error, Error.validation_error("Invalid catalog hit")}
+
+  defp attrs_to_map(attrs) when is_list(attrs) do
+    if Keyword.keyword?(attrs) do
+      {:ok, Map.new(attrs)}
+    else
+      {:error, Error.validation_error("Invalid catalog hit", %{details: :invalid_attrs})}
+    end
+  end
 
   @doc """
   Same as `new/1`, but raises on error.

--- a/lib/jido_action/catalog/query.ex
+++ b/lib/jido_action/catalog/query.ex
@@ -1,21 +1,16 @@
 defmodule Jido.Action.Catalog.Query do
   @moduledoc """
   Query value for filtering and searching an action catalog.
+
+  Queries are plain data used by `Jido.Action.Catalog.search/2`. They describe a
+  local filter operation only; they do not imply authorization, policy, or
+  execution behavior.
   """
 
   alias Jido.Action.Error
 
   @visibility_values [:public, :internal, :hidden]
-  @string_key_fields [
-    :text,
-    :namespace,
-    :tags,
-    :capabilities,
-    :visibility,
-    :limit,
-    :filters,
-    :metadata
-  ]
+  @visibility_enum Enum.map(@visibility_values, &{&1, Atom.to_string(&1)})
 
   @schema Zoi.struct(
             __MODULE__,
@@ -26,10 +21,14 @@ defmodule Jido.Action.Catalog.Query do
               capabilities:
                 Zoi.list(Zoi.string(), description: "Required capabilities") |> Zoi.default([]),
               visibility:
-                Zoi.list(
-                  Zoi.enum(@visibility_values),
+                Zoi.union(
+                  [
+                    Zoi.enum(@visibility_enum, coerce: true),
+                    Zoi.list(Zoi.enum(@visibility_enum, coerce: true))
+                  ],
                   description: "Allowed visibility values"
                 )
+                |> Zoi.transform({__MODULE__, :normalize_visibility, []})
                 |> Zoi.default([:public]),
               limit:
                 Zoi.integer(description: "Maximum hits to return")
@@ -58,11 +57,14 @@ defmodule Jido.Action.Catalog.Query do
   @spec new(map() | keyword() | String.t() | t()) :: {:ok, t()} | {:error, Exception.t()}
   def new(%__MODULE__{} = query), do: {:ok, query}
   def new(text) when is_binary(text), do: new(%{text: text})
-  def new(attrs) when is_list(attrs), do: attrs |> Map.new() |> new()
+
+  def new(attrs) when is_list(attrs) do
+    with {:ok, attrs} <- attrs_to_map(attrs) do
+      new(attrs)
+    end
+  end
 
   def new(%{} = attrs) do
-    attrs = normalize_attr_map(attrs)
-
     case Zoi.parse(@schema, attrs) do
       {:ok, query} ->
         {:ok, query}
@@ -74,45 +76,19 @@ defmodule Jido.Action.Catalog.Query do
 
   def new(_attrs), do: {:error, Error.validation_error("Invalid catalog query")}
 
-  defp normalize_attr_map(attrs) do
-    attrs
-    |> normalize_known_string_keys()
-    |> normalize_visibility()
-  end
-
-  defp normalize_known_string_keys(attrs) do
-    Enum.reduce(@string_key_fields, attrs, fn key, acc ->
-      maybe_rename(acc, Atom.to_string(key), key)
-    end)
-  end
-
-  defp maybe_rename(attrs, from, to) do
-    case Map.fetch(attrs, from) do
-      {:ok, value} ->
-        attrs
-        |> Map.delete(from)
-        |> Map.put_new(to, value)
-
-      :error ->
-        attrs
+  defp attrs_to_map(attrs) when is_list(attrs) do
+    if Keyword.keyword?(attrs) do
+      {:ok, Map.new(attrs)}
+    else
+      {:error, Error.validation_error("Invalid catalog query", %{details: :invalid_attrs})}
     end
   end
 
-  defp normalize_visibility(%{visibility: values} = attrs) when is_list(values) do
-    Map.put(attrs, :visibility, Enum.map(values, &normalize_visibility_value/1))
-  end
-
-  defp normalize_visibility(%{visibility: value} = attrs) do
-    Map.put(attrs, :visibility, [normalize_visibility_value(value)])
-  end
-
-  defp normalize_visibility(attrs), do: attrs
-
-  defp normalize_visibility_value(value) when is_binary(value) do
-    Enum.find(@visibility_values, value, &(Atom.to_string(&1) == value))
-  end
-
-  defp normalize_visibility_value(value), do: value
+  @doc false
+  @spec normalize_visibility(atom() | [atom()], keyword()) :: {:ok, [atom()]}
+  def normalize_visibility(values, _opts \\ [])
+  def normalize_visibility(values, _opts) when is_list(values), do: {:ok, values}
+  def normalize_visibility(value, _opts), do: {:ok, [value]}
 
   @doc """
   Same as `new/1`, but raises on error.

--- a/test/jido_action/catalog_test.exs
+++ b/test/jido_action/catalog_test.exs
@@ -156,6 +156,10 @@ defmodule Jido.Action.CatalogTest do
       assert {:error, _error} = Entry.from_module(SearchUsers, [:bad_override])
     end
 
+    test "rejects malformed keyword attrs without raising" do
+      assert {:error, _error} = Entry.new([:bad_attr])
+    end
+
     test "rejects unsupported enum values" do
       assert {:error, _error} =
                Entry.new(
@@ -279,6 +283,31 @@ defmodule Jido.Action.CatalogTest do
 
       assert {:error, _error} =
                Catalog.new(id: "test", entries: %{"invalid" => "not-entry"})
+    end
+
+    test "supports serialized catalog attrs with string keys" do
+      entry_attrs = %{
+        "id" => "email",
+        "module" => inspect(SendEmail),
+        "name" => "send_email"
+      }
+
+      assert {:ok, catalog} =
+               Catalog.new(%{
+                 "id" => "serialized",
+                 "name" => "Serialized Catalog",
+                 "entries" => %{"ignored-key" => entry_attrs},
+                 "metadata" => %{"owner" => "ops"}
+               })
+
+      assert catalog.id == "serialized"
+      assert catalog.name == "Serialized Catalog"
+      assert catalog.metadata == %{"owner" => "ops"}
+      assert [%Entry{id: "email", module: SendEmail, name: "send_email"}] = Catalog.list(catalog)
+    end
+
+    test "rejects malformed catalog keyword attrs without raising" do
+      assert {:error, _error} = Catalog.new([:bad_attr])
     end
 
     test "registers, fetches, and unregisters entries by id or name" do
@@ -520,6 +549,28 @@ defmodule Jido.Action.CatalogTest do
       assert {:ok, hit} = Hit.new(entry: entry, score: 1.5, matches: %{name: 1.5})
       assert hit.entry == entry
       assert hit.score == 1.5
+    end
+
+    test "supports serialized hit attrs with string keys" do
+      entry = Entry.new!(id: "entry", module: SearchUsers, name: "search_users")
+
+      assert {:ok, hit} =
+               Hit.new(%{
+                 "entry" => entry,
+                 "score" => 1.5,
+                 "reason" => "name",
+                 "matches" => %{"name" => 1.5}
+               })
+
+      assert hit.entry == entry
+      assert hit.score == 1.5
+      assert hit.reason == "name"
+      assert hit.matches == %{"name" => 1.5}
+    end
+
+    test "rejects malformed query and hit keyword attrs without raising" do
+      assert {:error, _error} = Query.new([:bad_attr])
+      assert {:error, _error} = Hit.new([:bad_attr])
     end
   end
 end


### PR DESCRIPTION
## Summary
- keep the released action catalog API intact while clarifying it as a foundational data contract
- harden catalog/query/entry/hit constructors so malformed list attrs return validation errors instead of raising
- support serialized string-key catalog attrs and hit attrs consistently
- clarify docs that search/filter fields are local data helpers, not policy or execution semantics

## Verification
- `mix test test/jido_action/catalog_test.exs`
- `mix test`
- `mix q`