### PR TITLE
fix(flow): preserve DSL formatting without parentheses

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,34 @@
 # Used by "mix format"
+# Only DSL declarations omit parentheses. Reference calls keep them.
+locals_without_parens = [
+  flow: 1,
+  step: 2,
+  choice: 2,
+  option: 2,
+  otherwise: 1,
+  map: 2,
+  reduce: 2,
+  iterate: 2,
+  state: 2,
+  dispatch: 2,
+  output: 1,
+  action: 1,
+  params: 1,
+  meta: 1,
+  condition: 1,
+  collection: 1,
+  on_error: 1,
+  initial: 1,
+  update: 1,
+  while: 1,
+  repeat: 1,
+  max_iterations: 1,
+  decision: 1,
+  expander: 1
+]
+
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens]
 ]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ def deps do
 end
 ```
 
+To keep Flow DSL declarations without parentheses, add `:jido_action` to
+`import_deps` in your project's `.formatter.exs`:
+
+```elixir
+[
+  import_deps: [:jido_action],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]
+```
+
+Keep your existing formatter options and imported dependencies. No formatter
+plugin is required. See [Flow Modules](guides/flow-modules.md#format-the-dsl).
+
 ## Define An Action
 
 ```elixir

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -27,6 +27,26 @@ end
 The DSL validates syntax, Flow structure, reference scope, graph cycles, and
 target contracts during compilation. Compile errors use DSL source locations.
 
+## Format The DSL
+
+Add `:jido_action` to the `import_deps` list in your project's `.formatter.exs`.
+Keep all existing formatter options and imported dependencies.
+
+```elixir
+[
+  import_deps: [:jido_action],
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]
+```
+
+The package exports `locals_without_parens` for Flow declarations and block
+fields. Standard `mix format` then keeps forms such as `step "greet", ...`
+and `output result("greet")`. No formatter plugin is required.
+
+Reference calls such as `input(:name)`, `result("greet")`, and `state(:count)`
+keep their parentheses. The formatter also preserves explicit parentheses on
+declarations. Remove those parentheses once if you want the form shown above.
+
 ## Generated API
 
 A Flow module exposes the Action-compatible and Flow-specific functions that

--- a/mix.exs
+++ b/mix.exs
@@ -227,6 +227,7 @@ defmodule JidoAction.MixProject do
       files: [
         "lib",
         "guides",
+        ".formatter.exs",
         "mix.exs",
         "README.md",
         "CHANGELOG.md",

--- a/test/jido_flow/dsl/formatter_test.exs
+++ b/test/jido_flow/dsl/formatter_test.exs
@@ -1,0 +1,127 @@
+defmodule Jido.Flow.DSL.FormatterTest do
+  use ExUnit.Case, async: true
+
+  @package_root Path.expand("../../..", __DIR__)
+  @formatter_path Path.join(@package_root, ".formatter.exs")
+
+  @keyword_flow """
+  defmodule FeedbackFlow do
+    use Jido.Flow, name: "feedback"
+
+    flow do
+      step "validate",
+        action: Jido.Examples.FeedbackSummarizer.ValidateBatch,
+        params: %{comments: input(:comments), summarizer: input(:summarizer)},
+        after: ["start"]
+
+      map "clean",
+        collection: result("validate", :comments),
+        action: Jido.Examples.FeedbackSummarizer.CleanComment,
+        params: %{comment: item()}
+
+      reduce "combined",
+        collection: result("clean"),
+        initial: %{},
+        action: Merge,
+        params: accumulator()
+
+      dispatch "next", decision: Decide, expander: Expand, params: result("combined")
+      output result("next")
+    end
+  end
+  """
+
+  @block_flow """
+  flow do
+    step "load" do
+      action Load
+      params %{value: input(:value), context: context()}
+      meta %{owner: "example"}
+    end
+
+    choice "route" do
+      option "match", condition: input(:kind) == :match, action: Match, params: %{}
+
+      option "other" do
+        condition input(:kind) == :other
+        action Other
+        params %{}
+      end
+
+      otherwise action: Default, params: %{}
+    end
+
+    map "items" do
+      collection input(:items)
+      action Clean
+      params %{item: item(:value)}
+      on_error :collect_errors
+    end
+
+    iterate "loop" do
+      state [], initial: %{count: 0}
+      action Increment
+      params %{count: state(:count)}
+      update %{count: body_result(:count)}
+      while state(:count) < 3
+      max_iterations 3
+    end
+
+    iterate "fixed" do
+      state [] do
+        initial %{count: 0}
+      end
+
+      action Increment
+      params state()
+      repeat 3
+    end
+
+    dispatch "next" do
+      decision Decide
+      expander Expand
+      params result("fixed")
+    end
+
+    output result("next")
+  end
+  """
+
+  test "the project formatter preserves keyword and block declarations without parentheses" do
+    {formatter, _opts} =
+      Mix.Tasks.Format.formatter_for_file("flow.ex", dot_formatter: @formatter_path)
+
+    for source <- [@keyword_flow, @block_flow] do
+      assert formatter.(source) == source
+      assert formatter.(formatter.(source)) == source
+    end
+  end
+
+  @tag :tmp_dir
+  test "a consumer imports the same rules from jido_action", %{tmp_dir: tmp_dir} do
+    consumer_formatter = Path.join(tmp_dir, ".formatter.exs")
+    File.write!(consumer_formatter, "[import_deps: [:jido_action]]\n")
+
+    {formatter, _opts} =
+      Mix.Tasks.Format.formatter_for_file("flow.ex",
+        dot_formatter: consumer_formatter,
+        deps_paths: %{jido_action: @package_root}
+      )
+
+    for source <- [@keyword_flow, @block_flow] do
+      assert formatter.(source) == source
+    end
+  end
+
+  test "the Hex package includes the exported formatter configuration" do
+    assert ".formatter.exs" in Mix.Project.config()[:package][:files]
+  end
+
+  test "reference calls and explicit parentheses stay unchanged" do
+    {formatter, _opts} =
+      Mix.Tasks.Format.formatter_for_file("flow.ex", dot_formatter: @formatter_path)
+
+    source = "step(1)\nstate(:count)\noutput(result(\"value\"))\nEnum.map(items, fun)\n"
+    assert formatter.(source) == source
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -60,6 +60,8 @@ Use `jido_action` for validated work and data-first composition:
 
 - Use the compile-time `Jido.Flow` DSL as the primary developer authoring
   surface.
+- Add `:jido_action` to `.formatter.exs` `import_deps` to keep DSL declarations
+  without parentheses. No formatter plugin is required.
 - Give every component a stable string name.
 - Use `step`, `choice`, `map`, `reduce`, `iterate`, and `dispatch` for graph
   structure.


### PR DESCRIPTION
## Description

The v3 Flow DSL can now keep declarations such as `step "validate", ...` and `output result("verify")` without parentheses when `mix format` runs. Consuming projects enable the exported rules with `import_deps: [:jido_action]`; no formatter plugin is required.

The Hex package includes the formatter configuration. Reference calls and explicit parentheses stay unchanged. This pull request targets `release/v3`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None. Existing parentheses are preserved. Remove them once to use declarations without parentheses.

## Testing

- [x] Tests pass (`mix test`): 421 passed.
- [x] Quality checks pass (`mix quality`), including Dialyzer and documentation checks.
- `mix test --cover --warnings-as-errors`: 421 passed; 93.92% coverage.
- `mix deps.audit`: no vulnerabilities found.

The regression tests verify project formatting, consumer imports, repeat formatting, package configuration, and unchanged reference calls. The tests failed for the expected reasons before the fix.

Correctness, test, and project-standards reviews found no issues. The additional Claude review produced no result because authentication failed in its execution context.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791074621&installation_model_id=434874&pr_number=213&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F213&signature=63805709510e2b62e4596fd229a9e12dad614b64b5a0b42726b196da027c74af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->