### PR TITLE
fix(security): harden built-in tool boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
+## Unreleased
+
+### Security:
+
+* scope built-in file tools with optional root capabilities and safer delete guards
+
+* enforce default Lua heap limits and clean up Lua workers when callers exit
+
+* sanitize exceptional execution messages before returning them
+
 ## [v2.3.0](https://github.com/agentjido/jido_action/compare/v2.2.1...v2.3.0) (2026-05-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- changelog -->
 
-## Unreleased
-
-### Security:
-
-* scope built-in file tools with optional root capabilities and safer delete guards
-
-* enforce default Lua heap limits and clean up Lua workers when callers exit
-
-* sanitize exceptional execution messages before returning them
-
 ## [v2.3.0](https://github.com/agentjido/jido_action/compare/v2.2.1...v2.3.0) (2026-05-22)
 
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ Jido.Action comes with a comprehensive library of pre-built tools organized by c
 | `MakeDirectory` | Create directories (recursive) | Setup operations |
 | `ListDirectory` | List directory contents with filtering | File discovery |
 
+File tools can be scoped with `config :jido_action, file_tool_roots: [...]` or per-run
+`%{allowed_file_roots: [...]}` context. Use roots before exposing these tools to agents or
+user-influenced requests.
+
 ### HTTP Operations (`Jido.Tools.ReqTool`)
 
 `ReqTool` is a specialized action that provides a behavior and macro for creating HTTP request actions using the Req library. It offers a standardized way to build HTTP-based actions with configurable URLs, methods, headers, and response processing.

--- a/guides/security.md
+++ b/guides/security.md
@@ -202,6 +202,23 @@ config :jido_action, :default_timeout, 30_000
 
 ### File System Restrictions
 
+If you use the built-in `Jido.Tools.Files.*` actions, scope them before exposing them to
+agent-selected or user-influenced calls:
+
+```elixir
+# config/runtime.exs
+config :jido_action, file_tool_roots: ["/srv/my_app/data"]
+
+# Per request, optionally narrower than the configured roots
+context = %{allowed_file_roots: ["/srv/my_app/data/uploads"]}
+Jido.Tools.Files.ReadFile.run(%{path: "profile.json"}, context)
+```
+
+When roots are present, relative paths resolve under the first allowed root. The file tools reject
+paths and symlinks that resolve outside the allowed roots, reject parent traversal in glob patterns,
+and refuse protected deletion targets such as `/`, the current working directory, and the current
+user's home directory.
+
 ```elixir
 defmodule MyApp.Actions.SecureFileOp do
   use Jido.Action,

--- a/guides/tools-reference.md
+++ b/guides/tools-reference.md
@@ -177,6 +177,25 @@ Square a number.
 
 ## File Operations
 
+Built-in file actions are unrestricted by default for backwards compatibility. To expose them to
+agents or untrusted callers, scope filesystem access with either application config or execution
+context:
+
+```elixir
+# Global ceiling
+config :jido_action, file_tool_roots: ["/srv/my_app/data"]
+
+# Per-run capability, optionally narrower than the global ceiling
+context = %{allowed_file_roots: ["/srv/my_app/data/uploads"]}
+Jido.Tools.Files.ReadFile.run(%{path: "report.json"}, context)
+```
+
+When roots are enforced, relative paths resolve under the first allowed root, symlinks that resolve
+outside the allowed roots are rejected, and glob patterns cannot traverse parent directories.
+`DeleteFile` also refuses protected targets such as `/`, the current working directory, and the
+current user's home directory. `force: true` no longer recursively removes directories unless
+`recursive: true` is also set.
+
 ### Read File
 Read contents from a file.
 
@@ -436,7 +455,7 @@ Execute Lua code in a sandboxed VM.
 - `enable_unsafe_libs` (boolean, default: false): Disable Lua.ex capability sandboxing; Lua.ex 1.0 still has no host shell or host filesystem access.
 - `timeout_ms` (integer, default: 1000): Execution timeout in milliseconds
 - `max_call_depth` (integer, default: 0): Maximum nested Lua call depth (0 = disabled)
-- `max_heap_bytes` (integer, default: 0): Per-process heap limit (0 = disabled)
+- `max_heap_bytes` (integer, default: 67108864): Per-process heap limit in bytes (0 = disabled)
 
 ### ZoiExample
 A production-quality example demonstrating Zoi schema features. Use this as a reference for building actions with complex validation.

--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -204,7 +204,8 @@ defmodule Jido.Exec do
       log_level = Util.resolve_log_level(opts)
       Telemetry.cond_log_caught_error(log_level, reason)
 
-      {:error, Error.internal_error("Caught #{kind}: #{inspect(reason)}")}
+      {:error,
+       Error.internal_error("Caught #{kind}: #{Telemetry.extract_safe_error_message(reason)}")}
   end
 
   def run(action, _params, _context, _opts) do
@@ -326,14 +327,22 @@ defmodule Jido.Exec do
     defp normalize_params({:error, reason}), do: {:error, Error.validation_error(reason)}
 
     defp normalize_params(params),
-      do: {:error, Error.validation_error("Invalid params type: #{inspect(params)}")}
+      do:
+        {:error,
+         Error.validation_error(
+           "Invalid params type: #{Telemetry.extract_safe_error_message(params)}"
+         )}
 
     @spec normalize_context(context()) :: {:ok, map()} | {:error, Exception.t()}
     defp normalize_context(context) when is_map(context), do: {:ok, context}
     defp normalize_context(context) when is_list(context), do: {:ok, Map.new(context)}
 
     defp normalize_context(context),
-      do: {:error, Error.validation_error("Invalid context type: #{inspect(context)}")}
+      do:
+        {:error,
+         Error.validation_error(
+           "Invalid context type: #{Telemetry.extract_safe_error_message(context)}"
+         )}
 
     @spec do_run_with_retry(action(), params(), context(), run_opts()) :: exec_result
     defp do_run_with_retry(action, params, context, opts) do
@@ -547,10 +556,13 @@ defmodule Jido.Exec do
 
         {:exit, reason} ->
           {:error,
-           Error.execution_error("Task exited: #{inspect(reason)}", %{
-             reason: reason,
-             action: action
-           })}
+           Error.execution_error(
+             "Task exited: #{Telemetry.extract_safe_error_message(reason)}",
+             %{
+               reason: reason,
+               action: action
+             }
+           )}
 
         :timeout ->
           {:error,
@@ -781,7 +793,11 @@ defmodule Jido.Exec do
 
     # Handle unexpected return shapes
     defp handle_action_result(unexpected_result, action, log_level, _opts) do
-      error = Error.execution_error("Unexpected return shape: #{inspect(unexpected_result)}")
+      error =
+        Error.execution_error(
+          "Unexpected return shape: #{Telemetry.extract_safe_error_message(unexpected_result)}"
+        )
+
       Telemetry.cond_log_error(log_level, action, error)
       {:error, error}
     end
@@ -808,8 +824,10 @@ defmodule Jido.Exec do
     defp extract_error_fields(reason) when is_atom(reason),
       do: {Atom.to_string(reason), %{reason: reason, retry: Error.retryable?(reason)}}
 
-    defp extract_error_fields(reason) when is_map(reason), do: {inspect(reason), reason}
-    defp extract_error_fields(reason), do: {inspect(reason), %{}}
+    defp extract_error_fields(reason) when is_map(reason),
+      do: {Telemetry.extract_safe_error_message(reason), reason}
+
+    defp extract_error_fields(reason), do: {Telemetry.extract_safe_error_message(reason), %{}}
 
     defp struct_error_details(reason) do
       reason
@@ -872,7 +890,7 @@ defmodule Jido.Exec do
     end
 
     defp build_exception_message(e, action) do
-      "An unexpected error occurred during execution of #{inspect(action)}: #{inspect(e)}"
+      "An unexpected error occurred during execution of #{inspect(action)}: #{Telemetry.extract_safe_error_message(e)}"
     end
   end
 end

--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -804,22 +804,23 @@ defmodule Jido.Exec do
 
     defp extract_error_fields(%{message: message} = reason)
          when is_struct(reason) and is_binary(message) do
-      {message, struct_error_details(reason)}
+      {Telemetry.extract_safe_error_message(reason), struct_error_details(reason)}
     end
 
     defp extract_error_fields(%{message: message} = reason) when is_struct(reason) do
-      {inspect(message), struct_error_details(reason)}
+      {Telemetry.extract_safe_error_message(%{message: message}), struct_error_details(reason)}
     end
 
     defp extract_error_fields(%{message: message} = reason) when is_binary(message) do
-      {message, Map.delete(reason, :message)}
+      {Telemetry.extract_safe_error_message(reason), Map.delete(reason, :message)}
     end
 
     defp extract_error_fields(%{message: message} = reason) do
-      {inspect(message), Map.delete(reason, :message)}
+      {Telemetry.extract_safe_error_message(%{message: message}), Map.delete(reason, :message)}
     end
 
-    defp extract_error_fields(reason) when is_binary(reason), do: {reason, %{}}
+    defp extract_error_fields(reason) when is_binary(reason),
+      do: {Telemetry.extract_safe_error_message(%{message: reason}), %{}}
 
     defp extract_error_fields(reason) when is_atom(reason),
       do: {Atom.to_string(reason), %{reason: reason, retry: Error.retryable?(reason)}}

--- a/lib/jido_action/exec/telemetry.ex
+++ b/lib/jido_action/exec/telemetry.ex
@@ -135,17 +135,17 @@ defmodule Jido.Exec.Telemetry do
   def extract_safe_error_message(error) do
     case error do
       %{message: %{message: inner_message}} when is_binary(inner_message) ->
-        inner_message
+        safe_message(inner_message)
 
       %{message: nil} ->
         ""
 
       %{message: message} when is_binary(message) ->
-        message
+        safe_message(message)
 
       %{message: message} when is_struct(message) ->
         if Map.has_key?(message, :message) and is_binary(message.message) do
-          message.message
+          safe_message(message.message)
         else
           safe_inspect(message)
         end
@@ -154,6 +154,8 @@ defmodule Jido.Exec.Telemetry do
         safe_inspect(error)
     end
   end
+
+  defp safe_message(message) when is_binary(message), do: Sanitizer.sanitize_telemetry(message)
 
   @doc """
   Conditional logging wrapper for start events.

--- a/lib/jido_action/sanitizer.ex
+++ b/lib/jido_action/sanitizer.ex
@@ -27,6 +27,9 @@ defmodule Jido.Action.Sanitizer do
   @max_depth 4
   @max_collection_items 25
   @max_binary_bytes 256
+  @sensitive_assignment_key_pattern "password|passwd|passphrase|secret|token|api[_-]?key|apikey|access[_-]?key|accesskey|private[_-]?key|privatekey|authorization|auth|cookie|session|credential"
+  @sensitive_assignment_regex ~r/((?:"|')?(?:#{@sensitive_assignment_key_pattern})(?:"|')?\s*(?:=>|=|:)\s*)(?:"[^"]*"|'[^']*'|[^\s,;}\]]+)/i
+  @authorization_token_regex ~r/\b(Bearer|Basic)\s+[A-Za-z0-9._~+\/=-]+/i
   @sensitive_patterns [
     "password",
     "passwd",
@@ -249,13 +252,9 @@ defmodule Jido.Action.Sanitizer do
   end
 
   defp do_sanitize_telemetry(value, _depth, opts) when is_binary(value) do
-    if byte_size(value) > opts.max_binary_bytes do
-      kept = binary_part(value, 0, opts.max_binary_bytes)
-      truncated = byte_size(value) - opts.max_binary_bytes
-      "#{kept}...(truncated #{truncated} bytes)"
-    else
-      value
-    end
+    value
+    |> redact_sensitive_binary()
+    |> truncate_binary(opts)
   end
 
   defp do_sanitize_telemetry(value, _depth, _opts), do: value
@@ -274,6 +273,22 @@ defmodule Jido.Action.Sanitizer do
        do: key
 
   defp sanitize_telemetry_key(key, depth, opts), do: do_sanitize_telemetry(key, depth, opts)
+
+  defp redact_sensitive_binary(value) do
+    value
+    |> then(&Regex.replace(@sensitive_assignment_regex, &1, "\\1[REDACTED]"))
+    |> then(&Regex.replace(@authorization_token_regex, &1, "\\1 [REDACTED]"))
+  end
+
+  defp truncate_binary(value, opts) do
+    if byte_size(value) > opts.max_binary_bytes do
+      kept = binary_part(value, 0, opts.max_binary_bytes)
+      truncated = byte_size(value) - opts.max_binary_bytes
+      "#{kept}...(truncated #{truncated} bytes)"
+    else
+      value
+    end
+  end
 
   defp summarize_truncated(%_{} = struct, opts), do: summarize_truncated_struct(struct, opts)
 

--- a/lib/jido_tools/files.ex
+++ b/lib/jido_tools/files.ex
@@ -18,6 +18,274 @@ defmodule Jido.Tools.Files do
 
   alias Jido.Action
 
+  @file_roots_config_key :file_tool_roots
+  @file_roots_context_keys [:allowed_file_roots, "allowed_file_roots", :file_roots, "file_roots"]
+  @max_symlink_depth 40
+
+  @doc false
+  @spec resolve_path(String.t(), map()) :: {:ok, String.t()} | {:error, String.t()}
+  def resolve_path(path, context) when is_binary(path) do
+    with {:ok, roots} <- active_file_roots(context) do
+      case roots do
+        [] ->
+          {:ok, path}
+
+        [default_root | _] = allowed_roots ->
+          expanded_path = expand_candidate_path(path, default_root)
+
+          with {:ok, guard_path} <- nearest_real_existing_path(expanded_path),
+               :ok <- ensure_inside_allowed_roots(guard_path, allowed_roots) do
+            {:ok, expanded_path}
+          end
+      end
+    end
+  end
+
+  def resolve_path(_path, _context), do: {:error, "Invalid file path"}
+
+  @doc false
+  @spec validate_glob_pattern(String.t(), map()) :: :ok | {:error, String.t()}
+  def validate_glob_pattern(pattern, context) when is_binary(pattern) do
+    with {:ok, roots} <- active_file_roots(context) do
+      cond do
+        roots == [] ->
+          :ok
+
+        Path.type(pattern) == :absolute ->
+          {:error, "Glob pattern must be relative when file roots are enforced"}
+
+        String.contains?(pattern, "..") ->
+          {:error, "Glob pattern cannot traverse parent directories when file roots are enforced"}
+
+        true ->
+          :ok
+      end
+    end
+  end
+
+  def validate_glob_pattern(_pattern, _context), do: {:error, "Invalid glob pattern"}
+
+  @doc false
+  @spec filter_allowed_paths([String.t()], map()) :: [String.t()]
+  def filter_allowed_paths(paths, context) when is_list(paths) do
+    case active_file_roots(context) do
+      {:ok, []} ->
+        paths
+
+      {:ok, _roots} ->
+        Enum.filter(paths, fn path ->
+          match?({:ok, _}, resolve_path(path, context))
+        end)
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  @doc false
+  @spec reject_protected_delete_target(String.t()) :: :ok | {:error, String.t()}
+  def reject_protected_delete_target(path) do
+    expanded = Path.expand(path)
+
+    protected_paths =
+      [Path.expand("/"), File.cwd!(), user_home()]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&Path.expand/1)
+
+    if expanded in protected_paths do
+      {:error, "Refusing to delete protected path: #{expanded}"}
+    else
+      :ok
+    end
+  end
+
+  @doc false
+  @spec reject_unsafe_nonrecursive_delete(String.t(), boolean()) :: :ok | {:error, String.t()}
+  def reject_unsafe_nonrecursive_delete(path, force) do
+    if force and File.dir?(path) do
+      {:error, "Refusing to force-delete directory without recursive: true"}
+    else
+      :ok
+    end
+  end
+
+  defp active_file_roots(context) do
+    with {:ok, configured_roots} <-
+           normalize_roots(Application.get_env(:jido_action, @file_roots_config_key, [])),
+         {:ok, context_roots} <- normalize_roots(context_file_roots(context)),
+         {:ok, configured_roots} <- canonicalize_roots(configured_roots),
+         {:ok, context_roots} <- canonicalize_roots(context_roots) do
+      cond do
+        configured_roots == [] and context_roots == [] ->
+          {:ok, []}
+
+        configured_roots == [] ->
+          {:ok, context_roots}
+
+        context_roots == [] ->
+          {:ok, configured_roots}
+
+        true ->
+          scoped_roots =
+            Enum.filter(context_roots, fn context_root ->
+              inside_any_root?(context_root, configured_roots)
+            end)
+
+          case scoped_roots do
+            [] -> {:error, "No context file roots are within configured file roots"}
+            roots -> {:ok, roots}
+          end
+      end
+    end
+  end
+
+  defp context_file_roots(context) when is_map(context) do
+    Enum.find_value(@file_roots_context_keys, fn key -> Map.get(context, key) end)
+  end
+
+  defp context_file_roots(_context), do: nil
+
+  defp normalize_roots(nil), do: {:ok, []}
+  defp normalize_roots(root) when is_binary(root), do: {:ok, [root]}
+
+  defp normalize_roots(roots) when is_list(roots) do
+    if Enum.all?(roots, &is_binary/1) do
+      {:ok, roots}
+    else
+      {:error, "File roots must be strings"}
+    end
+  end
+
+  defp normalize_roots(_roots), do: {:error, "File roots must be a string or list of strings"}
+
+  defp canonicalize_roots(roots) do
+    roots
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.reduce_while({:ok, []}, fn root, {:ok, acc} ->
+      root
+      |> Path.expand()
+      |> real_path()
+      |> case do
+        {:ok, real_path} -> {:cont, {:ok, [real_path | acc]}}
+        {:error, reason} -> {:halt, {:error, "Allowed file root is invalid: #{inspect(reason)}"}}
+      end
+    end)
+    |> case do
+      {:ok, roots} -> {:ok, roots |> Enum.reverse() |> Enum.uniq()}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp expand_candidate_path(path, default_root) do
+    case Path.type(path) do
+      :absolute -> Path.expand(path)
+      _relative -> Path.expand(path, default_root)
+    end
+  end
+
+  defp nearest_real_existing_path(path) do
+    with {:ok, existing_path} <- nearest_existing_path(Path.expand(path)) do
+      case real_path(existing_path) do
+        {:ok, real_path} -> {:ok, real_path}
+        {:error, reason} -> {:error, "Failed to resolve file path: #{inspect(reason)}"}
+      end
+    end
+  end
+
+  defp real_path(path) do
+    path
+    |> Path.expand()
+    |> Path.split()
+    |> resolve_real_path_parts(nil, 0)
+  end
+
+  defp resolve_real_path_parts([], nil, _symlink_depth), do: {:error, :enoent}
+
+  defp resolve_real_path_parts([root | rest], nil, symlink_depth) do
+    resolve_real_path_parts(rest, root, symlink_depth)
+  end
+
+  defp resolve_real_path_parts([], resolved_path, _symlink_depth), do: {:ok, resolved_path}
+
+  defp resolve_real_path_parts([part | rest], resolved_path, symlink_depth) do
+    candidate = Path.join(resolved_path, part)
+
+    case File.lstat(candidate) do
+      {:ok, %File.Stat{type: :symlink}} ->
+        resolve_symlink(candidate, resolved_path, rest, symlink_depth)
+
+      {:ok, _stat} ->
+        resolve_real_path_parts(rest, candidate, symlink_depth)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp resolve_symlink(_candidate, _parent, _rest, symlink_depth)
+       when symlink_depth >= @max_symlink_depth do
+    {:error, :too_many_symlinks}
+  end
+
+  defp resolve_symlink(candidate, parent, rest, symlink_depth) do
+    case :file.read_link(String.to_charlist(candidate)) do
+      {:ok, target} ->
+        target_path =
+          target
+          |> List.to_string()
+          |> expand_symlink_target(parent)
+
+        target_parts = Path.split(target_path) ++ rest
+        resolve_real_path_parts(target_parts, nil, symlink_depth + 1)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp expand_symlink_target(target, parent) do
+    case Path.type(target) do
+      :absolute -> Path.expand(target)
+      _relative -> Path.expand(target, parent)
+    end
+  end
+
+  defp nearest_existing_path(path) do
+    case File.lstat(path) do
+      {:ok, _stat} ->
+        {:ok, path}
+
+      {:error, _reason} ->
+        parent = Path.dirname(path)
+
+        if parent == path do
+          {:error, "No existing parent directory for file path"}
+        else
+          nearest_existing_path(parent)
+        end
+    end
+  end
+
+  defp ensure_inside_allowed_roots(path, allowed_roots) do
+    if inside_any_root?(path, allowed_roots) do
+      :ok
+    else
+      {:error, "File path is outside allowed file roots"}
+    end
+  end
+
+  defp inside_any_root?(path, roots), do: Enum.any?(roots, &inside_root?(path, &1))
+
+  defp inside_root?(_path, "/"), do: true
+  defp inside_root?(path, root), do: path == root or String.starts_with?(path, root <> "/")
+
+  defp user_home do
+    System.user_home!()
+  rescue
+    _ -> nil
+  end
+
   defmodule ReadFile do
     @moduledoc false
     use Action,
@@ -29,10 +297,12 @@ defmodule Jido.Tools.Files do
 
     @impl true
     @spec run(map(), map()) :: {:ok, map()} | {:error, String.t()}
-    def run(%{path: path}, _context) do
-      case File.read(path) do
-        {:ok, content} -> {:ok, %{path: path, content: content}}
-        {:error, reason} -> {:error, "Failed to read file: #{inspect(reason)}"}
+    def run(%{path: path}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context) do
+        case File.read(resolved_path) do
+          {:ok, content} -> {:ok, %{path: resolved_path, content: content}}
+          {:error, reason} -> {:error, "Failed to read file: #{inspect(reason)}"}
+        end
       end
     end
   end
@@ -58,14 +328,25 @@ defmodule Jido.Tools.Files do
       ]
 
     @impl true
-    def run(%{path: path, content: content, create_dirs: create_dirs, mode: mode}, _context) do
-      if create_dirs, do: File.mkdir_p(Path.dirname(path))
+    def run(%{path: path, content: content, create_dirs: create_dirs, mode: mode}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context),
+           :ok <- maybe_create_parent_dirs(resolved_path, create_dirs),
+           {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(resolved_path, context) do
+        case write_with_mode(resolved_path, content, mode) do
+          :ok -> {:ok, %{path: resolved_path, bytes_written: byte_size(content)}}
+          {:error, reason} -> {:error, "Failed to write file: #{inspect(reason)}"}
+        end
+      end
+    end
 
-      case write_with_mode(path, content, mode) do
-        :ok -> {:ok, %{path: path, bytes_written: byte_size(content)}}
+    defp maybe_create_parent_dirs(path, true) do
+      case File.mkdir_p(Path.dirname(path)) do
+        :ok -> :ok
         {:error, reason} -> {:error, "Failed to write file: #{inspect(reason)}"}
       end
     end
+
+    defp maybe_create_parent_dirs(_path, false), do: :ok
 
     defp write_with_mode(path, content, :write), do: File.write(path, content)
     defp write_with_mode(path, content, :append), do: File.write(path, content, [:append])
@@ -86,17 +367,33 @@ defmodule Jido.Tools.Files do
       ]
 
     @impl true
-    def run(%{path: path, recursive: true}, _context) do
-      case File.mkdir_p(path) do
-        :ok -> {:ok, %{path: path}}
-        {:error, reason} -> {:error, "Failed to create directory: #{inspect(reason)}"}
+    def run(%{path: path, recursive: true}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context) do
+        case File.mkdir_p(resolved_path) do
+          :ok ->
+            case Jido.Tools.Files.resolve_path(resolved_path, context) do
+              {:ok, _resolved_path} -> {:ok, %{path: resolved_path}}
+              {:error, reason} -> {:error, reason}
+            end
+
+          {:error, reason} ->
+            {:error, "Failed to create directory: #{inspect(reason)}"}
+        end
       end
     end
 
-    def run(%{path: path, recursive: false}, _context) do
-      case File.mkdir(path) do
-        :ok -> {:ok, %{path: path}}
-        {:error, reason} -> {:error, "Failed to create directory: #{inspect(reason)}"}
+    def run(%{path: path, recursive: false}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context) do
+        case File.mkdir(resolved_path) do
+          :ok ->
+            case Jido.Tools.Files.resolve_path(resolved_path, context) do
+              {:ok, _resolved_path} -> {:ok, %{path: resolved_path}}
+              {:error, reason} -> {:error, reason}
+            end
+
+          {:error, reason} ->
+            {:error, "Failed to create directory: #{inspect(reason)}"}
+        end
       end
     end
   end
@@ -121,34 +418,40 @@ defmodule Jido.Tools.Files do
       ]
 
     @impl true
-    def run(%{path: path, pattern: pattern, recursive: recursive}, _context)
+    def run(%{path: path, pattern: pattern, recursive: recursive}, context)
         when is_binary(pattern) do
-      result =
-        case recursive do
-          true -> Path.wildcard(Path.join(path, pattern))
-          false -> Path.wildcard(Path.join(path, pattern)) |> Enum.reject(&File.dir?/1)
-        end
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context),
+           :ok <- Jido.Tools.Files.validate_glob_pattern(pattern, context) do
+        result =
+          case recursive do
+            true -> Path.wildcard(Path.join(resolved_path, pattern))
+            false -> Path.wildcard(Path.join(resolved_path, pattern)) |> Enum.reject(&File.dir?/1)
+          end
+          |> Jido.Tools.Files.filter_allowed_paths(context)
 
-      {:ok, %{entries: result}}
+        {:ok, %{entries: result}}
+      end
     end
 
-    def run(%{path: path, recursive: recursive}, _context) do
-      case recursive do
-        true ->
-          case File.ls(path) do
-            {:ok, entries} -> {:ok, %{entries: entries}}
-            {:error, reason} -> {:error, "Failed to list directory: #{inspect(reason)}"}
-          end
+    def run(%{path: path, recursive: recursive}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context) do
+        case recursive do
+          true ->
+            case File.ls(resolved_path) do
+              {:ok, entries} -> {:ok, %{entries: entries}}
+              {:error, reason} -> {:error, "Failed to list directory: #{inspect(reason)}"}
+            end
 
-        false ->
-          case File.ls(path) do
-            {:ok, entries} ->
-              files = Enum.reject(entries, &File.dir?(Path.join(path, &1)))
-              {:ok, %{entries: files}}
+          false ->
+            case File.ls(resolved_path) do
+              {:ok, entries} ->
+                files = Enum.reject(entries, &File.dir?(Path.join(resolved_path, &1)))
+                {:ok, %{entries: files}}
 
-            {:error, reason} ->
-              {:error, "Failed to list directory: #{inspect(reason)}"}
-          end
+              {:error, reason} ->
+                {:error, "Failed to list directory: #{inspect(reason)}"}
+            end
+        end
       end
     end
   end
@@ -173,30 +476,38 @@ defmodule Jido.Tools.Files do
       ]
 
     @impl true
-    def run(%{path: path, recursive: true}, _context) do
-      case File.rm_rf(path) do
-        {:ok, paths} ->
-          {:ok, %{deleted: paths}}
+    def run(%{path: path, recursive: true}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context),
+           :ok <- Jido.Tools.Files.reject_protected_delete_target(resolved_path) do
+        case File.rm_rf(resolved_path) do
+          {:ok, paths} ->
+            {:ok, %{deleted: paths}}
 
-        {:error, reason, paths} ->
-          {:error, "Failed to delete some paths: #{inspect(reason)}, deleted: #{inspect(paths)}"}
+          {:error, reason, paths} ->
+            {:error,
+             "Failed to delete some paths: #{inspect(reason)}, deleted: #{inspect(paths)}"}
+        end
       end
     end
 
-    def run(%{path: path, recursive: false, force: force}, _context) do
-      result =
-        if force do
-          case File.rm_rf(path) do
-            {:ok, _paths} -> :ok
-            {:error, reason, _paths} -> {:error, reason}
+    def run(%{path: path, recursive: false, force: force}, context) do
+      with {:ok, resolved_path} <- Jido.Tools.Files.resolve_path(path, context),
+           :ok <- Jido.Tools.Files.reject_protected_delete_target(resolved_path),
+           :ok <- Jido.Tools.Files.reject_unsafe_nonrecursive_delete(resolved_path, force) do
+        result =
+          if force do
+            case File.rm_rf(resolved_path) do
+              {:ok, _paths} -> :ok
+              {:error, reason, _paths} -> {:error, reason}
+            end
+          else
+            File.rm(resolved_path)
           end
-        else
-          File.rm(path)
-        end
 
-      case result do
-        :ok -> {:ok, %{path: path}}
-        {:error, reason} -> {:error, "Failed to delete: #{inspect(reason)}"}
+        case result do
+          :ok -> {:ok, %{path: resolved_path}}
+          {:error, reason} -> {:error, "Failed to delete: #{inspect(reason)}"}
+        end
       end
     end
   end
@@ -213,13 +524,21 @@ defmodule Jido.Tools.Files do
 
     @impl true
     @spec run(map(), map()) :: {:ok, map()} | {:error, String.t()}
-    def run(%{source: source, destination: destination}, _context) do
-      case File.copy(source, destination) do
-        {:ok, bytes_copied} ->
-          {:ok, %{source: source, destination: destination, bytes_copied: bytes_copied}}
+    def run(%{source: source, destination: destination}, context) do
+      with {:ok, resolved_source} <- Jido.Tools.Files.resolve_path(source, context),
+           {:ok, resolved_destination} <- Jido.Tools.Files.resolve_path(destination, context) do
+        case File.copy(resolved_source, resolved_destination) do
+          {:ok, bytes_copied} ->
+            {:ok,
+             %{
+               source: resolved_source,
+               destination: resolved_destination,
+               bytes_copied: bytes_copied
+             }}
 
-        {:error, reason} ->
-          {:error, "Failed to copy file: #{inspect(reason)}"}
+          {:error, reason} ->
+            {:error, "Failed to copy file: #{inspect(reason)}"}
+        end
       end
     end
   end
@@ -236,10 +555,13 @@ defmodule Jido.Tools.Files do
 
     @impl true
     @spec run(map(), map()) :: {:ok, map()} | {:error, String.t()}
-    def run(%{source: source, destination: destination}, _context) do
-      case File.rename(source, destination) do
-        :ok -> {:ok, %{source: source, destination: destination}}
-        {:error, reason} -> {:error, "Failed to move file: #{inspect(reason)}"}
+    def run(%{source: source, destination: destination}, context) do
+      with {:ok, resolved_source} <- Jido.Tools.Files.resolve_path(source, context),
+           {:ok, resolved_destination} <- Jido.Tools.Files.resolve_path(destination, context) do
+        case File.rename(resolved_source, resolved_destination) do
+          :ok -> {:ok, %{source: resolved_source, destination: resolved_destination}}
+          {:error, reason} -> {:error, "Failed to move file: #{inspect(reason)}"}
+        end
       end
     end
   end

--- a/lib/jido_tools/lua_eval.ex
+++ b/lib/jido_tools/lua_eval.ex
@@ -58,6 +58,9 @@ defmodule Jido.Tools.LuaEval do
 
   alias Jido.Action.Error
 
+  @deadline_key :__jido_deadline_ms__
+  @default_max_heap_bytes 64 * 1024 * 1024
+
   use Jido.Action,
     name: "lua_eval",
     description: "Execute a Lua code string in a sandboxed VM and return the values.",
@@ -97,40 +100,48 @@ defmodule Jido.Tools.LuaEval do
       ],
       max_heap_bytes: [
         type: :non_neg_integer,
-        default: 0,
+        default: @default_max_heap_bytes,
         doc: "Per-process heap limit in bytes (0 = disabled)."
       ]
     ],
     output_schema: []
 
   @impl true
-  def run(params, _context) do
+  def run(params, context) do
     if Code.ensure_loaded?(Lua) do
-      timeout_ms = Map.get(params, :timeout_ms, 1000)
-      parent = self()
-      ref = make_ref()
+      requested_timeout_ms = Map.get(params, :timeout_ms, 1000)
 
-      {:ok, pid} =
-        Task.Supervisor.start_child(Jido.Action.TaskSupervisor, fn ->
-          send(parent, {:lua_eval_result, ref, do_run(params)})
-        end)
+      case effective_timeout_ms(requested_timeout_ms, context) do
+        {:ok, timeout_ms} ->
+          parent = self()
+          ref = make_ref()
 
-      monitor_ref = Process.monitor(pid)
+          {:ok, pid} =
+            Task.Supervisor.start_child(Jido.Action.TaskSupervisor, fn ->
+              send(parent, {:lua_eval_result, ref, do_run(params)})
+            end)
 
-      case await_lua_result(ref, pid, monitor_ref, timeout_ms) do
-        {:ok, result} ->
-          cleanup_lua_task(ref, monitor_ref)
-          result
+          watchdog_pid = start_lua_watchdog(parent, pid)
+          monitor_ref = Process.monitor(pid)
 
-        {:exit, reason} ->
-          cleanup_lua_task(ref, monitor_ref)
-          return_error(:lua_error, "Lua task exited: #{inspect(reason)}")
+          case await_lua_result(ref, pid, monitor_ref, timeout_ms) do
+            {:ok, result} ->
+              cleanup_lua_task(ref, monitor_ref, watchdog_pid)
+              result
 
-        :timeout ->
-          _ = Process.exit(pid, :kill)
-          wait_for_lua_down(monitor_ref, pid, 100)
-          cleanup_lua_task(ref, monitor_ref)
-          timeout_error(timeout_ms)
+            {:exit, reason} ->
+              cleanup_lua_task(ref, monitor_ref, watchdog_pid)
+              return_error(:lua_error, "Lua task exited: #{inspect(reason)}")
+
+            :timeout ->
+              _ = Process.exit(pid, :kill)
+              wait_for_lua_down(monitor_ref, pid, 100)
+              cleanup_lua_task(ref, monitor_ref, watchdog_pid)
+              timeout_error(timeout_ms)
+          end
+
+        {:error, error} ->
+          {:error, error}
       end
     else
       msg =
@@ -173,7 +184,8 @@ defmodule Jido.Tools.LuaEval do
       end
     end
 
-    defp cleanup_lua_task(ref, monitor_ref) do
+    defp cleanup_lua_task(ref, monitor_ref, watchdog_pid) do
+      send(watchdog_pid, :stop)
       Process.demonitor(monitor_ref, [:flush])
       flush_lua_results(ref)
     end
@@ -188,6 +200,49 @@ defmodule Jido.Tools.LuaEval do
     end
   end
 
+  defp start_lua_watchdog(parent, lua_pid) do
+    spawn(fn ->
+      parent_ref = Process.monitor(parent)
+      lua_ref = Process.monitor(lua_pid)
+
+      receive do
+        {:DOWN, ^parent_ref, :process, ^parent, _reason} ->
+          if Process.alive?(lua_pid), do: Process.exit(lua_pid, :kill)
+          Process.demonitor(lua_ref, [:flush])
+
+        {:DOWN, ^lua_ref, :process, ^lua_pid, _reason} ->
+          Process.demonitor(parent_ref, [:flush])
+
+        :stop ->
+          Process.demonitor(parent_ref, [:flush])
+          Process.demonitor(lua_ref, [:flush])
+      end
+    end)
+  end
+
+  defp effective_timeout_ms(timeout_ms, context) when is_map(context) do
+    case context[@deadline_key] do
+      deadline_ms when is_integer(deadline_ms) ->
+        now = System.monotonic_time(:millisecond)
+        remaining = deadline_ms - now
+
+        if remaining <= 0 do
+          {:error,
+           Error.timeout_error("Execution deadline exceeded before Lua dispatch", %{
+             deadline_ms: deadline_ms,
+             now_ms: now
+           })}
+        else
+          {:ok, min(timeout_ms, remaining)}
+        end
+
+      _ ->
+        {:ok, timeout_ms}
+    end
+  end
+
+  defp effective_timeout_ms(timeout_ms, _context), do: {:ok, timeout_ms}
+
   defp do_run(params) do
     code = Map.fetch!(params, :code)
     globals = Map.get(params, :globals, %{})
@@ -197,7 +252,11 @@ defmodule Jido.Tools.LuaEval do
     max_heap_bytes = Map.get(params, :max_heap_bytes, 0)
 
     if is_integer(max_heap_bytes) and max_heap_bytes > 0 do
-      :erlang.process_flag(:max_heap_size, %{size: max_heap_bytes, kill: true})
+      :erlang.process_flag(:max_heap_size, %{
+        size: bytes_to_heap_words(max_heap_bytes),
+        kill: true,
+        error_logger: false
+      })
     end
 
     try do
@@ -243,6 +302,12 @@ defmodule Jido.Tools.LuaEval do
   end
 
   defp maybe_put_max_call_depth(opts, _), do: opts
+
+  defp bytes_to_heap_words(bytes) do
+    bytes
+    |> div(:erlang.system_info(:wordsize))
+    |> max(1)
+  end
 
   defp inject_globals(lua, globals) do
     Enum.reduce(globals || %{}, lua, fn {key, value}, acc ->

--- a/lib/jido_tools/lua_eval.ex
+++ b/lib/jido_tools/lua_eval.ex
@@ -249,7 +249,7 @@ defmodule Jido.Tools.LuaEval do
     return_mode = Map.get(params, :return_mode, :list)
     enable_unsafe_libs = Map.get(params, :enable_unsafe_libs, false)
     max_call_depth = Map.get(params, :max_call_depth, 0)
-    max_heap_bytes = Map.get(params, :max_heap_bytes, 0)
+    max_heap_bytes = Map.get(params, :max_heap_bytes, @default_max_heap_bytes)
 
     if is_integer(max_heap_bytes) and max_heap_bytes > 0 do
       :erlang.process_flag(:max_heap_size, %{

--- a/test/jido_action/exec_return_shape_test.exs
+++ b/test/jido_action/exec_return_shape_test.exs
@@ -203,6 +203,27 @@ defmodule JidoTest.ExecReturnShapeTest do
       end)
     end
 
+    test "redacts sensitive values from unexpected return shape messages" do
+      defmodule SensitiveUnexpectedShapeAction do
+        use Jido.Action, name: "sensitive_unexpected_shape"
+
+        @dialyzer {:nowarn_function, run: 2}
+        def run(_params, _context) do
+          %{api_key: "api-secret", payload: String.duplicate("x", 300)}
+        end
+      end
+
+      capture_log(fn ->
+        assert {:error, %Error.ExecutionFailureError{message: message}} =
+                 Exec.run(SensitiveUnexpectedShapeAction, %{}, %{})
+
+        assert message =~ "Unexpected return shape"
+        assert message =~ "[REDACTED]"
+        assert message =~ "truncated"
+        refute message =~ "api-secret"
+      end)
+    end
+
     test "rejects integer - unexpected shape" do
       defmodule IntegerResultAction do
         use Jido.Action, name: "integer_result"

--- a/test/jido_action/exec_return_shape_test.exs
+++ b/test/jido_action/exec_return_shape_test.exs
@@ -224,6 +224,44 @@ defmodule JidoTest.ExecReturnShapeTest do
       end)
     end
 
+    test "redacts sensitive values from raw string error messages" do
+      defmodule SensitiveStringErrorAction do
+        use Jido.Action, name: "sensitive_string_error"
+
+        def run(_params, _context) do
+          {:error, "token=raw-secret " <> String.duplicate("x", 300)}
+        end
+      end
+
+      capture_log(fn ->
+        assert {:error, %Error.ExecutionFailureError{message: message}} =
+                 Exec.run(SensitiveStringErrorAction, %{}, %{})
+
+        assert message =~ "token=[REDACTED]"
+        assert message =~ "truncated"
+        refute message =~ "raw-secret"
+      end)
+    end
+
+    test "redacts sensitive values from exception messages" do
+      defmodule SensitiveExceptionMessageAction do
+        use Jido.Action, name: "sensitive_exception_message"
+
+        def run(_params, _context) do
+          raise "api_key=exception-secret " <> String.duplicate("x", 300)
+        end
+      end
+
+      capture_log(fn ->
+        assert {:error, %Error.ExecutionFailureError{message: message}} =
+                 Exec.run(SensitiveExceptionMessageAction, %{}, %{})
+
+        assert message =~ "api_key=[REDACTED]"
+        assert message =~ "truncated"
+        refute message =~ "exception-secret"
+      end)
+    end
+
     test "rejects integer - unexpected shape" do
       defmodule IntegerResultAction do
         use Jido.Action, name: "integer_result"

--- a/test/jido_action/sanitizer_test.exs
+++ b/test/jido_action/sanitizer_test.exs
@@ -101,4 +101,18 @@ defmodule Jido.Action.SanitizerTest do
              tail: %{password: "[REDACTED]"}
            }
   end
+
+  test "telemetry profile redacts sensitive assignments inside binary messages" do
+    sanitized =
+      Sanitizer.sanitize_telemetry(
+        "request failed api_key=api-secret password='hunter2' with Bearer abc.def"
+      )
+
+    assert sanitized =~ "api_key=[REDACTED]"
+    assert sanitized =~ "password=[REDACTED]"
+    assert sanitized =~ "Bearer [REDACTED]"
+    refute sanitized =~ "api-secret"
+    refute sanitized =~ "hunter2"
+    refute sanitized =~ "abc.def"
+  end
 end

--- a/test/jido_tools/files_test.exs
+++ b/test/jido_tools/files_test.exs
@@ -11,6 +11,74 @@ defmodule JidoTest.Actions.FilesTest do
     {:ok, tmp_dir: tmp_dir}
   end
 
+  describe "file root enforcement" do
+    test "resolves relative paths against the allowed root", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "data.txt")
+      File.write!(path, "safe")
+
+      assert {:ok, result} =
+               Files.ReadFile.run(%{path: "data.txt"}, %{allowed_file_roots: [tmp_dir]})
+
+      assert Path.basename(result.path) == "data.txt"
+      assert File.read!(result.path) == File.read!(path)
+      assert result.content == "safe"
+    end
+
+    test "rejects absolute paths outside allowed roots", %{tmp_dir: tmp_dir} do
+      outside = Path.join(System.tmp_dir!(), "jido_outside_#{System.unique_integer()}.txt")
+      File.write!(outside, "outside")
+      on_exit(fn -> File.rm(outside) end)
+
+      assert {:error, message} =
+               Files.ReadFile.run(%{path: outside}, %{allowed_file_roots: [tmp_dir]})
+
+      assert message =~ "outside allowed file roots"
+    end
+
+    test "rejects symlink escapes from allowed roots", %{tmp_dir: tmp_dir} do
+      outside = Path.join(System.tmp_dir!(), "jido_symlink_#{System.unique_integer()}.txt")
+      link = Path.join(tmp_dir, "link.txt")
+      File.write!(outside, "outside")
+      on_exit(fn -> File.rm(outside) end)
+
+      case File.ln_s(outside, link) do
+        :ok ->
+          assert {:error, message} =
+                   Files.ReadFile.run(%{path: "link.txt"}, %{allowed_file_roots: [tmp_dir]})
+
+          assert message =~ "outside allowed file roots"
+
+        {:error, _reason} ->
+          :ok
+      end
+    end
+
+    test "rejects parent traversal glob patterns when roots are enforced", %{tmp_dir: tmp_dir} do
+      assert {:error, message} =
+               Files.ListDirectory.run(
+                 %{path: tmp_dir, pattern: "../*.txt", recursive: true},
+                 %{allowed_file_roots: [tmp_dir]}
+               )
+
+      assert message =~ "cannot traverse parent directories"
+    end
+
+    test "checks both source and destination for copy operations", %{tmp_dir: tmp_dir} do
+      source = Path.join(tmp_dir, "source.txt")
+      outside = Path.join(System.tmp_dir!(), "jido_copy_#{System.unique_integer()}.txt")
+      File.write!(source, "copy")
+      on_exit(fn -> File.rm(outside) end)
+
+      assert {:error, message} =
+               Files.CopyFile.run(
+                 %{source: source, destination: outside},
+                 %{allowed_file_roots: [tmp_dir]}
+               )
+
+      assert message =~ "outside allowed file roots"
+    end
+  end
+
   describe "WriteFile" do
     test "writes content to a file with parent directory creation", %{tmp_dir: tmp_dir} do
       path = Path.join([tmp_dir, "subdir", "test.txt"])
@@ -226,6 +294,23 @@ defmodule JidoTest.Actions.FilesTest do
       # Cleanup: Reset permissions to allow cleanup
       File.chmod!(dir_path, 0o755)
       File.chmod!(file_path, 0o644)
+    end
+
+    test "refuses to force-delete a directory without recursive true", %{tmp_dir: tmp_dir} do
+      dir_path = Path.join(tmp_dir, "force_dir")
+      File.mkdir_p!(dir_path)
+      File.write!(Path.join(dir_path, "file.txt"), "keep")
+
+      assert {:error, message} =
+               Files.DeleteFile.run(%{path: dir_path, recursive: false, force: true}, %{})
+
+      assert message =~ "Refusing to force-delete directory"
+      assert File.exists?(Path.join(dir_path, "file.txt"))
+    end
+
+    test "refuses to recursively delete protected filesystem roots" do
+      assert {:error, message} = Files.DeleteFile.run(%{path: "/", recursive: true}, %{})
+      assert message =~ "Refusing to delete protected path"
     end
   end
 

--- a/test/jido_tools/lua_eval_supervision_test.exs
+++ b/test/jido_tools/lua_eval_supervision_test.exs
@@ -59,6 +59,31 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
       assert error.details[:reason] == %{type: :timeout, timeout_ms: 200}
     end
 
+    test "direct Lua execution applies the default heap cap" do
+      baseline_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
+      parent = self()
+
+      caller =
+        spawn(fn ->
+          send(parent, {:ready, self()})
+
+          receive do
+            :run ->
+              result = LuaEval.run(%{code: "while true do end", timeout_ms: 200}, @context)
+              send(parent, {:done, self(), result})
+          end
+        end)
+
+      assert_receive {:ready, ^caller}
+      send(caller, :run)
+      lua_pid = await_new_supervisor_child(baseline_children)
+
+      assert_default_heap_cap(lua_pid)
+
+      assert_receive {:done, ^caller, {:error, %Error.TimeoutError{} = error}}, 500
+      assert error.timeout == 200
+    end
+
     test "kills Lua worker when the caller exits before the Lua timeout" do
       baseline_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
       parent = self()
@@ -97,6 +122,34 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
 
       assert_supervisor_children_return_to(baseline_children)
     end
+  end
+
+  defp assert_default_heap_cap(pid, attempts_left \\ 20)
+
+  defp assert_default_heap_cap(pid, 0) do
+    flunk("Expected Lua worker #{inspect(pid)} to have the default max heap cap")
+  end
+
+  defp assert_default_heap_cap(pid, attempts_left) do
+    expected_size = default_heap_words()
+
+    case Process.info(pid, :max_heap_size) do
+      {:max_heap_size, %{kill: true, size: ^expected_size}} ->
+        :ok
+
+      {:max_heap_size, _max_heap_size} ->
+        Process.sleep(10)
+        assert_default_heap_cap(pid, attempts_left - 1)
+
+      nil ->
+        flunk("Lua worker #{inspect(pid)} exited before its heap cap could be inspected")
+    end
+  end
+
+  defp default_heap_words do
+    (64 * 1024 * 1024)
+    |> div(:erlang.system_info(:wordsize))
+    |> max(1)
   end
 
   defp assert_new_supervisor_child(baseline_children, attempts_left \\ 10)

--- a/test/jido_tools/lua_eval_supervision_test.exs
+++ b/test/jido_tools/lua_eval_supervision_test.exs
@@ -2,6 +2,7 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
   use ExUnit.Case, async: false
 
   alias Jido.Action.Error
+  alias Jido.Exec
   alias Jido.Tools.LuaEval
 
   @context %{}
@@ -57,6 +58,45 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
       assert error.timeout == 200
       assert error.details[:reason] == %{type: :timeout, timeout_ms: 200}
     end
+
+    test "kills Lua worker when the caller exits before the Lua timeout" do
+      baseline_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
+      parent = self()
+
+      caller =
+        spawn(fn ->
+          send(parent, {:ready, self()})
+
+          receive do
+            :run ->
+              result = LuaEval.run(%{code: "while true do end", timeout_ms: 5_000}, @context)
+              send(parent, {:done, self(), result})
+          end
+        end)
+
+      assert_receive {:ready, ^caller}
+      send(caller, :run)
+      lua_pid = await_new_supervisor_child(baseline_children)
+
+      Process.exit(caller, :kill)
+
+      refute_process_alive(lua_pid)
+      refute_receive {:done, ^caller, _result}, 100
+    end
+
+    test "Exec timeout does not leave an orphaned Lua worker" do
+      baseline_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
+
+      assert {:error, %Error.TimeoutError{}} =
+               Exec.run(
+                 LuaEval,
+                 %{code: "while true do end", timeout_ms: 5_000},
+                 %{},
+                 timeout: 50
+               )
+
+      assert_supervisor_children_return_to(baseline_children)
+    end
   end
 
   defp assert_new_supervisor_child(baseline_children, attempts_left \\ 10)
@@ -73,6 +113,64 @@ defmodule Jido.Tools.LuaEvalSupervisionTest do
     else
       Process.sleep(10)
       assert_new_supervisor_child(baseline_children, attempts_left - 1)
+    end
+  end
+
+  defp await_new_supervisor_child(baseline_children, attempts_left \\ 20)
+
+  defp await_new_supervisor_child(_baseline_children, 0) do
+    flunk("Expected a Lua task under Jido.Action.TaskSupervisor, but none was observed")
+  end
+
+  defp await_new_supervisor_child(baseline_children, attempts_left) do
+    current_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
+    new_children = MapSet.difference(current_children, baseline_children) |> MapSet.to_list()
+
+    case new_children do
+      [pid | _] ->
+        pid
+
+      [] ->
+        Process.sleep(10)
+        await_new_supervisor_child(baseline_children, attempts_left - 1)
+    end
+  end
+
+  defp refute_process_alive(pid, attempts_left \\ 20)
+
+  defp refute_process_alive(pid, 0) do
+    flunk("Expected Lua worker #{inspect(pid)} to exit")
+  end
+
+  defp refute_process_alive(pid, attempts_left) do
+    if Process.alive?(pid) do
+      Process.sleep(10)
+      refute_process_alive(pid, attempts_left - 1)
+    else
+      refute Process.alive?(pid)
+    end
+  end
+
+  defp assert_supervisor_children_return_to(baseline_children, attempts_left \\ 20)
+
+  defp assert_supervisor_children_return_to(baseline_children, 0) do
+    current_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
+
+    flunk("""
+    Expected Lua supervisor children to return to baseline.
+    Baseline: #{inspect(baseline_children)}
+    Current: #{inspect(current_children)}
+    """)
+  end
+
+  defp assert_supervisor_children_return_to(baseline_children, attempts_left) do
+    current_children = Task.Supervisor.children(Jido.Action.TaskSupervisor) |> MapSet.new()
+
+    if MapSet.equal?(current_children, baseline_children) do
+      :ok
+    else
+      Process.sleep(10)
+      assert_supervisor_children_return_to(baseline_children, attempts_left - 1)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add opt-in root capability enforcement for built-in file tools, including symlink escape checks and guarded glob traversal.
- Prevent dangerous delete behavior by refusing protected targets and blocking force-delete of directories unless recursive deletion is explicit.
- Harden LuaEval with default heap limits, deadline-aware timeouts, and watchdog cleanup when callers exit.
- Sanitize exceptional Exec error messages before returning them.

## Verification
- mix test
- mix quality
- mix deps.audit
- mix hex.audit
