### PR TITLE
feat(flow): support inline step bodies and compiled target reuse

### DIFF
--- a/.doctor.exs
+++ b/.doctor.exs
@@ -1,4 +1,8 @@
 %Doctor.Config{
+  # Doctor 0.23.0 counts quoted Action and owner definitions as compiler exports.
+  # InlineStepTest checks this module's actual BEAM docs and specs instead.
+  # This exception does not change runtime test coverage or its threshold.
+  ignore_modules: [Jido.Flow.DSL.InlineStepCompiler],
   min_module_doc_coverage: 100,
   min_module_spec_coverage: 100,
   min_overall_doc_coverage: 100,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -3,6 +3,9 @@
 locals_without_parens = [
   flow: 1,
   step: 2,
+  step: 3,
+  step: 4,
+  step: 5,
   choice: 2,
   option: 2,
   otherwise: 1,

--- a/README.md
+++ b/README.md
@@ -245,6 +245,42 @@ Map and Reduce collections, bounded Iterate components with State, independent
 components that can run in parallel, one Dispatch at the end of a Flow, and a
 step-wise execution API.
 
+### Use Inline Steps For Small Operations
+
+The unreleased v3 source also supports inline Step bodies. This form is not
+included in `3.0.0-beta.4`; use a source checkout that contains the feature.
+
+```elixir
+defmodule MyApp.Flows.SimpleGreeting do
+  use Jido.Flow,
+    name: "simple_greeting",
+    schema: Zoi.object(%{name: Zoi.string()}),
+    output_schema: Zoi.object(%{message: Zoi.string()})
+
+  flow do
+    step "normalize", name <- input(:name) do
+      {:ok, %{name: String.trim(name)}}
+    end
+
+    step "greet", name <- result("normalize", :name) do
+      {:ok, %{message: "Hello, " <> name <> "!"}}
+    end
+
+    output result("greet")
+  end
+end
+
+{:ok, %{message: "Hello, Ada!"}} =
+  Jido.Exec.run(MyApp.Flows.SimpleGreeting, %{name: " Ada "})
+```
+
+Binding sources use Flow data expressions. Bodies use normal Elixir and
+compile to ordinary Actions. This version supports inline `step` bodies only.
+Use a named Action when a step needs field schemas or validation hooks.
+Use `MyApp.Flows.SimpleGreeting.step_action("greet")` to reuse its target in
+Builder or a trusted Registry. Neither Builder nor JSON accepts body code,
+closures, or MFAs. See [Build Your First Flow](guides/build-your-first-flow.livemd).
+
 ## Build A Flow At Runtime
 
 Use `Jido.Flow.Builder` when runtime data defines the graph. Each node has an

--- a/guides/actions.md
+++ b/guides/actions.md
@@ -30,6 +30,35 @@ end
 
 The module must implement `run/2`.
 
+## Use An Inline Step For Small Local Work
+
+A Flow module can define a small Step body without a separate Action module:
+
+```elixir
+defmodule ActionGuide.Greeting do
+  use Jido.Flow, name: "inline_greeting"
+
+  flow do
+    step "greet", name <- input(:name) do
+      {:ok, %{message: "Hello, " <> name <> "!"}}
+    end
+
+    output result("greet")
+  end
+end
+```
+
+This unreleased v3 feature compiles the body to an ordinary Action. It does
+not add inline methods to `use Jido.Action` or function/MFA executable targets.
+The Action has empty field schemas, with the normal map input and output
+boundary. Exec still owns validation, errors, timeouts, and telemetry.
+
+Keep a named Action when work needs field schemas, validation hooks, its own
+description, or a public API independent of the Flow. Use
+`ActionGuide.Greeting.step_action("greet")` when you only need to reuse the
+compiled target. See [Build Your First Flow](build-your-first-flow.livemd) for
+the complete inline example and named-Action extraction.
+
 ## Callback Results
 
 An Action callback returns one of five shapes:

--- a/guides/build-your-first-flow.livemd
+++ b/guides/build-your-first-flow.livemd
@@ -7,45 +7,20 @@ Run the cells from top to bottom.
 
 ## Install The Package
 
-```elixir
-Mix.install([{:jido_action, "~> 3.0.0-beta.4"}])
-```
-
-## Define The Actions
-
-Keep transformation logic in Actions. Keep the Flow focused on data movement
-and dependencies.
+Inline Steps are an unreleased v3 feature. Use a local source checkout that
+contains this feature; version `3.0.0-beta.4` does not include it. Set
+`JIDO_ACTION_PATH` in the Livebook runtime environment to that checkout's
+absolute path before you run this cell.
 
 ```elixir
-defmodule FirstFlow.NormalizeName do
-  use Jido.Action,
-    name: "normalize_name",
-    schema: Zoi.object(%{name: Zoi.string()}),
-    output_schema: Zoi.object(%{name: Zoi.string()})
-
-  @impl true
-  def run(%{name: name}, _context) do
-    {:ok, %{name: name |> String.trim() |> String.capitalize()}}
-  end
-end
-
-defmodule FirstFlow.Greet do
-  use Jido.Action,
-    name: "greet",
-    schema: Zoi.object(%{name: Zoi.string()}),
-    output_schema: Zoi.object(%{message: Zoi.string()})
-
-  @impl true
-  def run(%{name: name}, _context) do
-    {:ok, %{message: "Hello, " <> name <> "!"}}
-  end
-end
+Mix.install([{:jido_action, path: System.fetch_env!("JIDO_ACTION_PATH")}])
 ```
 
 ## Define The Flow
 
 `input/1` reads Flow input. `result/2` reads a prior component result. The
-result reference creates the dependency between the two Steps.
+result reference creates the dependency between the two Steps. Each `<-`
+binds that data to a variable in the Step body.
 
 ```elixir
 defmodule FirstFlow.Greeting do
@@ -56,13 +31,13 @@ defmodule FirstFlow.Greeting do
     output_schema: Zoi.object(%{message: Zoi.string()})
 
   flow do
-    step "normalize",
-      action: FirstFlow.NormalizeName,
-      params: %{name: input(:name)}
+    step "normalize", name <- input(:name) do
+      {:ok, %{name: name |> String.trim() |> String.capitalize()}}
+    end
 
-    step "greet",
-      action: FirstFlow.Greet,
-      params: %{name: result("normalize", :name)}
+    step "greet", name <- result("normalize", :name) do
+      {:ok, %{message: "Hello, " <> name <> "!"}}
+    end
 
     output result("greet")
   end
@@ -70,7 +45,8 @@ end
 ```
 
 Source order does not create a dependency. References and `after:` create
-dependencies.
+dependencies. The body is normal Elixir code. Jido compiles it to an ordinary
+Action; you do not need a separate Action module for each small operation.
 
 ## Inspect And Run
 
@@ -93,8 +69,42 @@ Run the module or the canonical value.
   Jido.Exec.run(flow, %{name: "grace"})
 ```
 
+## Extract A Named Action When Needed
+
+The Flow schemas above validate its input and output. Inline Actions have no
+field schemas. Extract a named Action when a step needs its own schemas,
+validation hooks, description, or an independent public API.
+
+```elixir
+defmodule FirstFlow.CreateGreeting do
+  use Jido.Action,
+    name: "create_greeting",
+    description: "Creates one greeting",
+    schema: Zoi.object(%{name: Zoi.string()}),
+    output_schema: Zoi.object(%{message: Zoi.string()})
+
+  @impl true
+  def run(%{name: name}, _context) do
+    {:ok, %{message: "Hello, " <> name <> "!"}}
+  end
+end
+
+{:ok, %{message: "Hello, Ada!"}} =
+  Jido.Exec.run(FirstFlow.CreateGreeting, %{name: "Ada"})
+```
+
+In a Flow, replace the inline `greet` declaration with the existing Action
+form:
+
+```text
+step "greet",
+  action: FirstFlow.CreateGreeting,
+  params: %{name: result("normalize", :name)}
+```
+
 ## Next
 
 Use [Flow DSL](flow-language.livemd) for the complete language. Use
 [Executing Flows](flow-execution.livemd) for run-to-completion and step-wise
-execution.
+execution. [Direct Construction And Builder](flow-builder.md#reuse-an-inline-step)
+shows how to reuse the compiled body without extracting an Action.

--- a/guides/continuations.md
+++ b/guides/continuations.md
@@ -68,6 +68,30 @@ These rules apply:
 Dispatch chooses the Flow result or the next executable. It does not change the
 Flow graph.
 
+## Return Extras After A Flow
+
+When the caller needs Action extras after Flow work, a terminal Dispatch can
+continue to a final Action. Its expander returns:
+
+```elixir
+{:continue, final_input, MyApp.Finalize}
+```
+
+`MyApp.Finalize` can then return `{:ok, result, extras}`. The complete Exec call
+returns that tuple to its caller. This works with `run/4` and `run_async/4`.
+The same context, complete-call timeout, and continuation budget apply. No
+nested Exec call is needed.
+
+The final Action owns input and output validation. The original Flow's output
+schema does not validate the continued Action's result. Extras from earlier
+Steps are still discarded. If the expander returns `{:ok, result, extras}`
+instead of a continuation, its extras are also discarded as a Flow node result.
+
+This pattern can return Directives to a higher-level runtime that supports
+them. It does not collect or execute Directives inside Steps. That runtime
+must validate the Directives and control their execution. The existing
+Dispatch limits still apply: no step-wise execution or Subflow use.
+
 ## Example: an LLM Tool Loop
 
 Use continuation when the result of the current work tells you what must run

--- a/guides/execution.md
+++ b/guides/execution.md
@@ -32,7 +32,18 @@ A successful direct Action or Action Instruction returns:
 {:ok, result, extras}
 ```
 
-A successful Flow returns `{:ok, result}`. Flow nodes discard Action extras.
+A Flow that finishes normally returns `{:ok, result}`. Flow nodes discard
+Action extras. This includes explicit Steps, inline Steps, and the final Step,
+in both run-to-completion and step-wise execution.
+
+Extras are values for the caller. Jido Action and Exec do not interpret or
+dispatch Actor Directives. If a higher-level runtime uses Action extras as
+Directives, moving that Action into a Flow does not preserve their delivery.
+
+A terminal Dispatch can continue to a final Action. That Action can return
+extras to the caller of the complete Exec call. This does not collect extras
+from earlier nodes. See
+[Return Extras After A Flow](continuations.md#return-extras-after-a-flow).
 
 Public failures are exception structs. Action boundary errors use:
 

--- a/guides/flow-builder.md
+++ b/guides/flow-builder.md
@@ -62,6 +62,65 @@ builder =
 Builder keeps the first construction error. Each add function returns the
 Builder. `build/1` returns that error or validates the complete Flow.
 
+## Reuse An Inline Step
+
+First run the module definition in [Build Your First Flow](build-your-first-flow.livemd).
+Then look up its compiled targets. No generated module name is needed.
+
+```elixir
+alias Jido.Flow.Builder
+
+builder =
+  Builder.new(
+    name: FirstFlow.Greeting.name(),
+    description: FirstFlow.Greeting.description(),
+    schema: FirstFlow.Greeting.schema(),
+    output_schema: FirstFlow.Greeting.output_schema()
+  )
+  |> Builder.step(
+    "normalize",
+    FirstFlow.Greeting.step_action("normalize"),
+    %{name: Builder.input(:name)}
+  )
+  |> Builder.step(
+    "greet",
+    FirstFlow.Greeting.step_action(:greet),
+    %{name: Builder.result("normalize", :name)}
+  )
+  |> Builder.output(Builder.result("greet"))
+
+{:ok, built_flow} = Builder.build(builder)
+true = built_flow == FirstFlow.Greeting.flow()
+{:ok, %{message: "Hello, Ada!"}} = Jido.Exec.run(built_flow, %{name: " Ada "})
+```
+
+This rebuilds the same graph. You can instead supply different parameters,
+dependencies, and metadata. `step_action/1` returns only an Action target; it
+does not copy the original Step's fields. Named bindings require a parameter
+map with those atom keys. A sole map-pattern binding receives the complete
+source map. A no-input Step receives `%{}`.
+
+The target is an ordinary Action, so an existing Map can also reuse it:
+
+```elixir
+{:ok, names_flow} =
+  Builder.new(name: "normalize_names")
+  |> Builder.map(
+    "names",
+    Builder.input(:people),
+    FirstFlow.Greeting.step_action("normalize"),
+    %{name: Builder.item()}
+  )
+  |> Builder.output(%{names: Builder.result("names")})
+  |> Builder.build()
+
+{:ok, %{names: [%{name: "Ada"}, %{name: "Grace"}]}} =
+  Jido.Exec.run(names_flow, %{people: [" ada ", " grace "]})
+```
+
+This is Action reuse, not an inline Map body. Builder and direct constructors
+do not accept body code, anonymous functions, or MFAs as targets.
+
 ## Builder Functions
 
 Builder provides component functions:

--- a/guides/flow-language.livemd
+++ b/guides/flow-language.livemd
@@ -1,14 +1,19 @@
 # Flow DSL
 
-The Flow DSL is compile-time Elixir syntax for canonical Flow data. It is not
-general Elixir code. Put executable work in Actions.
+The Flow DSL is compile-time Elixir syntax for canonical Flow data. Its data
+expressions are restricted. An inline `step` body is normal Elixir code that
+compiles to an Action.
 
 Run the cells from top to bottom.
 
 ## Install The Package
 
+Inline Steps are an unreleased v3 feature, not part of `3.0.0-beta.4`. Set
+`JIDO_ACTION_PATH` in the Livebook runtime environment to the absolute path
+of a local source checkout that contains this feature.
+
 ```elixir
-Mix.install([{:jido_action, "~> 3.0.0-beta.4"}])
+Mix.install([{:jido_action, path: System.fetch_env!("JIDO_ACTION_PATH")}])
 ```
 
 ## Define Small Actions
@@ -50,9 +55,9 @@ defmodule FlowLanguage.Example do
   use Jido.Flow, name: "flow_language_example"
 
   flow do
-    step "seed",
-      action: FlowLanguage.Echo,
-      params: %{value: input(:value)}
+    step "seed", value <- input(:value) do
+      {:ok, %{value: value}}
+    end
 
     choice "route" do
       option "fast",
@@ -109,9 +114,9 @@ end
 result
 ```
 
-## Use Only Data Expressions
+## Keep Headers And Output As Data
 
-A Flow expression can contain:
+A Flow expression, including each inline binding source, can contain:
 
 - `nil`, Boolean values, numbers, strings, and atoms;
 - proper lists;
@@ -133,6 +138,21 @@ struct construction
 Use `value/1` when you want to mark one supported literal explicitly. Use
 `select/2` to append a path to a reference. The Reduce example uses
 `value([])` to mark its empty-list accumulator as literal data.
+
+These restrictions do not apply inside an inline Step body. It can call
+functions, use pipes, match patterns, and create local anonymous functions.
+Those functions are not Flow targets. Flow reference helpers have no runtime
+meaning in the body; bind their data in the header first. See
+[Steps And Output](flow-steps.livemd#write-an-inline-body) for the binding forms.
+
+An inline body has the owning Flow module's function scope. It can use private
+helpers, aliases, available imports, declaration-time module attributes, and
+`__MODULE__`. It does not capture runtime variables outside the Step. Jido
+removes its declaration imports inside the body. Spark can also remove an
+outer import that conflicts with a DSL name. Use a qualified call such as
+`MyApp.Helpers.output(value)`, or import that helper inside the body.
+
+Only `step` has this body form. Other components keep their Action fields.
 
 ## Use Closed Conditions
 

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -91,6 +91,33 @@ after its Flow module has compiled, not from that module's unfinished `flow`
 block. See [Builder reuse](flow-builder.md#reuse-an-inline-step) and
 [JSON storage](flow-storage.md#store-a-compiled-inline-step).
 
+Context bindings are also Step parameters. For example, `ctx <- context()`
+puts the Flow context in the generated Action's `:ctx` parameter. If you call
+that Action directly, supply `:ctx` in its input map. Passing only the Exec
+context does not recreate the binding. Reuse through a new Step also needs an
+explicit context reference in that Step's parameters.
+
+## Convert An Action To An Inline Step
+
+Inline Steps reduce source code for small transformations. They do not infer
+field types or defaults from the bindings. A generated Action has empty input
+and output schemas. It does not inherit the owning Flow's schemas or the
+validation hooks of an Action that it replaces.
+
+Keep a named Action when callers need field validation, defaults, output
+validation, custom hooks, or a separate public API. Keep it when a tool or
+router needs to derive named arguments from its schema. Inline binding names
+do not provide that schema.
+
+The owning Flow still validates its input and final output. Those schemas do
+not validate each intermediate Step result. Calling an extracted target with
+`step_action/1` also bypasses the owning Flow's validation and defaults. A
+missing binding can then fail as a function-clause error during execution.
+
+Moving a direct Action call into a Flow also changes how its return extras
+reach the caller. This rule applies to explicit and inline Steps. See
+[Results And Errors](execution.md#results-and-errors).
+
 ## Source Metadata
 
 The compiler stores file, line, and available column data in a source map

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -14,10 +14,9 @@ defmodule MyApp.Flows.Greeting do
     output_schema: Zoi.object(%{message: Zoi.string()})
 
   flow do
-    step "greet",
-      action: MyApp.Actions.CreateGreeting,
-      params: %{name: input(:name)},
-      meta: %{owner: "communications"}
+    step "greet", name <- input(:name), meta: %{owner: "communications"} do
+      {:ok, %{message: "Hello, " <> name <> "!"}}
+    end
 
     output result("greet")
   end
@@ -26,6 +25,11 @@ end
 
 The DSL validates syntax, Flow structure, reference scope, graph cycles, and
 target contracts during compilation. Compile errors use DSL source locations.
+This inline form needs the unreleased v3 source, not `3.0.0-beta.4`.
+
+An inline body becomes an ordinary Action. The Flow owns the body, so it can
+call the module's private helpers. Headers use data expressions; the body is
+normal Elixir. See [Steps And Output](flow-steps.livemd) for the full syntax.
 
 ## Format The DSL
 
@@ -61,6 +65,7 @@ MyApp.Flows.Greeting.validate_params(%{name: "Ada"})
 MyApp.Flows.Greeting.validate_output(%{message: "Hello"})
 MyApp.Flows.Greeting.flow()
 MyApp.Flows.Greeting.compiled()
+MyApp.Flows.Greeting.step_action("greet")
 MyApp.Flows.Greeting.run(%{name: "Ada"}, %{})
 ```
 
@@ -73,11 +78,39 @@ Runic workflow and the source map. It is not a storage format.
 `run/2` delegates to `Jido.Exec.run/4` with default options. Use `Jido.Exec`
 directly when you need runtime options.
 
+## Reuse A Step Target
+
+`step_action/1` returns the Action module for an inline or explicit
+Action-backed Step. It accepts an atom or string name. Invalid or unknown
+names and non-Step components, including Subflows, raise `ArgumentError`.
+Lookup does not execute the body or create atoms.
+
+The helper returns only the target. It does not copy the Step's parameters,
+`after`, or `meta`. Supply those fields for the new graph. Call the helper
+after its Flow module has compiled, not from that module's unfinished `flow`
+block. See [Builder reuse](flow-builder.md#reuse-an-inline-step) and
+[JSON storage](flow-storage.md#store-a-compiled-inline-step).
+
 ## Source Metadata
 
 The compiler stores file, line, and available column data in a source map
 outside the canonical Flow value. Component `meta` remains portable author
 data. This separation keeps direct, Builder, DSL, and Codec values equal.
+
+Inline body warnings and errors retain source locations. Runtime stacktraces
+include the body in its owning Flow module. Do not depend on the generated
+function or Action module names; they are internal.
+
+## Deploy Inline Steps
+
+Normal source compilation writes the owner and generated Action BEAM files.
+Deploy them together in the same application build. Lookup, Flow inspection,
+Codec operations, and execution do not compile stored code.
+
+The target identity depends on the owner module and Step name, not the body.
+A body-only edit can keep the same semantic Flow identity. That identity
+describes graph data, not a code version or a durable code snapshot. Use an
+application release version when you need to identify deployed behavior.
 
 ## Use The Flow Facade
 

--- a/guides/flow-steps.livemd
+++ b/guides/flow-steps.livemd
@@ -7,9 +7,91 @@ Run the cells from top to bottom.
 
 ## Install The Package
 
+Inline Steps are an unreleased v3 feature, not part of `3.0.0-beta.4`. Set
+`JIDO_ACTION_PATH` in the Livebook runtime environment to the absolute path
+of a local source checkout that contains this feature.
+
 ```elixir
-Mix.install([{:jido_action, "~> 3.0.0-beta.4"}])
+Mix.install([{:jido_action, path: System.fetch_env!("JIDO_ACTION_PATH")}])
 ```
+
+## Write An Inline Body
+
+Bind Flow data in the header. Write normal Elixir in the body and return an
+Action result. This example shows one binding, two bindings, a binding list,
+a sole map pattern, and the explicit no-input form `[]`.
+
+```elixir
+defmodule FlowSteps.Inline do
+  use Jido.Flow, name: "inline_steps"
+
+  flow do
+    step "ready", [] do
+      {:ok, %{ready: true}}
+    end
+
+    step "normalize", name <- input(:name), after: "ready", meta: %{owner: "guide"} do
+      {:ok, %{name: String.trim(name)}}
+    end
+
+    step "greet", name <- result("normalize", :name), prefix <- context(:prefix) do
+      {:ok, %{message: prefix <> ", " <> name <> "!"}}
+    end
+
+    step "label", [name <- result("normalize", :name), city <- input(:city), ctx <- context()] do
+      {:ok, %{label: name <> " / " <> city, language: ctx.language}}
+    end
+
+    step "profile", %{name: name, active: true} <- input(:profile) do
+      {:ok, %{name: name}}
+    end
+
+    output(%{
+      greeting: result("greet", :message),
+      label: result("label"),
+      profile: result("profile")
+    })
+  end
+end
+
+{:ok,
+ %{
+   greeting: "Hello, Ada!",
+   label: %{label: "Ada / London", language: "en"},
+   profile: %{name: "Ada"}
+ }} =
+  Jido.Exec.run(
+    FlowSteps.Inline,
+    %{name: " Ada ", city: "London", profile: %{name: "Ada", active: true}},
+    %{prefix: "Hello", language: "en"}
+  )
+```
+
+Named bindings create an atom-keyed parameter map. For example,
+`name <- input(:name)` supplies `%{name: ...}` to the compiled Action. A sole
+map pattern receives its source as the complete parameter map. `[]` supplies
+`%{}`. This mapping also applies when you reuse the Action in Builder.
+
+Only `after:` and `meta:` are inline header options. Use a list for more than
+two named bindings. Do not mix map patterns with named bindings or use more
+than one map pattern. Duplicate names, bare `_`, pins, header guards, and
+top-level struct patterns are not supported. Bind a value by name and match
+inside the body when you need a more complex pattern.
+
+The right side of `<-` uses the restricted Flow expression grammar. It cannot
+call application functions or read another binding variable. Put those
+operations in the body. Read context with an explicit binding such as
+`ctx <- context()`; there is no implicit context variable.
+
+Inline Actions use empty field schemas. Exec still requires map-shaped
+parameters and a map success result, unless you use `Jido.Action.Output`.
+A pattern mismatch becomes a structured execution failure. It is not field
+schema validation. A missing reference fails before the body runs.
+
+Use a named Action for field schemas or validation hooks. Both forms use the
+same Exec errors, telemetry, timeout, concurrency, and lifecycle rules. A
+normal Step cannot return a continuation. Inline bodies are supported only
+for `step`, not Choice, Map, Reduce, Iterate, or Dispatch.
 
 ## Define An Action
 
@@ -24,7 +106,7 @@ end
 
 ## Use Short Or Block Form
 
-Both forms lower to `Jido.Flow.Step`.
+The inline, short, and field-block forms all lower to `Jido.Flow.Step`.
 
 ```elixir
 defmodule FlowSteps.Example do

--- a/guides/flow-storage.md
+++ b/guides/flow-storage.md
@@ -79,6 +79,66 @@ and `output`.
 The exact component and expression fields are owned by Codec. Do not hand-edit
 a semantic `Jido.Flow.to_map/1` result into a stored document.
 
+## Store A Compiled Inline Step
+
+First define `FirstFlow.Greeting` from [Build Your First Flow](build-your-first-flow.livemd).
+The host registers its compiled Actions under application-owned identifiers.
+Named binding keys, such as `:name`, also need atom identifiers.
+
+```elixir
+registry =
+  Jido.Flow.Registry.new!(%{
+    "actions/greeting/normalize/v1" => {:action, FirstFlow.Greeting.step_action("normalize")},
+    "actions/greeting/greet/v1" => {:action, FirstFlow.Greeting.step_action("greet")},
+    "schemas/greeting/input/v1" => {:schema, FirstFlow.Greeting.schema()},
+    "schemas/greeting/output/v1" => {:schema, FirstFlow.Greeting.output_schema()},
+    "atoms/name" => {:atom, :name}
+  })
+
+flow = FirstFlow.Greeting.flow()
+{:ok, document} = Jido.Flow.Codec.encode(flow, registry)
+json = JSON.encode!(document)
+{:ok, restored} = Jido.Flow.Codec.decode(JSON.decode!(json), registry)
+
+true = restored == flow
+{:ok, %{message: "Hello, Ada!"}} = Jido.Exec.run(restored, %{name: " Ada "})
+```
+
+This example uses Elixir's built-in `JSON` module. No new stored format is
+needed. The encoded Steps still contain only these version 1 fields:
+
+```elixir
+%{"type" => "jido.flow", "version" => 1} = document
+[normalize, greet] = document["components"]
+"actions/greeting/greet/v1" = greet["action"]
+["action", "after", "kind", "meta", "name", "params"] = Enum.sort(Map.keys(greet))
+
+%{
+  "$type" => "map",
+  "entries" => [
+    %{
+      "key" => %{"$type" => "atom", "id" => "atoms/name"},
+      "value" => %{
+        "$ref" => %{
+          "source" => "input",
+          "component" => nil,
+          "path" => [%{"$type" => "atom", "id" => "atoms/name"}]
+        }
+      }
+    }
+  ]
+} = normalize["params"]
+```
+
+Stored JSON selects trusted deployed Actions. It cannot define a body, carry
+a closure or MFA, or evaluate Elixir. Deploy both the owning Flow module and
+its generated Actions. Keep identifiers under host control; do not store the
+internal generated module name as the public Action identifier.
+
+A body change can retain the same target and semantic graph identity. Neither
+the stored document nor its graph identity is a code snapshot. Select the
+application release and Registry version needed to run stored work.
+
 ## Validation And Limits
 
 Decode first checks the stored grammar and resource limits. It rejects:

--- a/lib/jido_flow.ex
+++ b/lib/jido_flow.ex
@@ -30,6 +30,39 @@ defmodule Jido.Flow do
         end
       end
 
+  For a small operation, bind data and write an inline Step body:
+
+      defmodule MyApp.Greeting do
+        use Jido.Flow, name: "greeting"
+
+        flow do
+          step "greet", name <- input(:name) do
+            {:ok, %{message: "Hello, " <> name <> "!"}}
+          end
+
+          output result("greet")
+        end
+      end
+
+  The binding source uses the Flow expression grammar. The body is normal
+  Elixir in the owning module's function scope. Use `ctx <- context()` to
+  bind context explicitly. Use a binding list for more than two inputs, a
+  sole map pattern for complete params, or `[]` for no input. Only `after:`
+  and `meta:` are inline options.
+
+  Inline bodies compile to ordinary Actions with empty field schemas and the
+  normal Exec validation and result rules. Extract a named Action for field
+  schemas or validation hooks. Only `step` supports inline bodies.
+
+  After the owner compiles, `MyApp.Greeting.step_action("greet")` returns its
+  Action target for Builder, direct construction, or trusted Registry reuse.
+  It does not copy parameters, dependencies, or metadata. Builder and stored
+  JSON do not accept body code, anonymous functions, or MFA targets.
+
+  Deploy the owning module and generated Action BEAM files together. A body
+  edit can retain the same target and semantic graph identity; graph identity
+  does not identify a deployed code version.
+
   Result references create data dependencies. `after:` keeps only explicit
   author control order. Source order does not create a dependency. The Spark
   compiler keeps source locations outside the canonical Flow value.

--- a/lib/jido_flow/dsl/inline_step.ex
+++ b/lib/jido_flow/dsl/inline_step.ex
@@ -186,6 +186,7 @@ defmodule Jido.Flow.DSL.InlineStep do
   defp normalize_literal({form, metadata, args}) when is_list(metadata), do: {form, [], args}
   defp normalize_literal(value), do: value
 
+  @spec error!(term(), Macro.Env.t(), String.t()) :: no_return()
   defp error!({_form, metadata, _args}, caller, description) when is_list(metadata) do
     caller = %{caller | line: Keyword.get(metadata, :line, caller.line)}
     MacroSupport.compile_error!(caller, description)

--- a/lib/jido_flow/dsl/inline_step.ex
+++ b/lib/jido_flow/dsl/inline_step.ex
@@ -1,0 +1,198 @@
+defmodule Jido.Flow.DSL.InlineStep do
+  @moduledoc false
+
+  alias Jido.Flow.DSL.{Expression, MacroSupport}
+
+  @enforce_keys [:params_ast, :pattern_ast, :body_ast, :options, :source]
+  defstruct @enforce_keys
+
+  @typedoc false
+  @type t :: %__MODULE__{
+          params_ast: Macro.t(),
+          pattern_ast: Macro.t(),
+          body_ast: Macro.t(),
+          options: keyword(),
+          source: %{file: String.t(), line: pos_integer()}
+        }
+
+  @doc false
+  @spec parse!(Macro.t(), term(), Macro.Env.t()) :: t()
+  def parse!(bindings, options, caller) do
+    bindings = if is_list(bindings), do: bindings, else: [bindings]
+    parse_bindings!(bindings, options, caller)
+  end
+
+  @doc false
+  @spec parse!(Macro.t(), Macro.t(), term(), Macro.Env.t()) :: t()
+  def parse!(bindings, options, body_options, caller) when is_list(options) do
+    parse!(bindings, merge_options!(options, body_options, caller), caller)
+  end
+
+  def parse!(left, right, options, caller) do
+    parse_bindings!([left, right], options, caller)
+  end
+
+  @doc false
+  @spec parse!(Macro.t(), Macro.t(), term(), term(), Macro.Env.t()) :: t()
+  def parse!(left, right, options, body_options, caller) do
+    parse_bindings!([left, right], merge_options!(options, body_options, caller), caller)
+  end
+
+  defp parse_bindings!(bindings, options, caller) do
+    validate_options!(options, caller)
+
+    body =
+      case Keyword.fetch(options, :do) do
+        {:ok, body} -> body
+        :error -> MacroSupport.compile_error!(caller, "inline Step requires a do block")
+      end
+
+    parsed = Enum.map(bindings, &parse_binding!(&1, caller))
+    {params, pattern} = params_and_pattern!(parsed, caller)
+
+    %__MODULE__{
+      params_ast: params,
+      pattern_ast: pattern,
+      body_ast: body,
+      options: Keyword.delete(options, :do),
+      source: %{file: caller.file, line: caller.line}
+    }
+  end
+
+  defp merge_options!(options, body_options, caller) do
+    validate_options!(options, caller)
+    validate_options!(body_options, caller)
+    options ++ body_options
+  end
+
+  defp validate_options!(options, caller) do
+    MacroSupport.validate_options!(
+      options,
+      caller,
+      "inline Step options must be a keyword list",
+      "inline Step field"
+    )
+
+    Enum.each(options, fn {field, _value} ->
+      unless field in [:after, :meta, :do] do
+        MacroSupport.compile_error!(
+          caller,
+          "unsupported inline Step field: #{inspect(field)}; use only after:, meta:, and do:"
+        )
+      end
+    end)
+  end
+
+  defp parse_binding!({:<-, _metadata, [pattern, source]}, caller) do
+    kind = binding_kind!(pattern, caller)
+
+    case Expression.parse(source) do
+      {:ok, _expression} -> :ok
+      {:error, error} -> error!(source, caller, "inline Step binding source: #{error.message}")
+    end
+
+    {kind, pattern, source}
+  end
+
+  defp parse_binding!(binding, caller) do
+    error!(binding, caller, "expected a binding in the form name <- source")
+  end
+
+  defp binding_kind!({:_, _, context} = pattern, caller) when is_atom(context) do
+    error!(pattern, caller, "a bare _ binding is not supported; use a named variable or []")
+  end
+
+  defp binding_kind!({name, _metadata, context}, _caller)
+       when is_atom(name) and is_atom(context),
+       do: {:named, name}
+
+  defp binding_kind!({:%{}, _, _pairs} = pattern, caller) do
+    validate_pattern!(pattern, caller)
+    :map
+  end
+
+  defp binding_kind!({:%, _, _} = pattern, caller) do
+    error!(pattern, caller, "top-level struct patterns are not supported in inline Step bindings")
+  end
+
+  defp binding_kind!({operator, _, _} = pattern, caller) when operator in [:^, :when] do
+    validate_pattern!(pattern, caller)
+  end
+
+  defp binding_kind!(pattern, caller) do
+    error!(pattern, caller, "inline Step requires a named variable or a sole map pattern")
+  end
+
+  defp params_and_pattern!([{:map, pattern, source}], _caller), do: {source, pattern}
+
+  defp params_and_pattern!(bindings, caller) do
+    if Enum.any?(bindings, &match?({:map, _, _}, &1)) do
+      MacroSupport.compile_error!(caller, "a map pattern must be the only inline Step binding")
+    end
+
+    {params, patterns, _names} =
+      Enum.reduce(bindings, {[], [], MapSet.new()}, fn {{:named, name}, pattern, source},
+                                                       {params, patterns, names} ->
+        if MapSet.member?(names, name) do
+          error!(pattern, caller, "duplicate inline Step binding: #{inspect(name)}")
+        end
+
+        {[{name, source} | params], [{name, pattern} | patterns], MapSet.put(names, name)}
+      end)
+
+    {{:%{}, [line: caller.line], Enum.reverse(params)},
+     {:%{}, [line: caller.line], Enum.reverse(patterns)}}
+  end
+
+  # Check only inline-header restrictions. The owner function compiler checks
+  # normal Elixir pattern syntax without expanding or evaluating it here.
+  defp validate_pattern!(pattern, caller) do
+    Macro.prewalk(pattern, fn
+      {:^, _, _} = node ->
+        error!(node, caller, "pinned variables are not supported in inline Step bindings")
+
+      {:when, _, _} = node ->
+        error!(node, caller, "guards are not supported in inline Step bindings")
+
+      {:%{}, _, pairs} = node ->
+        validate_map_keys!(pairs, node, caller)
+        node
+
+      node ->
+        node
+    end)
+  end
+
+  defp validate_map_keys!(pairs, pattern, caller) do
+    Enum.reduce(pairs, MapSet.new(), fn
+      {key, _value}, seen ->
+        normalized_key = Macro.postwalk(key, &normalize_literal/1)
+
+        unless Macro.quoted_literal?(normalized_key) do
+          error!(key, caller, "inline Step map pattern keys must be literals")
+        end
+
+        if MapSet.member?(seen, normalized_key) do
+          error!(pattern, caller, "duplicate inline Step map key: #{Macro.to_string(key)}")
+        end
+
+        MapSet.put(seen, normalized_key)
+
+      _update, _seen ->
+        error!(pattern, caller, "map updates are not supported in inline Step patterns")
+    end)
+  end
+
+  defp normalize_literal({:-, _, [number]}) when is_number(number), do: -number
+  defp normalize_literal({:+, _, [number]}) when is_number(number), do: number
+  defp normalize_literal({form, metadata, args}) when is_list(metadata), do: {form, [], args}
+  defp normalize_literal(value), do: value
+
+  defp error!({_form, metadata, _args}, caller, description) when is_list(metadata) do
+    caller = %{caller | line: Keyword.get(metadata, :line, caller.line)}
+    MacroSupport.compile_error!(caller, description)
+  end
+
+  defp error!(_expression, caller, description),
+    do: MacroSupport.compile_error!(caller, description)
+end

--- a/lib/jido_flow/dsl/inline_step.ex
+++ b/lib/jido_flow/dsl/inline_step.ex
@@ -3,7 +3,7 @@ defmodule Jido.Flow.DSL.InlineStep do
 
   alias Jido.Flow.DSL.{Expression, MacroSupport}
 
-  @enforce_keys [:params_ast, :pattern_ast, :body_ast, :options, :source]
+  @enforce_keys [:params_ast, :pattern_ast, :body_ast, :options]
   defstruct @enforce_keys
 
   @typedoc false
@@ -11,8 +11,7 @@ defmodule Jido.Flow.DSL.InlineStep do
           params_ast: Macro.t(),
           pattern_ast: Macro.t(),
           body_ast: Macro.t(),
-          options: keyword(),
-          source: %{file: String.t(), line: pos_integer()}
+          options: keyword()
         }
 
   @doc false
@@ -54,8 +53,7 @@ defmodule Jido.Flow.DSL.InlineStep do
       params_ast: params,
       pattern_ast: pattern,
       body_ast: body,
-      options: Keyword.delete(options, :do),
-      source: %{file: caller.file, line: caller.line}
+      options: Keyword.delete(options, :do)
     }
   end
 

--- a/lib/jido_flow/dsl/inline_step_compiler.ex
+++ b/lib/jido_flow/dsl/inline_step_compiler.ex
@@ -2,21 +2,48 @@ defmodule Jido.Flow.DSL.InlineStepCompiler do
   @moduledoc false
 
   alias Jido.Flow.Component
-  alias Jido.Flow.DSL.{InlineStep, MacroSupport}
+  alias Jido.Flow.DSL.{InlineStep, MacroSupport, ModuleCompiler}
 
   @doc false
   @spec compile!(Macro.t(), InlineStep.t(), Macro.Env.t()) :: {String.t(), module(), Macro.t()}
   def compile!(name_ast, parsed, caller) do
-    name = normalize_name!(name_ast, caller)
+    name =
+      case Component.name(Macro.expand(name_ast, caller)) do
+        {:ok, name} -> name
+        {:error, error} -> MacroSupport.compile_error!(caller, Exception.message(error))
+      end
+
     {action, function} = identity(caller.module, name)
-    create_action(action, function, name, caller)
-    {name, action, owner_definition(function, parsed, caller)}
+    definition = owner_definition(function, parsed, caller)
+
+    # Run compiler mutations at declaration evaluation, not macro expansion.
+    # This preserves source order and does not register untaken authoring branches.
+    quoted =
+      quote line: caller.line do
+        unquote(__MODULE__).create!(unquote(name), unquote(action), unquote(function), __ENV__)
+        unquote(definition)
+      end
+
+    {name, action, quoted}
   end
 
-  defp normalize_name!(name_ast, caller) do
-    case Component.name(Macro.expand(name_ast, caller)) do
-      {:ok, name} -> name
-      {:error, error} -> MacroSupport.compile_error!(caller, Exception.message(error))
+  @doc false
+  @spec create!(String.t(), module(), atom(), Macro.Env.t()) :: term()
+  def create!(name, action, function, caller) do
+    ModuleCompiler.register_step!(name, caller)
+    ModuleCompiler.reserve_function!(caller, {function, 2})
+    ensure_owner!(action, name, caller)
+    create_action(action, function, name, caller)
+  end
+
+  defp ensure_owner!(action, name, caller) do
+    if Code.ensure_loaded?(action) and
+         not (function_exported?(action, :__jido_inline_step__, 0) and
+                action.__jido_inline_step__() == {caller.module, name}) do
+      MacroSupport.compile_error!(
+        caller,
+        "generated inline Step module #{inspect(action)} already belongs to another definition"
+      )
     end
   end
 
@@ -67,10 +94,13 @@ defmodule Jido.Flow.DSL.InlineStepCompiler do
     # the caller's diagnostics, lexical expansion, and original source lines.
     quote line: caller.line do
       @doc false
+      @__jido_flow_generated_definition__ {unquote(function), 2}
       def unquote(function)(unquote(parsed.pattern_ast), _context) do
         unquote_splicing(unimports)
         unquote(parsed.body_ast)
       end
+
+      Module.delete_attribute(__MODULE__, :__jido_flow_generated_definition__)
     end
   end
 

--- a/lib/jido_flow/dsl/inline_step_compiler.ex
+++ b/lib/jido_flow/dsl/inline_step_compiler.ex
@@ -1,26 +1,23 @@
 defmodule Jido.Flow.DSL.InlineStepCompiler do
   @moduledoc false
 
-  alias Jido.Flow.Component
   alias Jido.Flow.DSL.{InlineStep, MacroSupport, ModuleCompiler}
 
   @doc false
-  @spec compile!(Macro.t(), InlineStep.t(), Macro.Env.t()) :: {String.t(), module(), Macro.t()}
+  @spec compile!(Macro.t(), InlineStep.t(), Macro.Env.t()) :: {Macro.t(), Macro.t(), Macro.t()}
   def compile!(name_ast, parsed, caller) do
-    name =
-      case Component.name(Macro.expand(name_ast, caller)) do
-        {:ok, name} -> name
-        {:error, error} -> MacroSupport.compile_error!(caller, Exception.message(error))
-      end
-
-    {action, function} = identity(caller.module, name)
+    name = Macro.unique_var(:step_name, __MODULE__)
+    action = Macro.unique_var(:step_action, __MODULE__)
+    function = Macro.unique_var(:step_function, __MODULE__)
     definition = owner_definition(function, parsed, caller)
 
-    # Run compiler mutations at declaration evaluation, not macro expansion.
-    # This preserves source order and does not register untaken authoring branches.
+    # Resolve names and create targets at declaration evaluation. Attribute reads
+    # then see preceding declarations, and each name expression runs only once.
     quoted =
       quote line: caller.line do
-        unquote(__MODULE__).create!(unquote(name), unquote(action), unquote(function), __ENV__)
+        {unquote(name), unquote(action), unquote(function)} =
+          unquote(__MODULE__).create!(unquote(name_ast), __ENV__)
+
         unquote(definition)
       end
 
@@ -28,12 +25,14 @@ defmodule Jido.Flow.DSL.InlineStepCompiler do
   end
 
   @doc false
-  @spec create!(String.t(), module(), atom(), Macro.Env.t()) :: term()
-  def create!(name, action, function, caller) do
-    ModuleCompiler.register_step!(name, caller)
+  @spec create!(term(), Macro.Env.t()) :: {String.t(), module(), atom()}
+  def create!(value, caller) do
+    name = ModuleCompiler.register_step!(value, caller)
+    {action, function} = identity(caller.module, name)
     ModuleCompiler.reserve_function!(caller, {function, 2})
     ensure_owner!(action, name, caller)
     create_action(action, function, name, caller)
+    {name, action, function}
   end
 
   defp ensure_owner!(action, name, caller) do
@@ -89,13 +88,15 @@ defmodule Jido.Flow.DSL.InlineStepCompiler do
 
   defp owner_definition(function, parsed, caller) do
     unimports = declaration_unimports(caller)
+    # Keep this unquote for def to resolve the declaration-time function name.
+    function_name = {:unquote, [], [function]}
 
     # Do not mark this definition as generated: the pattern and body must keep
     # the caller's diagnostics, lexical expansion, and original source lines.
     quote line: caller.line do
       @doc false
       @__jido_flow_generated_definition__ {unquote(function), 2}
-      def unquote(function)(unquote(parsed.pattern_ast), _context) do
+      def unquote(function_name)(unquote(parsed.pattern_ast), _context) do
         unquote_splicing(unimports)
         unquote(parsed.body_ast)
       end

--- a/lib/jido_flow/dsl/inline_step_compiler.ex
+++ b/lib/jido_flow/dsl/inline_step_compiler.ex
@@ -1,0 +1,90 @@
+defmodule Jido.Flow.DSL.InlineStepCompiler do
+  @moduledoc false
+
+  alias Jido.Flow.Component
+  alias Jido.Flow.DSL.{InlineStep, MacroSupport}
+
+  @doc false
+  @spec compile!(Macro.t(), InlineStep.t(), Macro.Env.t()) :: {String.t(), module(), Macro.t()}
+  def compile!(name_ast, parsed, caller) do
+    name = normalize_name!(name_ast, caller)
+    {action, function} = identity(caller.module, name)
+    create_action(action, function, name, caller)
+    {name, action, owner_definition(function, parsed, caller)}
+  end
+
+  defp normalize_name!(name_ast, caller) do
+    case Component.name(Macro.expand(name_ast, caller)) do
+      {:ok, name} -> name
+      {:error, error} -> MacroSupport.compile_error!(caller, Exception.message(error))
+    end
+  end
+
+  defp identity(owner, name) do
+    digest =
+      :sha256
+      |> :crypto.hash(:erlang.term_to_binary({owner, name}))
+      |> Base.encode16(case: :lower)
+
+    {Module.concat(Jido.Flow.Generated.InlineStep, "A" <> digest),
+     String.to_atom("__jido_inline_step_" <> digest)}
+  end
+
+  defp create_action(action, function, name, caller) do
+    owner = caller.module
+
+    definition =
+      quote generated: true do
+        @moduledoc false
+        @compile {:no_warn_undefined, unquote(owner)}
+        use Jido.Action, name: unquote(name), schema: [], output_schema: []
+
+        @doc false
+        def __jido_inline_step__, do: {unquote(owner), unquote(name)}
+
+        @impl Jido.Action
+        def run(params, context), do: unquote(owner).unquote(function)(params, context)
+      end
+
+    # Keep the source compiler's trackers, but do not import the owner's DSL or
+    # application aliases into the self-contained Action wrapper.
+    env = %{
+      __ENV__
+      | file: caller.file,
+        line: caller.line,
+        aliases: [],
+        lexical_tracker: caller.lexical_tracker,
+        tracers: caller.tracers
+    }
+
+    Module.create(action, definition, env)
+  end
+
+  defp owner_definition(function, parsed, caller) do
+    unimports = declaration_unimports(caller)
+
+    # Do not mark this definition as generated: the pattern and body must keep
+    # the caller's diagnostics, lexical expansion, and original source lines.
+    quote line: caller.line do
+      @doc false
+      def unquote(function)(unquote(parsed.pattern_ast), _context) do
+        unquote_splicing(unimports)
+        unquote(parsed.body_ast)
+      end
+    end
+  end
+
+  defp declaration_unimports(caller) do
+    (Keyword.keys(caller.functions) ++ Keyword.keys(caller.macros))
+    |> Enum.uniq()
+    |> Enum.filter(fn module ->
+      name = Atom.to_string(module)
+      String.starts_with?(name, ["Elixir.Jido.Flow.DSL", "Elixir.Spark.Dsl"])
+    end)
+    |> Enum.map(fn module ->
+      quote generated: true do
+        import unquote(module), only: []
+      end
+    end)
+  end
+end

--- a/lib/jido_flow/dsl/inline_step_compiler.ex
+++ b/lib/jido_flow/dsl/inline_step_compiler.ex
@@ -109,7 +109,9 @@ defmodule Jido.Flow.DSL.InlineStepCompiler do
     |> Enum.uniq()
     |> Enum.filter(fn module ->
       name = Atom.to_string(module)
-      String.starts_with?(name, ["Elixir.Jido.Flow.DSL", "Elixir.Spark.Dsl"])
+
+      module in [Jido.Flow.DSL, Spark.Dsl] or
+        String.starts_with?(name, ["Elixir.Jido.Flow.DSL.", "Elixir.Spark.Dsl."])
     end)
     |> Enum.map(fn module ->
       quote generated: true do

--- a/lib/jido_flow/dsl/macros.ex
+++ b/lib/jido_flow/dsl/macros.ex
@@ -52,10 +52,20 @@ end
 defmodule Jido.Flow.DSL.Macros do
   @moduledoc false
 
-  alias Jido.Flow.DSL.{InlineStep, InlineStepCompiler, MacroSupport}
+  alias Jido.Flow.DSL.{InlineStep, InlineStepCompiler, MacroSupport, ModuleCompiler}
 
   defmacro step(name, options) do
-    entity(name, options, extension_module(["Flow", "Step"]), :__step__, [:params], __CALLER__)
+    caller = __CALLER__
+    step_name = Macro.unique_var(:step_name, __MODULE__)
+
+    declaration =
+      entity(step_name, options, extension_module(["Flow", "Step"]), :__step__, [:params], caller)
+
+    quote line: caller.line do
+      unquote(step_name) = unquote(name)
+      unquote(ModuleCompiler).register_step!(unquote(step_name), __ENV__)
+      unquote(declaration)
+    end
   end
 
   defmacro step(name, bindings, options) do

--- a/lib/jido_flow/dsl/macros.ex
+++ b/lib/jido_flow/dsl/macros.ex
@@ -52,10 +52,39 @@ end
 defmodule Jido.Flow.DSL.Macros do
   @moduledoc false
 
-  alias Jido.Flow.DSL.MacroSupport
+  alias Jido.Flow.DSL.{InlineStep, InlineStepCompiler, MacroSupport}
 
   defmacro step(name, options) do
     entity(name, options, extension_module(["Flow", "Step"]), :__step__, [:params], __CALLER__)
+  end
+
+  defmacro step(name, bindings, options) do
+    inline_step(name, InlineStep.parse!(bindings, options, __CALLER__), __CALLER__)
+  end
+
+  defmacro step(name, left, right, options) do
+    inline_step(name, InlineStep.parse!(left, right, options, __CALLER__), __CALLER__)
+  end
+
+  defmacro step(name, left, right, options, body_options) do
+    inline_step(
+      name,
+      InlineStep.parse!(left, right, options, body_options, __CALLER__),
+      __CALLER__
+    )
+  end
+
+  defp inline_step(name, parsed, caller) do
+    {name, action, definition} = InlineStepCompiler.compile!(name, parsed, caller)
+    options = [action: action, params: parsed.params_ast] ++ parsed.options
+
+    declaration =
+      entity(name, options, extension_module(["Flow", "Step"]), :__step__, [:params], caller)
+
+    quote do
+      unquote(definition)
+      unquote(declaration)
+    end
   end
 
   defmacro map(name, options) do

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -1,7 +1,7 @@
 defmodule Jido.Flow.DSL.ModuleCompiler do
   @moduledoc false
 
-  alias Jido.Flow.DSL.Lowerer
+  alias Jido.Flow.DSL.{Lowerer, MacroSupport}
   alias Jido.Flow.Component
 
   @doc false
@@ -13,6 +13,8 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       @behaviour Jido.Executable
       use Jido.Flow.DSL
       @before_compile Jido.Flow.DSL.ModuleCompiler
+      @on_definition Jido.Flow.DSL.ModuleCompiler
+      unquote(module_compiler).reserve_function!(__ENV__, {:step_action, 1})
 
       {validated_opts, stored_schema, stored_output_schema} =
         unquote(module_compiler).prepare_config!(unquote(opts_ast), __ENV__)
@@ -74,6 +76,54 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
   end
 
   @doc false
+  @spec register_step!(term(), Macro.Env.t()) :: String.t()
+  def register_step!(value, env) do
+    name =
+      case Component.name(value) do
+        {:ok, name} -> name
+        {:error, error} -> MacroSupport.compile_error!(env, Exception.message(error))
+      end
+
+    names = Module.get_attribute(env.module, :__jido_flow_step_names__) || MapSet.new()
+
+    if MapSet.member?(names, name) do
+      MacroSupport.compile_error!(env, "duplicate Step name: #{inspect(name)}")
+    end
+
+    Module.put_attribute(env.module, :__jido_flow_step_names__, MapSet.put(names, name))
+    name
+  end
+
+  @doc false
+  @spec reserve_function!(Macro.Env.t(), {atom(), non_neg_integer()}) :: :ok
+  def reserve_function!(env, function) do
+    if Module.defines?(env.module, function), do: reserved_function_error!(env, function)
+    reserved = Module.get_attribute(env.module, :__jido_flow_reserved_functions__) || []
+    Module.put_attribute(env.module, :__jido_flow_reserved_functions__, [function | reserved])
+  end
+
+  @doc false
+  @spec __on_definition__(Macro.Env.t(), atom(), atom(), list(), list(), term()) :: :ok
+  def __on_definition__(env, _kind, name, args, _guards, _body) do
+    function = {name, length(args)}
+    reserved = Module.get_attribute(env.module, :__jido_flow_reserved_functions__) || []
+    generated = Module.get_attribute(env.module, :__jido_flow_generated_definition__)
+
+    if function in reserved and generated != function do
+      reserved_function_error!(env, function)
+    end
+
+    :ok
+  end
+
+  defp reserved_function_error!(env, {name, arity}) do
+    MacroSupport.compile_error!(
+      env,
+      "reserved Flow function #{name}/#{arity} cannot have user clauses"
+    )
+  end
+
+  @doc false
   @spec prepare_config!(term(), Macro.Env.t()) ::
           {map(), Jido.Action.schema(), Jido.Action.schema()} | no_return()
   def prepare_config!(raw_opts, env) do
@@ -117,10 +167,37 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
     escaped_flow = Macro.escape(flow)
     escaped_source_map = Macro.escape(source_map)
 
-    quote do
+    step_actions =
+      for %Jido.Flow.Step{name: name, action: action} <- flow.components,
+          into: %{},
+          do: {name, action}
+
+    quote generated: true do
       def __jido_executable__, do: Jido.Executable.flow(__MODULE__)
       def flow, do: unquote(escaped_flow)
       def __jido_flow_source_map__, do: unquote(escaped_source_map)
+
+      @doc """
+      Returns the Action target of a named Step.
+
+      Accepts a string or atom name. Raises `ArgumentError` for invalid names,
+      unknown names, and non-Step components, including Subflows. The result
+      does not include the original Step's params, dependencies, or metadata.
+      """
+      @spec step_action(String.t() | atom()) :: module()
+      @__jido_flow_generated_definition__ {:step_action, 1}
+      def step_action(name) do
+        with {:ok, normalized} <- Jido.Flow.Component.name(name),
+             {:ok, action} <- Map.fetch(unquote(Macro.escape(step_actions)), normalized) do
+          action
+        else
+          _ ->
+            raise ArgumentError,
+                  "expected an Action-backed Step name in #{inspect(__MODULE__)}, got: #{inspect(name)}"
+        end
+      end
+
+      Module.delete_attribute(__MODULE__, :__jido_flow_generated_definition__)
 
       def compiled,
         do: Jido.Flow.compile!(flow(), source_map: __jido_flow_source_map__())

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -127,12 +127,17 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
   @doc false
   @spec __on_definition__(Macro.Env.t(), atom(), atom(), list(), list(), term()) :: :ok
   def __on_definition__(env, _kind, name, args, _guards, _body) do
-    function = {name, length(args)}
+    arity = length(args)
+    defaults = Enum.count(args, &match?({:\\, _, [_, _]}, &1))
     reserved = Module.get_attribute(env.module, :__jido_flow_reserved_functions__) || []
     generated = Module.get_attribute(env.module, :__jido_flow_generated_definition__)
 
-    if function in reserved and generated != function do
-      reserved_function_error!(env, function)
+    for defined_arity <- (arity - defaults)..arity do
+      function = {name, defined_arity}
+
+      if function in reserved and generated != function do
+        reserved_function_error!(env, function)
+      end
     end
 
     :ok

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -61,6 +61,28 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       @spec flow() :: Jido.Flow.t()
       def flow()
 
+      @doc """
+      Returns the Action target of a named Step.
+
+      Accepts a string or atom name. Raises `ArgumentError` for invalid names,
+      unknown names, and non-Step components, including Subflows. The result
+      does not include the original Step's params, dependencies, or metadata.
+
+      Works for inline and explicit Action-backed Steps. Call it after this
+      Flow module has compiled, not from its unfinished DSL block. Lookup
+      does not run the body or create atoms. Supply new Step fields when
+      reusing the target through Builder or direct constructors. For stored
+      JSON, register the target with an application-owned Action identifier
+      and register the required parameter atom keys.
+
+      Deploy the owning module and generated Actions together. The target
+      can remain unchanged after a body edit; it is not a code version.
+      """
+      @spec step_action(String.t() | atom()) :: module()
+      @__jido_flow_generated_definition__ {:step_action, 1}
+      def step_action(name)
+      Module.delete_attribute(__MODULE__, :__jido_flow_generated_definition__)
+
       @doc false
       @spec __jido_flow_source_map__() :: Jido.Flow.Compiled.source_map()
       def __jido_flow_source_map__()
@@ -116,6 +138,7 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
     :ok
   end
 
+  @spec reserved_function_error!(Macro.Env.t(), {atom(), non_neg_integer()}) :: no_return()
   defp reserved_function_error!(env, {name, arity}) do
     MacroSupport.compile_error!(
       env,
@@ -177,24 +200,6 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       def flow, do: unquote(escaped_flow)
       def __jido_flow_source_map__, do: unquote(escaped_source_map)
 
-      @doc """
-      Returns the Action target of a named Step.
-
-      Accepts a string or atom name. Raises `ArgumentError` for invalid names,
-      unknown names, and non-Step components, including Subflows. The result
-      does not include the original Step's params, dependencies, or metadata.
-
-      Works for inline and explicit Action-backed Steps. Call it after this
-      Flow module has compiled, not from its unfinished DSL block. Lookup
-      does not run the body or create atoms. Supply new Step fields when
-      reusing the target through Builder or direct constructors. For stored
-      JSON, register the target with an application-owned Action identifier
-      and register the required parameter atom keys.
-
-      Deploy the owning module and generated Actions together. The target
-      can remain unchanged after a body edit; it is not a code version.
-      """
-      @spec step_action(String.t() | atom()) :: module()
       @__jido_flow_generated_definition__ {:step_action, 1}
       def step_action(name) do
         with {:ok, normalized} <- Jido.Flow.Component.name(name),

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -183,6 +183,16 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       Accepts a string or atom name. Raises `ArgumentError` for invalid names,
       unknown names, and non-Step components, including Subflows. The result
       does not include the original Step's params, dependencies, or metadata.
+
+      Works for inline and explicit Action-backed Steps. Call it after this
+      Flow module has compiled, not from its unfinished DSL block. Lookup
+      does not run the body or create atoms. Supply new Step fields when
+      reusing the target through Builder or direct constructors. For stored
+      JSON, register the target with an application-owned Action identifier
+      and register the required parameter atom keys.
+
+      Deploy the owning module and generated Actions together. The target
+      can remain unchanged after a body edit; it is not a code version.
       """
       @spec step_action(String.t() | atom()) :: module()
       @__jido_flow_generated_definition__ {:step_action, 1}

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,10 @@ defmodule JidoAction.MixProject do
 
           # Spark owns this generated namespace. Handwritten DSL and compiler
           # modules remain part of the coverage result.
-          ~r/^Jido\.Flow\.DSL\.Extension\.Flow\./
+          ~r/^Jido\.Flow\.DSL\.Extension\.Flow\./,
+
+          # Inline wrappers contain generated Action scaffolding only.
+          ~r/^Jido\.Flow\.Generated\.InlineStep\./
         ],
         summary: [threshold: 93]
       ],

--- a/test/jido_exec/action_execution_test.exs
+++ b/test/jido_exec/action_execution_test.exs
@@ -9,6 +9,7 @@ defmodule JidoActionTest.Exec.ActionExecutionTest do
   alias Jido.Flow.{Ref, Step}
   alias Jido.Instruction
   alias JidoActionTest.Fixtures.ActionWithFlowFunction
+  alias JidoActionTest.Fixtures.InlineResultFlow
 
   alias JidoActionTest.Fixtures.Actions.{
     Add,
@@ -49,6 +50,68 @@ defmodule JidoActionTest.Exec.ActionExecutionTest do
     def validate_output(output), do: {:ok, output}
     def run(params, _context), do: {:ok, params}
     def name, do: throw(:action_name_failed)
+  end
+
+  test "inline targets keep normal success, Output, and extras rules" do
+    action = InlineResultFlow.step_action("result")
+    assert action.schema() == []
+    assert action.output_schema() == []
+
+    for {mode, value, expected} <- [
+          {:map, 3, %{value: 3}},
+          {:output, "raw success", Jido.Action.Output.raw("raw success")}
+        ] do
+      input = %{mode: mode, value: value}
+      assert Exec.run(action, input) == {:ok, expected}
+      assert Exec.run(InlineResultFlow, input) == {:ok, expected}
+    end
+
+    input = %{mode: :extras, value: 3}
+    instruction = Instruction.new!(target: action, params: input)
+
+    for target <- [action, instruction] do
+      assert Exec.run(target, input) == {:ok, %{value: 3}, %{effect: :already_ran}}
+    end
+
+    assert Exec.run(InlineResultFlow, input) == {:ok, %{value: 3}}
+  end
+
+  test "inline callback failures retain current structured errors in Actions and Steps" do
+    action = InlineResultFlow.step_action("result")
+
+    cases = [
+      {:raise, "inline body failed", %{exception: RuntimeError}},
+      {:throw, "action throw", %{reason: {:inline_throw, 42}}},
+      {:exit, "action exit", %{reason: {:inline_exit, 42}}},
+      {:invalid_callback, "action returned an unsupported result",
+       %{result: :not_a_result_tuple}},
+      {:invalid_output, "action returned a value that requires an output envelope",
+       %{callback: :run, output: 42}}
+    ]
+
+    for {mode, message, expected_details} <- cases, target <- [action, InlineResultFlow] do
+      assert {:error, %ExecutionFailureError{} = error} =
+               Exec.run(target, %{mode: mode, value: 42})
+
+      assert error.message == message
+      assert error.details.action == action
+      assert Map.take(error.details, Map.keys(expected_details)) == expected_details
+      refute Error.retryable?(error)
+      if target == InlineResultFlow, do: assert(error.details.node == "result")
+
+      if mode in [:raise, :throw, :exit] do
+        assert %Splode.Stacktrace{stacktrace: stacktrace} = error.stacktrace
+
+        assert Enum.any?(stacktrace, fn
+                 {InlineResultFlow, _function, _arity, location} ->
+                   to_string(location[:file]) =~ "test/support/fixtures/flow/inline.ex" and
+                     is_integer(location[:line])
+
+                 _frame ->
+                   false
+               end)
+      end
+    end
   end
 
   describe "run/3 with action modules" do

--- a/test/jido_exec/action_execution_test.exs
+++ b/test/jido_exec/action_execution_test.exs
@@ -73,7 +73,19 @@ defmodule JidoActionTest.Exec.ActionExecutionTest do
       assert Exec.run(target, input) == {:ok, %{value: 3}, %{effect: :already_ran}}
     end
 
-    assert Exec.run(InlineResultFlow, input) == {:ok, %{value: 3}}
+    explicit_flow =
+      Flow.new!(
+        name: "explicit_inline_result",
+        components: [Step.new!(name: "result", action: action, params: Ref.input([]))],
+        output: Ref.result("result")
+      )
+
+    for flow <- [InlineResultFlow, explicit_flow] do
+      assert Exec.run(flow, input) == {:ok, %{value: 3}}
+      assert {:ok, execution} = Exec.start(flow, input)
+      assert {:ok, execution} = Exec.continue(execution)
+      assert Exec.result(execution) == {:ok, %{value: 3}}
+    end
   end
 
   test "inline callback failures retain current structured errors in Actions and Steps" do

--- a/test/jido_exec/async_mailbox_hygiene_test.exs
+++ b/test/jido_exec/async_mailbox_hygiene_test.exs
@@ -34,47 +34,49 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
   end
 
   test "await accepts a queued result after a matching normal DOWN" do
-    handle = Exec.run_async(Add, %{value: 1})
-    result_message = receive_result_message(handle)
+    with_released_action(2, fn handle ->
+      result_message = receive_result_message(handle)
 
-    assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
-    assert monitor_ref == handle.monitor_ref
-    assert pid == handle.pid
+      assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
+      assert monitor_ref == handle.monitor_ref
+      assert pid == handle.pid
 
-    send(self(), down)
-    send(self(), result_message)
+      send(self(), down)
+      send(self(), result_message)
 
-    assert {:ok, %{value: 2}} = Exec.await(handle, 1_000)
-    refute_handle_messages(handle)
+      assert {:ok, %{value: 2}} = Exec.await(handle, 1_000)
+      refute_handle_messages(handle)
+    end)
   end
 
   test "a normal DOWN consumes an already queued result without blocking" do
-    handle = Exec.run_async(Add, %{value: 2})
+    with_released_action(3, fn handle ->
+      assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
+      assert monitor_ref == handle.monitor_ref
+      assert pid == handle.pid
 
-    assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
-    assert monitor_ref == handle.monitor_ref
-    assert pid == handle.pid
-
-    assert {:done, {:ok, %{value: 3}}} = Exec.handle_message(handle, down)
-    refute_handle_messages(handle)
+      assert {:done, {:ok, %{value: 3}}} = Exec.handle_message(handle, down)
+      refute_handle_messages(handle)
+    end)
   end
 
   test "an unexpected normal DOWN returns one terminal execution error" do
-    handle = Exec.run_async(Add, %{value: 2})
-    result_message = receive_result_message(handle)
+    with_released_action(3, fn handle ->
+      result_message = receive_result_message(handle)
 
-    assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
-    assert monitor_ref == handle.monitor_ref
-    assert pid == handle.pid
+      assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
+      assert monitor_ref == handle.monitor_ref
+      assert pid == handle.pid
 
-    assert {:done,
-            {:error,
-             %Error.AsyncExecutionError{
-               message: "Asynchronous execution finished without a result",
-               details: %{operation: :handle_message}
-             }}} = Exec.handle_message(handle, down)
+      assert {:done,
+              {:error,
+               %Error.AsyncExecutionError{
+                 message: "Asynchronous execution finished without a result",
+                 details: %{operation: :handle_message}
+               }}} = Exec.handle_message(handle, down)
 
-    assert :ignore = Exec.handle_message(handle, result_message)
+      assert :ignore = Exec.handle_message(handle, result_message)
+    end)
   end
 
   test "an abnormal DOWN returns one terminal execution error" do
@@ -120,16 +122,17 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
   end
 
   test "duplicate results and stale DOWN messages are ignored" do
-    handle = Exec.run_async(Add, %{value: 2})
-    result_message = receive_result_message(handle)
+    with_released_action(3, fn handle ->
+      result_message = receive_result_message(handle)
 
-    assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
-    assert monitor_ref == handle.monitor_ref
-    assert pid == handle.pid
+      assert_receive {:DOWN, monitor_ref, :process, pid, :normal} = down, 1_000
+      assert monitor_ref == handle.monitor_ref
+      assert pid == handle.pid
 
-    assert {:done, {:ok, %{value: 3}}} = Exec.handle_message(handle, result_message)
-    assert :ignore = Exec.handle_message(handle, result_message)
-    assert :ignore = Exec.handle_message(handle, down)
+      assert {:done, {:ok, %{value: 3}}} = Exec.handle_message(handle, result_message)
+      assert :ignore = Exec.handle_message(handle, result_message)
+      assert :ignore = Exec.handle_message(handle, down)
+    end)
   end
 
   test "cancel by PID claims the shared handle and leaves no mailbox residue" do
@@ -170,6 +173,19 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
     assert :ok = Exec.cancel(handle)
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
     refute_handle_messages(handle)
+  end
+
+  defp with_released_action(value, fun) do
+    handle = Exec.run_async(BlockingAction, %{value: value}, %{test_pid: self()})
+
+    try do
+      assert_receive {:blocking_flow_node_started, worker}, 1_000
+      # The handle monitor is installed before the worker can finish.
+      send(worker, :finish)
+      fun.(handle)
+    after
+      Exec.cancel(handle)
+    end
   end
 
   defp receive_result_message(handle) do

--- a/test/jido_exec/flow_contract_test.exs
+++ b/test/jido_exec/flow_contract_test.exs
@@ -9,12 +9,14 @@ defmodule JidoActionTest.Exec.FlowContractTest do
   alias Jido.Flow
   alias Jido.Flow.Error.{InvalidDefinitionError, InvalidExecutionError}
   alias Jido.Flow.{Ref, Step}
+  alias Jido.Instruction
   alias JidoActionTest.Fixtures.Execution, as: ExecFixtures
 
   alias JidoActionTest.Fixtures.{
     CountedValidationFlow,
     EnvelopeFlow,
     ImproperListOutputAction,
+    InlineResultFlow,
     ListOutputAction,
     MathFlow,
     ScalarResultFlow,
@@ -37,6 +39,111 @@ defmodule JidoActionTest.Exec.FlowContractTest do
   defmodule StructInput do
     @moduledoc false
     defstruct [:value]
+  end
+
+  defmodule InlinePatternFlow do
+    use Jido.Flow, name: "inline_pattern_boundary"
+
+    flow do
+      step "match",
+           %{profile: %{name: name}, active: true, test_pid: test_pid, token: token} <-
+             input(:payload) do
+        send(test_pid, {:inline_pattern_body, token})
+        {:ok, %{name: name}}
+      end
+
+      output(result("match"))
+    end
+  end
+
+  defmodule InlineContextFlow do
+    use Jido.Flow, name: "inline_context_boundary"
+
+    flow do
+      step "first", [value <- input(:value), ctx <- context()] do
+        value = value + 1
+        ctx = Map.put(ctx, :local_only, true)
+        {:ok, %{value: value, context: ctx}}
+      end
+
+      step "second",
+           [value <- input(:value), prior <- result("first"), ctx <- context()] do
+        {:ok, %{value: value, prior: prior, context: ctx}}
+      end
+
+      output(result("second"))
+    end
+  end
+
+  test "inline binding failures stop before body work at the existing boundaries" do
+    token = make_ref()
+    payload = %{profile: %{name: "Ada"}, active: true, test_pid: self(), token: token}
+
+    assert {:error, %Jido.Flow.Error.ExecutionFailureError{} = missing_ref} =
+             Exec.run(InlinePatternFlow)
+
+    assert missing_ref.message == "flow reference path does not exist"
+    assert missing_ref.details.reason == :missing_key
+    assert missing_ref.details.path == [:payload]
+    refute_received {:inline_pattern_body, ^token}
+
+    for invalid <- [put_in(payload.profile, %{}), %{payload | active: false}] do
+      assert {:error, %ActionExecutionFailureError{} = mismatch} =
+               Exec.run(InlinePatternFlow, %{payload: invalid})
+
+      assert mismatch.details.exception == FunctionClauseError
+      assert mismatch.details.action == InlinePatternFlow.step_action("match")
+      assert mismatch.details.node == "match"
+      refute_received {:inline_pattern_body, ^token}
+    end
+
+    assert {:error, %Jido.Action.Error.InvalidInputError{} = non_map} =
+             Exec.run(InlinePatternFlow, %{payload: :not_a_map})
+
+    assert non_map.details.node == "match"
+    refute_received {:inline_pattern_body, ^token}
+
+    assert Exec.run(InlinePatternFlow, %{payload: Map.put(payload, :extra, :accepted)}) ==
+             {:ok, %{name: "Ada"}}
+
+    assert_received {:inline_pattern_body, ^token}
+    refute_received {:inline_pattern_body, ^token}
+  end
+
+  test "inline Steps preserve caller context and keep header bindings local" do
+    context = %{trace_id: make_ref(), prefix: "Hello"}
+
+    assert Exec.run(InlineContextFlow, %{value: 3}, context) ==
+             {:ok,
+              %{
+                value: 3,
+                prior: %{value: 4, context: Map.put(context, :local_only, true)},
+                context: context
+              }}
+  end
+
+  test "one inline target has equal results across public execution forms" do
+    input = %{mode: :map, value: 3}
+    action = InlineResultFlow.step_action("result")
+    expected = {:ok, %{value: 3}}
+
+    assert Exec.run(action, input) == expected
+    assert Exec.run(Instruction.new!(target: action, params: input)) == expected
+
+    for {path, run} <- ExecFixtures.flow_execution_paths(InlineResultFlow, input) do
+      assert run.() == expected, to_string(path)
+    end
+
+    for target <- [action, InlineResultFlow] do
+      handle = Exec.run_async(target, input)
+      assert Exec.await(handle) == expected
+    end
+
+    assert {:ok, execution} = Exec.start(InlineResultFlow, input)
+    assert [runnable] = Exec.ready(execution)
+    assert {:ok, %{status: :completed}, execution} = Exec.step(execution, runnable)
+    assert Exec.status(execution) == :succeeded
+    assert Exec.result(execution) == expected
   end
 
   def fail_flow_transform(_value, mode, _opts) do

--- a/test/jido_exec/flow_contract_test.exs
+++ b/test/jido_exec/flow_contract_test.exs
@@ -75,6 +75,21 @@ defmodule JidoActionTest.Exec.FlowContractTest do
     end
   end
 
+  defmodule InlineSchemaFlow do
+    use Jido.Flow,
+      name: "inline_schema_boundary",
+      schema: Zoi.object(%{value: Zoi.integer() |> Zoi.default(1)}),
+      output_schema: Zoi.object(%{value: Zoi.integer() |> Zoi.min(0)})
+
+    flow do
+      step "echo", value <- input(:value) do
+        {:ok, %{value: value}}
+      end
+
+      output result("echo")
+    end
+  end
+
   test "inline binding failures stop before body work at the existing boundaries" do
     token = make_ref()
     payload = %{profile: %{name: "Ada"}, active: true, test_pid: self(), token: token}
@@ -120,6 +135,43 @@ defmodule JidoActionTest.Exec.FlowContractTest do
                 prior: %{value: 4, context: Map.put(context, :local_only, true)},
                 context: context
               }}
+  end
+
+  test "an extracted inline target does not recreate context bindings" do
+    action = InlineContextFlow.step_action("first")
+    context = %{trace_id: "inline-reuse"}
+
+    assert {:error, %ActionExecutionFailureError{details: details}} =
+             Exec.run(action, %{value: 3}, context)
+
+    assert details.exception == FunctionClauseError
+    assert details.action == action
+
+    assert Exec.run(action, %{value: 3, ctx: context}, %{trace_id: "other"}) ==
+             {:ok, %{value: 4, context: Map.put(context, :local_only, true)}}
+  end
+
+  test "an extracted inline target does not inherit Flow input validation or defaults" do
+    action = InlineSchemaFlow.step_action("echo")
+    assert action.schema() == []
+    assert Exec.run(InlineSchemaFlow) == {:ok, %{value: 1}}
+
+    assert {:error, %ActionExecutionFailureError{details: %{exception: FunctionClauseError}}} =
+             Exec.run(action)
+
+    assert {:error, %InvalidExecutionError{details: %{phase: :flow_input}}} =
+             Exec.run(InlineSchemaFlow, %{value: "invalid"})
+
+    assert Exec.run(action, %{value: "invalid"}) == {:ok, %{value: "invalid"}}
+  end
+
+  test "an extracted inline target does not inherit Flow output validation" do
+    action = InlineSchemaFlow.step_action("echo")
+    assert action.output_schema() == []
+    assert Exec.run(action, %{value: -1}) == {:ok, %{value: -1}}
+
+    assert {:error, %InvalidExecutionError{details: %{phase: :flow_output}}} =
+             Exec.run(InlineSchemaFlow, %{value: -1})
   end
 
   test "one inline target has equal results across public execution forms" do

--- a/test/jido_exec/native_flow_execution_test.exs
+++ b/test/jido_exec/native_flow_execution_test.exs
@@ -6,6 +6,7 @@ defmodule JidoActionTest.Exec.NativeFlowExecutionTest do
   alias Jido.Flow.{Map, Reduce, Ref, Step, Subflow}
   alias JidoActionTest.Fixtures.{ChoicePublicPaths, MathFlow}
   alias JidoActionTest.Fixtures.ChildIterator
+  alias JidoActionTest.Fixtures.InlineControlledFlow
 
   alias JidoActionTest.Fixtures.Actions.{
     EchoParamsAction,
@@ -72,6 +73,37 @@ defmodule JidoActionTest.Exec.NativeFlowExecutionTest do
     refute_received {RecorderAction, _params}
     assert {:ok, completed} = Exec.continue(current)
     assert Exec.result(completed) == {:ok, %{left: :left, right: :right}}
+  end
+
+  test "a stale inline wave cannot repeat body effects" do
+    token = make_ref()
+    context = %{test_pid: self(), token: token, block: false}
+    input = %{first: 1, second: 2, third: 3}
+    assert {:ok, stale} = Exec.start(InlineControlledFlow, input, context, max_concurrency: 2)
+    assert length(Exec.ready(stale)) == 3
+    assert {:ok, executed, current} = Exec.wave(stale)
+    assert Enum.map(executed, & &1.node.name) |> Enum.sort() == ["first", "second", "third"]
+    assert current.revision == 1
+
+    for value <- 1..3 do
+      assert_received {:inline_started, ^token, ^value, worker}
+      monitor = Process.monitor(worker)
+      assert_receive {:DOWN, ^monitor, :process, ^worker, _reason}, 1_000
+      assert_received {:inline_finished, ^token, ^value}
+    end
+
+    for mutate <- [&Exec.step/1, &Exec.wave/1, &Exec.continue/1] do
+      assert {:error,
+              %Jido.Flow.Error.InvalidExecutionError{
+                message: "stale flow execution",
+                details: %{reason: :stale_revision, revision: 0, current_revision: 1}
+              }} = mutate.(stale)
+    end
+
+    refute_received {:inline_started, ^token, _value, _worker}
+    refute_received {:inline_finished, ^token, _value}
+    assert {:ok, completed} = Exec.continue(current)
+    assert Exec.result(completed) == {:ok, %{values: [1, 2, 3]}}
   end
 
   test "ready, step, and wave expose Runic support runnables" do

--- a/test/jido_exec/native_runtime_policy_test.exs
+++ b/test/jido_exec/native_runtime_policy_test.exs
@@ -112,6 +112,8 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
     ControlledErrorAction
   }
 
+  alias JidoActionTest.Fixtures.InlineControlledFlow
+
   alias JidoActionTest.Fixtures.Execution, as: ExecFixtures
   alias JidoActionTest.Fixtures.FlowAuthoring, as: FlowFixtures
   alias JidoActionTest.Fixtures.Actions.{Add, EchoParamsAction, RecorderAction}
@@ -175,6 +177,58 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
     assert Enum.map([first, second], &elem(&1, 0)) |> Enum.sort() == [:left, :right]
     assert Task.await(task) == {:ok, %{left: :left, right: :right}}
     assert Agent.get(probe, & &1.max) == 1
+  end
+
+  test "independent inline Steps obey the concurrency limit and return canonical results" do
+    for limit <- [1, 2] do
+      probe =
+        start_supervised!(
+          Supervisor.child_spec({Agent, fn -> %{max: 0, running: 0} end},
+            id: {:inline_probe, limit}
+          )
+        )
+
+      token = make_ref()
+      context = %{probe: probe, test_pid: self(), token: token}
+
+      handle =
+        Exec.run_async(InlineControlledFlow, %{first: 1, second: 2, third: 3}, context,
+          max_concurrency: limit
+        )
+
+      try do
+        workers =
+          Enum.flat_map(Enum.chunk_every(1..3, limit), fn batch ->
+            started =
+              Enum.map(batch, fn _index ->
+                assert_receive {:inline_started, ^token, value, worker}, 1_000
+                {value, worker, Process.monitor(worker)}
+              end)
+
+            assert Agent.get(probe, & &1.max) == limit
+
+            for {_value, worker, _monitor} <- Enum.reverse(started) do
+              send(worker, {:release, token})
+            end
+
+            started
+          end)
+
+        assert Exec.await(handle) == {:ok, %{values: [1, 2, 3]}}
+        assert Agent.get(probe, & &1) == %{max: limit, running: 0}
+        assert Enum.map(workers, &elem(&1, 0)) |> Enum.sort() == [1, 2, 3]
+
+        for {value, worker, monitor} <- workers do
+          assert_receive {:DOWN, ^monitor, :process, ^worker, _reason}, 1_000
+          assert_received {:inline_finished, ^token, ^value}
+        end
+
+        refute_received {:inline_started, ^token, _value, _worker}
+        refute_received {:inline_finished, ^token, _value}
+      after
+        Exec.cancel(handle)
+      end
+    end
   end
 
   test "supports Flow module options and validates policy values" do
@@ -422,12 +476,8 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
 
   defp assert_process_stops(pid) do
     monitor = Process.monitor(pid)
-
-    if Process.alive?(pid) do
-      assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, 1_000
-    else
-      assert_receive {:DOWN, ^monitor, :process, ^pid, :noproc}, 1_000
-    end
+    assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, 1_000
+    refute Process.alive?(pid)
   end
 
   defp self_or_owner do

--- a/test/jido_exec/telemetry_test.exs
+++ b/test/jido_exec/telemetry_test.exs
@@ -11,6 +11,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
   alias Jido.Flow.Map, as: FlowMap
   alias Jido.Instruction
   alias JidoActionTest.Fixtures.{BlockingFlow, MathFlow, TelemetryParentFlow}
+  alias JidoActionTest.Fixtures.InlineControlledFlow
   alias JidoActionTest.Fixtures.Execution.BlockingAction
   alias JidoActionTest.Fixtures.Actions.{Add, ErrorAction}
 
@@ -286,6 +287,107 @@ defmodule JidoActionTest.Exec.TelemetryTest do
              {@action_start, _, %{name: :tracker_test}},
              {@action_stop, _, %{name: :tracker_test}}
            ] = events()
+  end
+
+  for form <- [:action, :flow], terminal <- [:cancel, :timeout] do
+    @tag timeout: 10_000
+    @tag inline_form: form, inline_terminal: terminal
+    test "inline #{form} #{terminal} cleans up workers and closes each started lifecycle once", %{
+      inline_form: form,
+      inline_terminal: terminal
+    } do
+      attach([@action_start, @action_stop, @action_error] ++ @flow_events)
+      token = make_ref()
+      context = %{test_pid: self(), token: token}
+      action = InlineControlledFlow.step_action("first")
+      supervisor = Exec.task_supervisor_name(__MODULE__)
+      start_supervised!({Task.Supervisor, name: supervisor})
+
+      {target, input, prefixes} =
+        case form do
+          :action ->
+            {action, %{value: 1, ctx: context}, [[:jido, :action]]}
+
+          :flow ->
+            {InlineControlledFlow, %{first: 1, second: 2, third: 3},
+             [[:jido, :flow], [:jido, :flow, :node], [:jido, :flow, :target]]}
+        end
+
+      opts = [max_concurrency: 1, jido: __MODULE__]
+      opts = if terminal == :timeout, do: Keyword.put(opts, :timeout, 2_000), else: opts
+      handle = Exec.run_async(target, input, context, opts)
+      caller_monitor = Process.monitor(handle.pid)
+
+      try do
+        assert_receive {:inline_started, ^token, value, worker}, 1_000
+        worker_monitor = Process.monitor(worker)
+
+        worker_action =
+          InlineControlledFlow.step_action(Enum.at(["first", "second", "third"], value - 1))
+
+        expected_error =
+          case {terminal, form} do
+            {:cancel, _form} ->
+              assert :ok = Exec.cancel(handle)
+              Jido.Exec.Error.CancelledError
+
+            {:timeout, :action} ->
+              assert {:error, %Jido.Action.Error.TimeoutError{timeout: 2_000}} =
+                       Exec.await(handle, 5_000)
+
+              Jido.Action.Error.TimeoutError
+
+            {:timeout, :flow} ->
+              assert {:error, %Jido.Flow.Error.TimeoutError{timeout: 2_000}} =
+                       Exec.await(handle, 5_000)
+
+              Jido.Flow.Error.TimeoutError
+          end
+
+        assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
+        assert_receive {:DOWN, ^caller_monitor, :process, _, _reason}, 1_000
+        assert Task.Supervisor.children(supervisor) == []
+        refute_received {:inline_started, ^token, _value, _worker}
+        refute_received {:inline_finished, ^token, _value}
+
+        recorded = events()
+        assert length(recorded) == length(prefixes) * 2
+
+        assert [_execution_id] =
+                 recorded
+                 |> Enum.map(fn {_event, _measurements, metadata} -> metadata.execution_id end)
+                 |> Enum.uniq()
+
+        for prefix <- prefixes do
+          start_event = prefix ++ [:start]
+          error_event = prefix ++ [:error]
+
+          assert [
+                   {^start_event, _, start_metadata},
+                   {^error_event, measurements, error_metadata}
+                 ] = Enum.filter(recorded, fn {event, _, _} -> Enum.drop(event, -1) == prefix end)
+
+          assert error_metadata.error.__struct__ == expected_error
+
+          expected_error_type =
+            case {terminal, form} do
+              {:cancel, _form} -> :async_cancelled
+              {:timeout, :action} -> :timeout
+              {:timeout, :flow} -> :flow_timeout
+            end
+
+          assert error_metadata.error_type == expected_error_type
+
+          assert Map.drop(error_metadata, [:error, :error_type]) == start_metadata
+          assert measurements.duration >= 0
+
+          if prefix == [:jido, :flow, :target], do: assert(start_metadata.target == worker_action)
+        end
+      after
+        Exec.cancel(handle)
+        Process.demonitor(caller_monitor, [:flush])
+      end
+    end
   end
 
   test "tracker calls are safe after the tracker stops" do

--- a/test/jido_exec/terminal_transition_test.exs
+++ b/test/jido_exec/terminal_transition_test.exs
@@ -151,6 +151,25 @@ defmodule JidoActionTest.Exec.TerminalTransitionTest do
     def run(params, _context), do: {:continue, params, Add}
   end
 
+  defmodule InlineFlowToExtras do
+    use Jido.Flow,
+      name: "inline_flow_to_extras",
+      output_schema: Zoi.object(%{value: Zoi.string()})
+
+    flow do
+      step "prepare", value <- input(:value) do
+        {:ok, %{value: value}, %{step_extra: :discarded}}
+      end
+
+      dispatch "finish",
+        decision: Decision,
+        expander: ContinueToExtras,
+        params: result("prepare")
+
+      output result("finish")
+    end
+  end
+
   describe "root Action transitions" do
     test "runs Action and Flow targets as the next executable" do
       assert Exec.run(ContinueToAdd, %{value: 3}) == {:ok, %{value: 5}}
@@ -258,6 +277,24 @@ defmodule JidoActionTest.Exec.TerminalTransitionTest do
   end
 
   describe "terminal Dispatch transitions" do
+    test "only the final Action owns extras after an inline Flow continuation" do
+      input = %{value: 3}
+      context = %{trace_id: "final-action"}
+      expected = {:ok, %{value: 3}, %{trace_id: "final-action"}}
+
+      # The continued Action, not the original Flow, owns output validation.
+      assert Exec.run(InlineFlowToExtras, input, context) == expected
+      handle = Exec.run_async(InlineFlowToExtras, input, context)
+      assert Exec.await(handle) == expected
+
+      # An expander's normal result is still a Flow node result: its extras drop.
+      assert Exec.run(
+               dispatch_flow!(expander: ExtrasAction),
+               %{continue?: false, value: 3, target: Add},
+               context
+             ) == {:ok, %{value: 3}}
+    end
+
     test "a terminal expander can close normally or select the next executable" do
       flow = dispatch_flow!()
 

--- a/test/jido_exec/terminal_transition_test.exs
+++ b/test/jido_exec/terminal_transition_test.exs
@@ -10,6 +10,7 @@ defmodule JidoActionTest.Exec.TerminalTransitionTest do
   alias Jido.Flow.{Dispatch, Ref, Step}
   alias JidoActionTest.Fixtures.Actions.{Add, ExtrasAction}
   alias JidoActionTest.Fixtures.MathFlow
+  alias JidoActionTest.Fixtures.InlineResultFlow
 
   defmodule ContinueToAdd do
     use Jido.Action,
@@ -315,6 +316,21 @@ defmodule JidoActionTest.Exec.TerminalTransitionTest do
 
       assert {:error, %ExecutionFailureError{message: message}} = Exec.run(flow)
       assert message == "action continuation is not allowed from this Flow position"
+    end
+
+    test "an inline continuation is valid only when its Action is the root target" do
+      action = InlineResultFlow.step_action("result")
+      input = %{mode: :continue, value: 3}
+
+      assert Exec.run(action, input) == {:ok, %{value: 5}}
+
+      assert {:error, %ExecutionFailureError{message: message, details: details}} =
+               Exec.run(InlineResultFlow, input)
+
+      assert message == "action continuation is not allowed from this Flow position"
+      assert details.action == action
+      assert details.component == "result"
+      assert details.component_kind == :node
     end
 
     test "Dispatch must end every Flow path and be the exact Flow output" do

--- a/test/jido_executable_test.exs
+++ b/test/jido_executable_test.exs
@@ -45,6 +45,15 @@ defmodule JidoActionTest.ExecutableTest do
     assert {:ok, MathFlow.__jido_executable__()} == Executable.resolve(MathFlow)
   end
 
+  test "inline Step wrappers expose ordinary Action descriptors" do
+    for step <- JidoActionTest.Fixtures.InlineGreetingFlow.flow().components do
+      action = step.action
+      assert {:ok, %Executable{kind: :action, target: ^action}} = Executable.resolve(action)
+      assert :ok = Executable.validate(action)
+      assert action.__jido_executable__() == Executable.action(action)
+    end
+  end
+
   test "Flow artifacts resolve through the same descriptor type" do
     flow = MathFlow.flow()
 

--- a/test/jido_flow/canonical_authoring_test.exs
+++ b/test/jido_flow/canonical_authoring_test.exs
@@ -123,8 +123,92 @@ defmodule Jido.Flow.CanonicalAuthoringTest do
   alias Jido.Flow.Subflow
   alias JidoActionTest.Fixtures.CodecRegistry
   alias JidoActionTest.Fixtures.FlowAuthoring
+  alias JidoActionTest.Fixtures.InlineAuthoring
+  alias JidoActionTest.Fixtures.InlineParityFlow
   alias JidoActionTest.Fixtures.NestedFlow
   alias JidoActionTest.Fixtures.Actions.Add
+
+  test "all inline binding forms have equal DSL, Builder, direct, and JSON graphs and results" do
+    direct = InlineAuthoring.direct_flow!()
+    assert {:ok, built} = InlineAuthoring.builder() |> Builder.build()
+    dsl = InlineParityFlow.flow()
+    assert built == direct
+    assert dsl == direct
+
+    registry = InlineAuthoring.registry()
+    assert {:ok, document} = Codec.encode(built, registry)
+
+    assert Enum.map(document["components"], & &1["action"]) == [
+             "actions/demo/empty/v1",
+             "actions/demo/named/v1",
+             "actions/demo/multiple/v1",
+             "actions/demo/sole-map/v1"
+           ]
+
+    assert {:ok, decoded} =
+             document |> Jason.encode!() |> Jason.decode!() |> Codec.decode(registry)
+
+    assert decoded == direct
+
+    input = %{
+      raw_name: " Ada ",
+      payload: %{"profile" => %{"city" => "London"}, "active" => true, "extra" => "preserved"}
+    }
+
+    expected = %{
+      "empty" => %{ready: true},
+      "greeting" => %{message: "Welcome, Ada!"},
+      "profile" => %{city: "London"}
+    }
+
+    for flow <- [dsl, built, direct, decoded] do
+      assert Jido.Exec.run(flow, input, %{prefix: "Welcome"}) == {:ok, expected}
+    end
+  end
+
+  test "looked-up Actions use only the new Builder refs, dependencies, and metadata" do
+    action = InlineParityFlow.step_action(:multiple)
+
+    assert {:ok, flow} =
+             Builder.new(name: "reused_inline")
+             |> Builder.step("gate", InlineParityFlow.step_action(:empty), %{})
+             |> Builder.step(
+               "message",
+               action,
+               %{name: Builder.input(:recipient), prefix: Builder.input(:salutation)},
+               after: ["gate"],
+               meta: %{owner: "builder"}
+             )
+             |> Builder.output(Builder.result("message"))
+             |> Builder.build()
+
+    assert [_, %Step{} = reused] = flow.components
+    assert reused.action == action
+    assert reused.params == %{name: Ref.input(:recipient), prefix: Ref.input(:salutation)}
+    assert reused.after == ["gate"]
+    assert reused.meta == %{owner: "builder"}
+
+    assert {:ok, %{"message" => %{after: ["gate"], references: [], effective: ["gate"]}}} =
+             Flow.dependencies(flow)
+
+    assert Jido.Exec.run(flow, %{recipient: "Grace", salutation: "Hi"}) ==
+             {:ok, %{message: "Hi, Grace!"}}
+  end
+
+  test "a normal Map can reuse a looked-up inline Action with item refs" do
+    action = InlineParityFlow.step_action("named")
+
+    assert {:ok, flow} =
+             Builder.new(name: "mapped_inline")
+             |> Builder.map("names", Builder.input(:people), action, %{name: Builder.item()})
+             |> Builder.output(%{names: Builder.result("names")})
+             |> Builder.build()
+
+    assert [%FlowMap{action: ^action, params: %{name: %Ref{source: :item}}}] = flow.components
+
+    assert Jido.Exec.run(flow, %{people: [" Ada ", " Grace "]}) ==
+             {:ok, %{names: [%{name: "Ada"}, %{name: "Grace"}]}}
+  end
 
   test "direct, Builder, and Spark Step authoring produce the same canonical data" do
     direct =

--- a/test/jido_flow/codec_test.exs
+++ b/test/jido_flow/codec_test.exs
@@ -1,5 +1,5 @@
 defmodule Jido.Flow.CodecTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Jido.Flow.Error.InvalidDefinitionError
   alias Jido.Flow
@@ -14,8 +14,166 @@ defmodule Jido.Flow.CodecTest do
   alias Jido.Flow.Subflow
   alias JidoActionTest.Fixtures.CodecRegistry
   alias JidoActionTest.Fixtures.FlowAuthoring
+  alias JidoActionTest.Fixtures.InlineAuthoring
+  alias JidoActionTest.Fixtures.InlineParityFlow
   alias JidoActionTest.Fixtures.NestedFlow
   alias JidoActionTest.Fixtures.Actions.{Add, Multiply}
+
+  defmodule InlineProbeFlow do
+    @moduledoc false
+
+    use Jido.Flow, name: "inline_codec_probe"
+
+    flow do
+      step "mark", marker <- value("stored") do
+        send(Jido.Flow.CodecTest.InlineProbeObserver, {:inline_codec_body, marker, self()})
+        {:ok, %{marker: marker}}
+      end
+
+      output(result("mark"))
+    end
+  end
+
+  setup context do
+    if context[:inline_probe] do
+      observer_name = __MODULE__.InlineProbeObserver
+      assert Process.register(self(), observer_name)
+
+      # The VM removes this registration on every exit of the test owner.
+      on_exit(fn -> assert Process.whereis(observer_name) == nil end)
+    end
+
+    :ok
+  end
+
+  test "inline Steps use the exact version 1 stored Step fields" do
+    assert {:ok, document} = Codec.encode(InlineParityFlow.flow(), InlineAuthoring.registry())
+    assert document["version"] == 1
+
+    for step <- document["components"] do
+      assert step["kind"] == "step"
+      assert Enum.sort(Map.keys(step)) == ["action", "after", "kind", "meta", "name", "params"]
+    end
+
+    [empty, named, multiple, sole_map] = document["components"]
+    assert empty["params"] == %{"$type" => "map", "entries" => []}
+    assert [%{"key" => %{"$type" => "atom", "id" => "atoms/name"}}] = named["params"]["entries"]
+
+    assert Enum.map(multiple["params"]["entries"], & &1["key"]["id"]) ==
+             ["atoms/name", "atoms/prefix"]
+
+    assert sole_map["params"] == %{
+             "$ref" => %{
+               "source" => "input",
+               "component" => nil,
+               "path" => [%{"$type" => "atom", "id" => "atoms/payload"}]
+             }
+           }
+  end
+
+  @tag :inline_probe
+  test "stored inline Steps reject body, code, callable, and run fields without work" do
+    registry = inline_probe_registry()
+    assert {:ok, document} = Codec.encode(InlineProbeFlow.flow(), registry)
+    [step] = document["components"]
+
+    for field <- ["body", "code", "callable", "run"] do
+      invalid = replace_component(document, 0, Map.put(step, field, "send(self(), :work)"))
+
+      assert {:error,
+              %InvalidDefinitionError{
+                message: "stored Flow contains an unknown field",
+                details: %{field: ^field, path: ["components", 0, ^field]}
+              }} = invalid |> Jason.encode!() |> Jason.decode!() |> Codec.decode(registry)
+    end
+
+    # The synchronous decode calls above are the barrier for this mailbox check.
+    refute_received {:inline_codec_body, _, _}
+  end
+
+  @tag :inline_probe
+  test "inline Action and binding atom identifiers must exist in the trusted Registry" do
+    flow = InlineProbeFlow.flow()
+    registry = inline_probe_registry()
+    assert {:ok, document} = Codec.encode(flow, registry)
+    [step] = document["components"]
+    unknown_action = "untrusted/inline-action/#{System.unique_integer([:positive])}"
+    unknown_atom = "untrusted/inline-binding/#{System.unique_integer([:positive])}"
+
+    refute existing_atom?(unknown_action)
+    refute existing_atom?(unknown_atom)
+
+    for {identifier, message} <- [
+          {unknown_action, "unknown flow registry identifier"},
+          {"flows/not-an-action", "flow registry identifier has the wrong entry kind"}
+        ] do
+      invalid = replace_component(document, 0, %{step | "action" => identifier})
+
+      assert {:error,
+              %InvalidDefinitionError{
+                message: ^message,
+                details: %{identifier: ^identifier, path: ["components", 0, "action"]}
+              }} = Codec.decode(invalid, registry)
+    end
+
+    missing_binding = Registry.new!(Map.delete(registry.entries, "atoms/marker"))
+
+    assert {:error, %InvalidDefinitionError{details: %{kind: :atom}}} =
+             Codec.encode(flow, missing_binding)
+
+    assert {:error,
+            %InvalidDefinitionError{
+              message: "unknown flow registry identifier",
+              details: %{
+                identifier: "atoms/marker",
+                path: ["components", 0, "params", "entries", 0, "key", "id"]
+              }
+            }} = Codec.decode(document, missing_binding)
+
+    [entry] = step["params"]["entries"]
+    untrusted_entry = %{entry | "key" => %{"$type" => "atom", "id" => unknown_atom}}
+    invalid = put_in(step, ["params", "entries"], [untrusted_entry])
+
+    assert {:error,
+            %InvalidDefinitionError{
+              message: "unknown flow registry identifier",
+              details: %{identifier: ^unknown_atom, kind: :atom}
+            }} = Codec.decode(replace_component(document, 0, invalid), registry)
+
+    refute existing_atom?(unknown_action)
+    refute existing_atom?(unknown_atom)
+    refute_received {:inline_codec_body, _, _}
+  end
+
+  @tag :inline_probe
+  test "lookup, validation, inspection, and JSON operations do not run an inline body" do
+    action = InlineProbeFlow.step_action(:mark)
+    marker = make_ref()
+
+    assert Jido.Exec.run(action, %{marker: marker}) == {:ok, %{marker: marker}}
+    assert_received {:inline_codec_body, ^marker, worker}
+    refute worker == self()
+    refute_received {:inline_codec_body, _, _}
+
+    flow = InlineProbeFlow.flow()
+    registry = inline_probe_registry()
+
+    assert InlineProbeFlow.step_action("mark") == action
+    assert [%Step{action: ^action}] = flow.components
+    assert {:ok, ^flow} = Flow.validate(flow)
+    assert {:ok, ^flow} = Flow.validate_executable(flow)
+    assert {:ok, _} = Flow.explain(flow)
+    assert is_map(Flow.to_map(flow))
+    assert {:ok, document} = Codec.encode(flow, registry)
+
+    assert {:ok, ^flow} =
+             document |> Jason.encode!() |> Jason.decode!() |> Codec.decode(registry)
+
+    assert {:ok, ^flow} = Codec.diagnose(document, registry)
+    assert {:ok, temporary_document, temporary_registry} = Codec.encode(flow)
+    assert {:ok, ^flow} = Codec.decode(temporary_document, temporary_registry)
+    refute_received {:inline_codec_body, _, _}
+  end
 
   test "JSON bytes round trip to the equal canonical Flow" do
     flow = FlowAuthoring.mixed_flow!()
@@ -753,6 +911,15 @@ defmodule Jido.Flow.CodecTest do
       assert {:error, %Error.Invalid{errors: [_first | _rest]}} =
                Codec.diagnose(invalid, CodecRegistry.mixed())
     end
+  end
+
+  defp inline_probe_registry do
+    Registry.new!(%{
+      "actions/mark/v1" => {:action, InlineProbeFlow.step_action("mark")},
+      "flows/not-an-action" => {:flow, NestedFlow},
+      "atoms/marker" => {:atom, :marker},
+      "schemas/empty/v1" => {:schema, []}
+    })
   end
 
   defp replace_component(document, index, component) do

--- a/test/jido_flow/dsl/flow_test.exs
+++ b/test/jido_flow/dsl/flow_test.exs
@@ -49,6 +49,33 @@ defmodule Jido.Flow.DSL.FlowTest.MixedFlow do
   end
 end
 
+defmodule Jido.Flow.DSL.FlowTest.InlineAndExistingFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "inline_and_existing"
+
+  flow do
+    step "inline", name <- input(:name) do
+      {:ok, %{name: name}}
+    end
+
+    step "keyword",
+      action: JidoActionTest.Fixtures.Actions.Add,
+      params: %{value: 1, amount: 2}
+
+    step "field_block" do
+      action(JidoActionTest.Fixtures.Actions.Multiply)
+      params(%{value: result("keyword", :value), amount: 2})
+    end
+
+    step "child",
+      action: JidoActionTest.Fixtures.InlineGreetingFlow,
+      params: result("inline")
+
+    output(%{message: result("child", :message), value: result("field_block", :value)})
+  end
+end
+
 defmodule Jido.Flow.DSL.FlowTest do
   use ExUnit.Case, async: true
 
@@ -58,6 +85,15 @@ defmodule Jido.Flow.DSL.FlowTest do
   alias Jido.Flow.Reduce
   alias Jido.Flow.Ref
   alias Jido.Flow.Step
+
+  test "inline Steps coexist with keyword Steps, field-block Steps, and Subflows" do
+    module = Jido.Flow.DSL.FlowTest.InlineAndExistingFlow
+
+    assert [%Step{}, %Step{}, %Step{}, %Jido.Flow.Subflow{}] = module.flow().components
+
+    assert Jido.Exec.run(module, %{name: " Ada "}) ==
+             {:ok, %{message: "Hello, Ada!", value: 6}}
+  end
 
   test "the unchanged Spark forms lower directly to canonical records" do
     flow = Jido.Flow.DSL.FlowTest.MixedFlow.flow()

--- a/test/jido_flow/dsl/flow_test.exs
+++ b/test/jido_flow/dsl/flow_test.exs
@@ -95,6 +95,31 @@ defmodule Jido.Flow.DSL.FlowTest do
              {:ok, %{message: "Hello, Ada!", value: 6}}
   end
 
+  test "step_action returns only canonical Action-backed Step targets" do
+    module = Jido.Flow.DSL.FlowTest.InlineAndExistingFlow
+    [inline, keyword, field_block, _child] = module.flow().components
+
+    for step <- [inline, keyword, field_block] do
+      assert module.step_action(step.name) == step.action
+    end
+
+    assert module.step_action(:inline) == inline.action
+    assert module.step_action(:keyword) == JidoActionTest.Fixtures.Actions.Add
+    assert module.step_action(:field_block) == JidoActionTest.Fixtures.Actions.Multiply
+
+    for name <- ["child", "unknown", nil, "", 17, %{}, <<255>>, String.duplicate("x", 257)] do
+      assert_raise ArgumentError, ~r/expected an Action-backed Step name/, fn ->
+        module.step_action(name)
+      end
+    end
+
+    for name <- ["route", "mapped", "reduced", "loop"] do
+      assert_raise ArgumentError, ~r/expected an Action-backed Step name/, fn ->
+        Jido.Flow.DSL.FlowTest.MixedFlow.step_action(name)
+      end
+    end
+  end
+
   test "the unchanged Spark forms lower directly to canonical records" do
     flow = Jido.Flow.DSL.FlowTest.MixedFlow.flow()
 
@@ -115,6 +140,7 @@ defmodule Jido.Flow.DSL.FlowTest do
     for {name, arity} <- [
           __jido_executable__: 0,
           flow: 0,
+          step_action: 1,
           compiled: 0,
           name: 0,
           description: 0,

--- a/test/jido_flow/dsl/formatter_test.exs
+++ b/test/jido_flow/dsl/formatter_test.exs
@@ -87,11 +87,46 @@ defmodule Jido.Flow.DSL.FormatterTest do
   end
   """
 
+  @inline_flow """
+  flow do
+    step "one", name <- input(:name) do
+      {:ok, %{name: String.trim(name)}}
+    end
+
+    step "two", name <- result("one", :name), prefix <- context(:prefix) do
+      {:ok, %{message: prefix <> name}}
+    end
+
+    step "two_options", name <- input(:name), prefix <- context(:prefix), after: ["one"] do
+      {:ok, %{message: prefix <> name}}
+    end
+
+    step "list", [a <- input(:a), b <- input(:b), c <- input(:c)], after: ["two"] do
+      {:ok, %{total: a + b + c}}
+    end
+
+    step "pattern", %{name: name} <- input(), meta: %{owner: "example"} do
+      {:ok, %{name: name}}
+    end
+
+    step "empty", [], after: ["pattern"], meta: %{owner: "example"} do
+      {:ok, %{ready: true}}
+    end
+  end
+  """
+
+  @inline_keyword_flow """
+  step "one", name <- input(:name), do: {:ok, %{name: name}}
+  step "two", a <- input(:a), b <- input(:b), do: {:ok, %{sum: a + b}}
+  step "list", [a <- input(:a), b <- input(:b), c <- input(:c)], do: {:ok, %{sum: a + b + c}}
+  step "empty", [], do: {:ok, %{ready: true}}
+  """
+
   test "the project formatter preserves keyword and block declarations without parentheses" do
     {formatter, _opts} =
       Mix.Tasks.Format.formatter_for_file("flow.ex", dot_formatter: @formatter_path)
 
-    for source <- [@keyword_flow, @block_flow] do
+    for source <- [@keyword_flow, @block_flow, @inline_flow, @inline_keyword_flow] do
       assert formatter.(source) == source
       assert formatter.(formatter.(source)) == source
     end
@@ -108,8 +143,9 @@ defmodule Jido.Flow.DSL.FormatterTest do
         deps_paths: %{jido_action: @package_root}
       )
 
-    for source <- [@keyword_flow, @block_flow] do
+    for source <- [@keyword_flow, @block_flow, @inline_flow, @inline_keyword_flow] do
       assert formatter.(source) == source
+      assert formatter.(formatter.(source)) == source
     end
   end
 
@@ -123,5 +159,20 @@ defmodule Jido.Flow.DSL.FormatterTest do
 
     source = "step(1)\nstate(:count)\noutput(result(\"value\"))\nEnum.map(items, fun)\n"
     assert formatter.(source) == source
+  end
+
+  test "inline declarations with parentheses remain stable" do
+    {formatter, _opts} =
+      Mix.Tasks.Format.formatter_for_file("flow.ex", dot_formatter: @formatter_path)
+
+    source = """
+    step("one", name <- input(:name), do: {:ok, %{name: name}})
+    step("two", a <- input(:a), b <- input(:b), do: {:ok, %{sum: a + b}})
+    step("list", [a <- input(:a), b <- input(:b), c <- input(:c)], do: {:ok, %{sum: a + b + c}})
+    step("empty", [], do: {:ok, %{ready: true}})
+    """
+
+    assert formatter.(source) == source
+    assert formatter.(formatter.(source)) == source
   end
 end

--- a/test/jido_flow/dsl/inline_step_build_test.exs
+++ b/test/jido_flow/dsl/inline_step_build_test.exs
@@ -1,0 +1,242 @@
+defmodule Jido.Flow.DSL.InlineStepBuildTest do
+  use ExUnit.Case, async: false
+
+  @moduletag timeout: 180_000
+  @wrapper_prefix "Elixir.Jido.Flow.Generated.InlineStep."
+  @owner InlineBuild.Flow
+
+  setup do
+    directory =
+      Path.join(
+        System.tmp_dir!(),
+        "jido_inline_build_" <> Base.url_encode64(:crypto.strong_rand_bytes(12))
+      )
+
+    File.mkdir!(directory)
+    File.mkdir!(Path.join(directory, "lib"))
+    on_exit(fn -> File.rm_rf!(directory) end)
+
+    File.write!(Path.join(directory, "mix.exs"), """
+    defmodule InlineBuild.MixProject do
+      use Mix.Project
+      def project, do: [app: :inline_build, version: "0.1.0", deps: []]
+      def application, do: [extra_applications: [:jido_action]]
+    end
+    """)
+
+    paths =
+      :code.get_path()
+      |> Enum.map(&(&1 |> to_string() |> Path.expand()))
+      |> Enum.filter(&(Path.basename(&1) == "ebin" and File.dir?(&1)))
+
+    {:ok, directory: directory, paths: paths}
+  end
+
+  test "Mix emits deployable wrappers and removes old targets through rebuild and repair",
+       fixture do
+    write_source(fixture, "flow.ex", flow_source("first", 1))
+    assert_compile(fixture)
+    [first, second] = initial_targets = wrapper_beams(fixture)
+    assert length(initial_targets) == 2
+
+    initial = probe(fixture, "first", 3, 6)
+    assert initial["names"] == ["first", "second"]
+    assert initial["target"] in Enum.map([first, second], &Path.rootname/1)
+
+    # A body-only edit retains target identity but changes the deployed work.
+    write_source(fixture, "flow.ex", flow_source("first", 20))
+    assert_compile(fixture)
+    changed = probe(fixture, "first", 22, 44)
+    assert changed["target"] == initial["target"]
+    assert wrapper_beams(fixture) == initial_targets
+
+    # Rename and removal must update both the emitted beams and the static index.
+    write_source(fixture, "flow.ex", flow_source("renamed", 20))
+    assert_compile(fixture)
+    renamed = probe(fixture, "renamed", 22, 44, ["first"])
+    refute renamed["target"] == initial["target"]
+    refute (initial["target"] <> ".beam") in wrapper_beams(fixture)
+    assert length(wrapper_beams(fixture)) == 2
+
+    write_source(fixture, "flow.ex", flow_source("renamed", 20, second?: false))
+    assert_compile(fixture)
+    removed = probe(fixture, "renamed", 22, 22, ["first", "second"])
+    assert removed["names"] == ["renamed"]
+    assert wrapper_beams(fixture) == [renamed["target"] <> ".beam"]
+
+    # Failed owner compilation can leave modules loaded in that compiler VM.
+    # A later ordinary Mix build must recover without a foreign-owner error.
+    write_source(fixture, "flow.ex", flow_source("renamed", :invalid, second?: false))
+    {output, status} = compile(fixture)
+    assert status != 0
+    assert output =~ "missing_inline_body_function"
+
+    write_source(fixture, "flow.ex", flow_source("renamed", 30, second?: false))
+    assert_compile(fixture)
+    repaired = probe(fixture, "renamed", 32, 32, ["first", "second"])
+    assert repaired["target"] == renamed["target"]
+    assert wrapper_beams(fixture) == [repaired["target"] <> ".beam"]
+
+    write_source(fixture, "flow.ex", flow_source("failed_name", :invalid, second?: false))
+    {output, status} = compile(fixture)
+    assert status != 0
+    assert output =~ "missing_inline_body_function"
+    write_source(fixture, "flow.ex", flow_source("recovered", 400, second?: false))
+    assert_compile(fixture)
+    recovered = probe(fixture, "recovered", 402, 402, ["renamed", "failed_name", "second"])
+    assert wrapper_beams(fixture) == [recovered["target"] <> ".beam"]
+  end
+
+  test "a changed body macro recompiles the unchanged owner through Mix dependency tracking",
+       fixture do
+    write_source(fixture, "macro.ex", macro_source(1))
+    write_source(fixture, "flow.ex", flow_source("first", :macro))
+    assert_compile(fixture)
+    refute assert_compile(fixture) =~ "Compiling"
+    initial = probe(fixture, "first", 3, 6)
+    owner_path = Path.join(fixture.directory, "lib/flow.ex")
+    owner_source = File.read!(owner_path)
+    owner_stat = File.stat!(owner_path, time: :posix)
+    owner_beam = File.read!(Path.join(ebin(fixture), "Elixir.InlineBuild.Flow.beam"))
+
+    write_source(fixture, "macro.ex", macro_source(100))
+    output = assert_compile(fixture)
+
+    assert output =~ "Compiling"
+    assert File.read!(owner_path) == owner_source
+    assert File.stat!(owner_path, time: :posix).mtime == owner_stat.mtime
+    refute File.read!(Path.join(ebin(fixture), "Elixir.InlineBuild.Flow.beam")) == owner_beam
+    changed = probe(fixture, "first", 102, 204)
+    assert changed["target"] == initial["target"]
+  end
+
+  defp flow_source(name, version, options \\ []) do
+    body =
+      case version do
+        :invalid -> "missing_inline_body_function(value)"
+        :macro -> "InlineBuild.BodyMacro.increment(value)"
+        value -> "value + #{value}"
+      end
+
+    second =
+      if Keyword.get(options, :second?, true) do
+        """
+        step "second", value <- result(#{inspect(name)}, :value) do
+          {:ok, %{value: value * 2}}
+        end
+        output(result("second"))
+        """
+      else
+        "output(result(#{inspect(name)}))"
+      end
+
+    """
+    defmodule #{inspect(@owner)} do
+      use Jido.Flow, name: "inline_build"
+      #{if version == :macro, do: "require InlineBuild.BodyMacro", else: ""}
+      flow do
+        step #{inspect(name)}, value <- input(:value) do
+          {:ok, %{value: #{body}}}
+        end
+        #{second}
+      end
+    end
+    """
+  end
+
+  defp macro_source(increment) do
+    """
+    defmodule InlineBuild.BodyMacro do
+      defmacro increment(value) do
+        quote do: unquote(value) + #{increment}
+      end
+    end
+    """
+  end
+
+  defp write_source(fixture, file, source) do
+    path = Path.join([fixture.directory, "lib", file])
+    mtime = if File.exists?(path), do: File.stat!(path, time: :posix).mtime + 1, else: 946_684_800
+    File.write!(path, source)
+    # Advance only this source's recorded mtime. Use past times so same-second
+    # edits are deterministic without forcing unchanged owners or touching Mix state.
+    File.touch!(path, mtime)
+  end
+
+  defp assert_compile(fixture) do
+    {output, status} = compile(fixture)
+    assert status == 0, output
+    output
+  end
+
+  defp compile(fixture), do: child(fixture, ~s|Mix.CLI.main(["compile", "--warnings-as-errors"])|)
+
+  defp probe(fixture, name, direct_value, flow_value, missing \\ []) do
+    # The wrapper module atom comes from a real emitted beam, not owner lookup.
+    # This process has no source compilation call and starts with the owner unloaded.
+    script = """
+    {:ok, _} = Application.ensure_all_started(:jido_action)
+    owner = :"Elixir.InlineBuild.Flow"
+    {:before_registry, false} = {:before_registry, :code.is_loaded(owner)}
+    targets =
+      for file <- File.ls!(#{inspect(ebin(fixture))}),
+          String.starts_with?(file, #{inspect(@wrapper_prefix)}),
+          String.ends_with?(file, ".beam"),
+          do: file |> Path.rootname() |> String.to_atom()
+    target = Enum.find(targets, &(&1.name() == #{inspect(name)}))
+    registry = Jido.Flow.Registry.new!(%{"inline/step" => {:action, target}})
+    {:ok, ^target} = Jido.Flow.Registry.resolve(registry, "inline/step", :action)
+    {:after_registry, false} = {:after_registry, :code.is_loaded(owner)}
+    {:ok, %{value: #{direct_value}}} = Jido.Exec.run(target, %{value: 2})
+    ^target = apply(owner, :step_action, [#{inspect(name)}])
+    {:ok, %{value: #{flow_value}}} = Jido.Exec.run(owner, %{value: 2})
+    for name <- #{inspect(missing)} do
+      try do
+        apply(owner, :step_action, [name])
+        raise "stale lookup entry"
+      rescue
+        ArgumentError -> :ok
+      end
+    end
+    IO.puts("INLINE_BUILD_RESULT=" <> JSON.encode!(%{
+      "target" => Atom.to_string(target),
+      "names" => Enum.map(apply(owner, :flow, []).components, & &1.name)
+    }))
+    """
+
+    {output, status} = child(fixture, script)
+    assert status == 0, output
+    [_, json] = Regex.run(~r/INLINE_BUILD_RESULT=(.*)/, output)
+    JSON.decode!(json)
+  end
+
+  defp wrapper_beams(fixture) do
+    fixture
+    |> ebin()
+    |> File.ls!()
+    |> Enum.filter(&(String.starts_with?(&1, @wrapper_prefix) and String.ends_with?(&1, ".beam")))
+    |> Enum.sort()
+  end
+
+  defp ebin(fixture), do: Path.join(fixture.directory, "_build/test/lib/inline_build/ebin")
+
+  defp child(fixture, script) do
+    # Bound the child VM itself. ExUnit timeouts alone cannot stop an OS child.
+    watchdog = "spawn(fn -> receive do after 30_000 -> System.halt(124) end end)\n"
+    paths = [ebin(fixture) | fixture.paths]
+    args = Enum.flat_map(paths, &["-pa", &1]) ++ ["-e", watchdog <> script]
+
+    System.cmd(System.find_executable("elixir"), args,
+      cd: fixture.directory,
+      stderr_to_stdout: true,
+      env: [
+        {"MIX_ENV", "test"},
+        {"MIX_BUILD_PATH", Path.join(fixture.directory, "_build/test")},
+        {"MIX_DEPS_PATH", nil},
+        {"MIX_TARGET", "host"},
+        {"ERL_FLAGS", "+S 2:2 +SDcpu 1 +SDio 1"},
+        {"ELIXIR_ERL_OPTIONS", nil}
+      ]
+    )
+  end
+end

--- a/test/jido_flow/dsl/inline_step_build_test.exs
+++ b/test/jido_flow/dsl/inline_step_build_test.exs
@@ -48,6 +48,7 @@ defmodule Jido.Flow.DSL.InlineStepBuildTest do
     assert_compile(fixture)
     changed = probe(fixture, "first", 22, 44)
     assert changed["target"] == initial["target"]
+    assert changed["semantic_identity"] == initial["semantic_identity"]
     assert wrapper_beams(fixture) == initial_targets
 
     # Rename and removal must update both the emitted beams and the static index.
@@ -198,8 +199,10 @@ defmodule Jido.Flow.DSL.InlineStepBuildTest do
         ArgumentError -> :ok
       end
     end
+    {:ok, semantic_identity} = Jido.Flow.semantic_identity(apply(owner, :flow, []))
     IO.puts("INLINE_BUILD_RESULT=" <> JSON.encode!(%{
       "target" => Atom.to_string(target),
+      "semantic_identity" => semantic_identity,
       "names" => Enum.map(apply(owner, :flow, []).components, & &1.name)
     }))
     """

--- a/test/jido_flow/dsl/inline_step_build_test.exs
+++ b/test/jido_flow/dsl/inline_step_build_test.exs
@@ -32,7 +32,7 @@ defmodule Jido.Flow.DSL.InlineStepBuildTest do
     {:ok, directory: directory, paths: paths}
   end
 
-  test "Mix emits deployable wrappers and removes old targets through rebuild and repair",
+  test "Mix emits attribute-named targets and removes old targets through rebuild and repair",
        fixture do
     write_source(fixture, "flow.ex", flow_source("first", 1))
     assert_compile(fixture)
@@ -134,9 +134,10 @@ defmodule Jido.Flow.DSL.InlineStepBuildTest do
     """
     defmodule #{inspect(@owner)} do
       use Jido.Flow, name: "inline_build"
+      @step_name #{inspect(name)}
       #{if version == :macro, do: "require InlineBuild.BodyMacro", else: ""}
       flow do
-        step #{inspect(name)}, value <- input(:value) do
+        step @step_name, value <- input(:value) do
           {:ok, %{value: #{body}}}
         end
         #{second}

--- a/test/jido_flow/dsl/inline_step_docs_test.exs
+++ b/test/jido_flow/dsl/inline_step_docs_test.exs
@@ -1,0 +1,188 @@
+defmodule Jido.Flow.DSL.InlineStepDocsTest do
+  use ExUnit.Case, async: false
+
+  @root Path.expand("../../..", __DIR__)
+  @owners [
+    "Elixir.FirstFlow.",
+    "Elixir.FlowSteps.",
+    "Elixir.FlowLanguage.",
+    "Elixir.MyApp.Flows.SimpleGreeting",
+    "Elixir.MyApp.Flows.Greeting",
+    "Elixir.ActionGuide."
+  ]
+
+  setup do
+    assert owned_modules() == [], "documentation example modules must not already be loaded"
+
+    on_exit(fn ->
+      for module <- owned_modules() do
+        :code.purge(module)
+        :code.delete(module)
+      end
+    end)
+  end
+
+  test "the first-Flow guide runs, extracts an Action, and agrees with Builder and real JSON" do
+    first = eval_cells("guides/build-your-first-flow.livemd", install: true)
+    flow = Keyword.fetch!(first, :flow)
+
+    assert {:ok, %{message: "Hello, Ada!"}} = Jido.Exec.run(flow, %{name: " Ada "})
+    assert length(flow.components) == 2
+    assert Enum.all?(flow.components, &match?(%Jido.Flow.Step{}, &1))
+
+    for step <- flow.components do
+      assert step.action.__jido_inline_step__() == {FirstFlow.Greeting, step.name}
+    end
+
+    assert flow.schema != []
+    assert flow.output_schema != []
+
+    built = eval_cells("guides/flow-builder.md", section: "Reuse An Inline Step")
+    built_flow = Keyword.fetch!(built, :built_flow)
+    assert built_flow == flow
+
+    stored = eval_cells("guides/flow-storage.md", section: "Store A Compiled Inline Step")
+    restored = Keyword.fetch!(stored, :restored)
+    document = Keyword.fetch!(stored, :document)
+    json = Keyword.fetch!(stored, :json)
+
+    assert restored == built_flow
+    assert is_binary(json)
+    assert JSON.decode!(json) == document
+    assert document["version"] == 1
+
+    assert Enum.map(document["components"], & &1["action"]) == [
+             "actions/greeting/normalize/v1",
+             "actions/greeting/greet/v1"
+           ]
+
+    for step <- document["components"] do
+      assert Enum.sort(Map.keys(step)) == ["action", "after", "kind", "meta", "name", "params"]
+    end
+
+    assert {:ok, %{message: "Hello, Ada!"}} = Jido.Exec.run(restored, %{name: " Ada "})
+  end
+
+  test "the Steps Livebook runs every binding form and the existing Action forms" do
+    bindings = eval_cells("guides/flow-steps.livemd", install: true)
+
+    assert Keyword.fetch!(bindings, :output) == %{
+             first: %{value: 7},
+             second: %{value: 7, tag: :complete}
+           }
+
+    flow = apply(FlowSteps.Inline, :flow, [])
+
+    assert Enum.map(flow.components, & &1.name) == [
+             "ready",
+             "normalize",
+             "greet",
+             "label",
+             "profile"
+           ]
+
+    for step <- flow.components do
+      assert step.action.__jido_inline_step__() == {FlowSteps.Inline, step.name}
+    end
+
+    [ready, normalize, greet, label, profile] = flow.components
+    assert ready.params == %{}
+    assert normalize.params == %{name: Jido.Flow.Ref.input(:name)}
+    assert Enum.sort(Map.keys(greet.params)) == [:name, :prefix]
+    assert Enum.sort(Map.keys(label.params)) == [:city, :ctx, :name]
+    assert label.params.ctx == Jido.Flow.Ref.context()
+    assert profile.params == Jido.Flow.Ref.input(:profile)
+  end
+
+  test "the DSL Livebook combines an inline Step with the other component forms" do
+    bindings = eval_cells("guides/flow-language.livemd", install: true)
+
+    assert Keyword.fetch!(bindings, :result) == %{
+             route: %{route: :fast, value: 10},
+             values: [1, 2, 3],
+             counter: %{count: 2}
+           }
+  end
+
+  test "the README, Action guide, and Flow module example compile from their source" do
+    eval_cells("README.md", section: "Use Inline Steps For Small Operations", level: 3)
+    eval_cells("guides/actions.md", section: "Use An Inline Step For Small Local Work")
+    eval_cells("guides/flow-modules.md", section: "Define A Module")
+    eval_cells("guides/flow-modules.md", section: "Generated API")
+
+    for owner <- [MyApp.Flows.SimpleGreeting, ActionGuide.Greeting, MyApp.Flows.Greeting] do
+      assert {:ok, %{message: "Hello, Ada!"}} = Jido.Exec.run(owner, %{name: "Ada"})
+    end
+  end
+
+  defp eval_cells(relative_path, opts) do
+    path = Path.join(@root, relative_path)
+    source = path |> File.read!() |> select_section(opts)
+
+    cells =
+      for [block, code] <- Regex.scan(~r/^```elixir\n(.*?)^```/ms, source, return: :index),
+          not markdown_cell?(source, block) do
+        {start, length} = code
+        binary_part(source, start, length)
+      end
+
+    assert cells != [], "no Elixir cells found in #{relative_path}"
+    {install, cells} = Enum.split_with(cells, &String.starts_with?(&1, "Mix.install("))
+
+    if opts[:install] do
+      assert [install_cell] = install
+      assert install_cell =~ ~s|path: System.fetch_env!("JIDO_ACTION_PATH")|
+    else
+      assert install == []
+    end
+
+    # Mix already owns this test application's dependencies. Execute every
+    # other cell from the guide, with one shared binding scope per guide.
+    {{_value, bindings}, diagnostics} =
+      Code.with_diagnostics(fn ->
+        Code.eval_string(Enum.join(cells, "\n\n"), [], file: path)
+      end)
+
+    assert diagnostics == []
+    bindings
+  end
+
+  defp select_section(source, opts) do
+    case opts[:section] do
+      nil ->
+        source
+
+      heading ->
+        marker = String.duplicate("#", Keyword.get(opts, :level, 2)) <> " " <> heading <> "\n"
+        [_, section] = String.split(source, marker, parts: 2)
+        section |> String.split(~r/^\#{1,3} /m, parts: 2) |> hd()
+    end
+  end
+
+  defp markdown_cell?(source, {start, _length}) do
+    source
+    |> binary_part(0, start)
+    |> String.trim_trailing()
+    |> String.ends_with?(~s(<!-- livebook:{"force_markdown":true} -->))
+  end
+
+  defp owned_modules do
+    for {module, _path} <- :code.all_loaded(), owned_module?(module), do: module
+  end
+
+  defp owned_module?(module) do
+    name = Atom.to_string(module)
+
+    cond do
+      String.starts_with?(name, @owners) ->
+        true
+
+      String.starts_with?(name, "Elixir.Jido.Flow.Generated.InlineStep.") ->
+        {owner, _step} = module.__jido_inline_step__()
+        String.starts_with?(Atom.to_string(owner), @owners)
+
+      true ->
+        false
+    end
+  end
+end

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -824,6 +824,22 @@ defmodule Jido.Flow.DSL.InlineStepTest do
     assert parse(source).pattern_ast == pattern_ast
   end
 
+  test "map patterns reject equivalent signed literal keys" do
+    for pattern <- [
+          "%{-1 => first,\n  -1 => second}",
+          "%{+1 => first, 1 => second}",
+          "%{1 => first, +1 => second}"
+        ] do
+      error =
+        assert_raise CompileError, ~r/duplicate inline Step map key/, fn ->
+          parse("step :read, #{pattern} <- input(), do: :ok")
+        end
+
+      assert error.file == @source_file
+      assert error.line == @source_line
+    end
+  end
+
   defp parse(source) do
     {:step, _, [_name | arguments]} = ast(source)
     apply(InlineStep, :parse!, arguments ++ [caller()])

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -7,6 +7,224 @@ defmodule Jido.Flow.DSL.InlineStepTest do
   @source_file "inline_header.ex"
   @source_line 40
 
+  defmodule NameSource do
+    defmacro literal_name do
+      send(self(), :inline_name_macro_expanded)
+      "macro_name"
+    end
+
+    def expression_name do
+      send(self(), :inline_name_expression_evaluated)
+      "expression_name"
+    end
+  end
+
+  test "legacy Step names expand or evaluate once" do
+    for {expression, marker, name} <- [
+          {"#{inspect(NameSource)}.literal_name()", :inline_name_macro_expanded, "macro_name"},
+          {"#{inspect(NameSource)}.expression_name()", :inline_name_expression_evaluated,
+           "expression_name"}
+        ] do
+      owner = unique_owner("LegacyName")
+
+      declaration =
+        "step #{expression}, action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}"
+
+      compile_source(flow_source(owner, declaration, "require #{inspect(NameSource)}"))
+      assert_received ^marker
+      refute_received ^marker
+      assert owner.step_action(name) == JidoActionTest.Fixtures.Actions.Add
+    end
+  end
+
+  test "a dynamic explicit name is registered before a later inline declaration" do
+    owner = unique_owner("DynamicDuplicate")
+    {target, _} = generated_identity(owner, "expression_name")
+
+    source = """
+    defmodule #{inspect(owner)} do
+      use Jido.Flow, name: "dynamic_duplicate"
+      flow do
+        step #{inspect(NameSource)}.expression_name(), action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}
+        step "expression_name", [], do: {:ok, %{}}
+        output(%{})
+      end
+    end
+    """
+
+    error =
+      assert_raise CompileError, ~r/duplicate Step name: "expression_name"/, fn ->
+        compile_source(source)
+      end
+
+    assert error.line == 5
+    assert_received :inline_name_expression_evaluated
+    refute_received :inline_name_expression_evaluated
+    refute Code.ensure_loaded?(target)
+  end
+
+  test "a Step in a false authoring branch does not reserve its name" do
+    for unused <- [
+          ~s(step "same", action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}),
+          ~s(step "same", [], do: {:ok, %{value: :unused}})
+        ] do
+      owner = unique_owner("Conditional")
+
+      declarations = """
+      if false do
+        #{unused}
+      end
+      step "same", [], do: {:ok, %{value: :used}}
+      """
+
+      compile_source(flow_source(owner, declarations))
+      assert [%Jido.Flow.Step{name: "same"}] = owner.flow().components
+      assert owner.step_action("same").run(%{}, %{}) == {:ok, %{value: :used}}
+    end
+  end
+
+  test "duplicate Steps fail before a second inline target can replace the first" do
+    inline = ~s(step :same, [], do: {:ok, %{value: :first}})
+    replacement = ~s(step "same", [], do: {:ok, %{value: :second}})
+    keyword = ~s(step "same", action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1})
+
+    block =
+      "step \"same\" do\n action(JidoActionTest.Fixtures.Actions.Add)\n params(%{value: 1})\n end"
+
+    for {first, second} <- [
+          {inline, replacement},
+          {inline, keyword},
+          {keyword, inline},
+          {inline, block},
+          {block, inline}
+        ] do
+      owner = unique_owner("Duplicate")
+      target = generated_identity(owner, "same") |> elem(0)
+
+      assert_raise CompileError, ~r/duplicate Step name: "same"/, fn ->
+        compile_source(flow_source(owner, first <> "\n" <> second))
+      end
+
+      if first == inline do
+        assert target.__jido_inline_step__() == {owner, "same"}
+      else
+        refute Code.ensure_loaded?(target)
+      end
+    end
+  end
+
+  test "foreign generated module names cannot be overwritten" do
+    owner = unique_owner("Foreign")
+    {target, _function} = generated_identity(owner, "same")
+    compile_source("defmodule #{inspect(target)} do\n def untouched, do: :foreign\nend")
+
+    assert_raise CompileError, ~r/generated inline Step module.*already belongs/, fn ->
+      compile_source(flow_source(owner, ~s(step "same", [], do: {:ok, %{}})))
+    end
+
+    assert target.untouched() == :foreign
+    refute function_exported?(target, :run, 2)
+  end
+
+  test "generated owner functions and lookup reject user clauses before and after declarations" do
+    for position <- [:before, :after], kind <- [:body, :lookup], visibility <- [:def, :defp] do
+      owner = unique_owner("Reserved")
+      {_target, body_function} = generated_identity(owner, "same")
+      {function, args} = if kind == :body, do: {body_function, "_, _"}, else: {:step_action, "_"}
+      clause = "#{visibility} #{function}(#{args}), do: :user_clause"
+      declaration = ~s(step "same", [], do: {:ok, %{}})
+      {before, after_code} = if position == :before, do: {clause, ""}, else: {"", clause}
+
+      # Elixir itself rejects a private clause after a public generated body
+      # before it calls the definition callback.
+      message =
+        if position == :after and kind == :body and visibility == :defp,
+          do: ~r/cannot compile file|already defined as def/,
+          else: ~r/reserved Flow function.*#{function}/
+
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert_raise CompileError, message, fn ->
+          compile_source(flow_source(owner, declaration, before, after_code))
+        end
+      end)
+    end
+  end
+
+  test "lookup is reserved even when it is defined before use Jido.Flow" do
+    owner = unique_owner("EarlyLookup")
+
+    assert_raise CompileError, ~r/reserved Flow function.*step_action/, fn ->
+      compile_source("""
+      defmodule #{inspect(owner)} do
+        def step_action(_), do: :user_clause
+        use Jido.Flow, name: "early_lookup"
+        flow do
+          step "same", action: JidoActionTest.Fixtures.Actions.Add
+          output(%{})
+        end
+      end
+      """)
+    end
+  end
+
+  test "bounded target names preserve long, punctuation, and Unicode names across owners" do
+    names = [String.duplicate("x", 256), "hello-world?!", "café/世界"]
+    owner = unique_owner(String.duplicate("L", 150))
+    other = unique_owner("Other")
+    declarations = Enum.map_join(names, "\n", &"step #{inspect(&1)}, [], do: {:ok, %{}}")
+    compile_source(flow_source(owner, declarations))
+    compile_source(flow_source(other, declarations))
+
+    for name <- names do
+      target = owner.step_action(name)
+      assert target != other.step_action(name)
+      assert byte_size(Atom.to_string(target)) < 128
+      assert target.name() == name
+      assert target.__jido_inline_step__() == {owner, name}
+    end
+  end
+
+  test "normal recompilation keeps identity and replaces the body" do
+    owner = unique_owner("Recompiled")
+    compile_source(flow_source(owner, ~s(step "same", [], do: {:ok, %{version: 1}})))
+    target = owner.step_action("same")
+
+    ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      compile_source(flow_source(owner, ~s(step "same", [], do: {:ok, %{version: 2}})))
+    end)
+
+    assert owner.step_action("same") == target
+    assert target.run(%{}, %{}) == {:ok, %{version: 2}}
+  end
+
+  test "repeated runtime access creates no target modules or atoms from unknown names" do
+    owner = JidoActionTest.Fixtures.InlineGreetingFlow
+
+    unknown_names =
+      for n <- 1..100, do: "unknown_inline_step_#{n}_#{System.unique_integer([:positive])}"
+
+    access = fn ->
+      for name <- unknown_names do
+        assert_raise ArgumentError, fn -> owner.step_action(name) end
+      end
+
+      assert is_atom(owner.step_action(:greet))
+      assert {:ok, _} = Jido.Flow.validate(owner.flow())
+      assert {:ok, _} = Jido.Exec.run(owner, %{name: "Ada"})
+    end
+
+    access.()
+    targets = generated_modules()
+    atoms = :erlang.system_info(:atom_count)
+    for _ <- 1..3, do: access.()
+    assert :erlang.system_info(:atom_count) == atoms
+    assert generated_modules() == targets
+
+    for name <- unknown_names do
+      assert_raise ArgumentError, fn -> String.to_existing_atom(name) end
+    end
+  end
+
   test "inline bindings compile and run through ordinary Steps with inferred dependencies" do
     assert [%Jido.Flow.Step{action: action, params: params}, %Jido.Flow.Step{}] =
              JidoActionTest.Fixtures.InlineGreetingFlow.flow().components
@@ -546,6 +764,38 @@ defmodule Jido.Flow.DSL.InlineStepTest do
   defp parse(source) do
     {:step, _, [_name | arguments]} = ast(source)
     apply(InlineStep, :parse!, arguments ++ [caller()])
+  end
+
+  defp unique_owner(prefix),
+    do: Module.concat(__MODULE__, "#{prefix}#{System.unique_integer([:positive])}")
+
+  defp flow_source(owner, declarations, before_code \\ "", after_code \\ "") do
+    """
+    defmodule #{inspect(owner)} do
+      use Jido.Flow, name: "inline_test"
+      #{before_code}
+      flow do
+        #{declarations}
+        output(%{})
+      end
+      #{after_code}
+    end
+    """
+  end
+
+  defp generated_identity(owner, name) do
+    digest =
+      :crypto.hash(:sha256, :erlang.term_to_binary({owner, name})) |> Base.encode16(case: :lower)
+
+    {Module.concat(Jido.Flow.Generated.InlineStep, "A" <> digest),
+     String.to_atom("__jido_inline_step_" <> digest)}
+  end
+
+  defp generated_modules do
+    for {module, _} <- :code.all_loaded(),
+        String.starts_with?(Atom.to_string(module), "Elixir.Jido.Flow.Generated.InlineStep."),
+        into: MapSet.new(),
+        do: module
   end
 
   defp ast(source), do: Code.string_to_quoted!(source, line: @source_line, columns: true)

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -40,21 +40,107 @@ defmodule Jido.Flow.DSL.InlineStepTest do
     end
   end
 
-  test "legacy Step names expand or evaluate once" do
+  test "Step names expand or evaluate once in either form" do
     for {expression, marker, name} <- [
           {"#{inspect(NameSource)}.literal_name()", :inline_name_macro_expanded, "macro_name"},
           {"#{inspect(NameSource)}.expression_name()", :inline_name_expression_evaluated,
            "expression_name"}
-        ] do
-      owner = unique_owner("LegacyName")
+        ],
+        inline? <- [false, true] do
+      owner = unique_owner("EvaluatedName")
 
       declaration =
-        "step #{expression}, action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}"
+        if inline?,
+          do: "step #{expression}, value <- 1, do: {:ok, %{value: value + 1}}",
+          else:
+            "step #{expression}, action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}"
 
       compile_source(flow_source(owner, declaration, "require #{inspect(NameSource)}"))
       assert_received ^marker
       refute_received ^marker
-      assert owner.step_action(name) == JidoActionTest.Fixtures.Actions.Add
+      assert {:ok, %{value: 2}} = Jido.Exec.run(owner.step_action(name), %{value: 1})
+    end
+  end
+
+  test "string attribute names survive conversion from explicit to inline Steps" do
+    for declaration <- [
+          "step @step_name, action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}",
+          "step @step_name, value <- 1, do: {:ok, %{value: value + 1}}"
+        ] do
+      owner = unique_owner("AttributeName")
+
+      compile_source("""
+      defmodule #{inspect(owner)} do
+        use Jido.Flow, name: "attribute_name"
+        @step_name "increment"
+        flow do
+          #{declaration}
+          output result("increment")
+        end
+      end
+      """)
+
+      assert [%Jido.Flow.Step{name: "increment", action: action}] = owner.flow().components
+      assert owner.step_action("increment") == action
+      assert {:ok, %{value: 2}} = Jido.Exec.run(owner, %{})
+    end
+  end
+
+  test "inline names and bodies retain attributes at each declaration" do
+    owner = unique_owner("AttributeOrder")
+
+    declarations = """
+    step @step_name, [], do: {:ok, %{name: @step_name}}
+    @step_name "second"
+    step @step_name, [], do: {:ok, %{name: @step_name}}
+    """
+
+    compile_source(flow_source(owner, declarations, ~s(@step_name "first")))
+
+    assert Enum.map(owner.flow().components, & &1.name) == ["first", "second"]
+
+    for name <- ["first", "second"] do
+      {target, _} = generated_identity(owner, name)
+      assert owner.step_action(name) == target
+      assert target.name() == name
+      assert {:ok, %{name: ^name}} = Jido.Exec.run(target, %{})
+    end
+  end
+
+  test "attribute names detect mixed duplicates at the second declaration" do
+    inline = "step @step_name, [], do: {:ok, %{}}"
+    explicit = "step @step_name, action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}"
+
+    for {first, second} <- [{inline, explicit}, {explicit, inline}, {inline, inline}] do
+      owner = unique_owner("AttributeDuplicate")
+      {target, _} = generated_identity(owner, "same")
+      source = flow_source(owner, first <> "\n" <> second, ~s(@step_name "same"))
+
+      error =
+        assert_raise CompileError, ~r/duplicate Step name: "same"/, fn ->
+          compile_source(source)
+        end
+
+      assert error.file == "inline_compile.ex"
+      assert error.line == 6
+
+      if first == inline,
+        do: assert(target.__jido_inline_step__() == {owner, "same"}),
+        else: refute(Code.ensure_loaded?(target))
+    end
+  end
+
+  test "invalid evaluated inline names report the Step location" do
+    for value <- ["", nil, 123] do
+      owner = unique_owner("InvalidAttributeName")
+
+      source =
+        flow_source(owner, "step @step_name, [], do: {:ok, %{}}", "@step_name #{inspect(value)}")
+
+      error = assert_raise CompileError, fn -> compile_source(source) end
+      assert error.file == "inline_compile.ex"
+      assert error.line == 5
+      assert error.description =~ "name"
     end
   end
 
@@ -87,7 +173,8 @@ defmodule Jido.Flow.DSL.InlineStepTest do
   test "a Step in a false authoring branch does not reserve its name" do
     for unused <- [
           ~s(step "same", action: JidoActionTest.Fixtures.Actions.Add, params: %{value: 1}),
-          ~s(step "same", [], do: {:ok, %{value: :unused}})
+          ~s(step "same", [], do: {:ok, %{value: :unused}}),
+          "step #{inspect(NameSource)}.expression_name(), [], do: {:ok, %{}}"
         ] do
       owner = unique_owner("Conditional")
 
@@ -101,6 +188,9 @@ defmodule Jido.Flow.DSL.InlineStepTest do
       compile_source(flow_source(owner, declarations))
       assert [%Jido.Flow.Step{name: "same"}] = owner.flow().components
       assert owner.step_action("same").run(%{}, %{}) == {:ok, %{value: :used}}
+      refute_received :inline_name_expression_evaluated
+      {unused_target, _} = generated_identity(owner, "expression_name")
+      refute Code.ensure_loaded?(unused_target)
     end
   end
 
@@ -205,6 +295,77 @@ defmodule Jido.Flow.DSL.InlineStepTest do
       end
       """)
     end
+  end
+
+  test "default arguments that define reserved arities report the user declaration" do
+    for {kind, position} <- [{:lookup, :before}, {:lookup, :after}, {:body, :after}],
+        visibility <- [:def, :defp],
+        defaults <- [1, 2] do
+      owner = unique_owner("DefaultConflict")
+      {_target, body_function} = generated_identity(owner, "same")
+      {function, arity} = if kind == :lookup, do: {:step_action, 1}, else: {body_function, 2}
+      required = List.duplicate("_", arity)
+      optional = List.duplicate("_ \\\\ []", defaults)
+
+      clause =
+        "#{visibility} #{function}(#{Enum.join(required ++ optional, ", ")}), do: :user_clause"
+
+      {before, after_code} = if position == :before, do: {clause, ""}, else: {"", clause}
+      source = flow_source(owner, ~s(step "same", [], do: {:ok, %{}}), before, after_code)
+      clause_line = source |> String.split("\n") |> Enum.find_index(&(String.trim(&1) == clause))
+
+      {error, diagnostics} =
+        Code.with_diagnostics(fn ->
+          assert_raise CompileError, fn -> compile_source(source) end
+        end)
+
+      if error.description =~ "reserved Flow function" do
+        assert error.description =~ "#{function}/#{arity}"
+        assert error.file == "inline_compile.ex"
+        assert error.line == clause_line + 1
+      else
+        # Elixir can reject a private default-generated clause before our callback.
+        assert visibility == :defp
+        definition_line = if kind == :lookup, do: 2, else: 5
+
+        assert Enum.any?(diagnostics, fn diagnostic ->
+                 diagnostic.severity == :error and
+                   diagnostic.message ==
+                     "defp #{function}/#{arity} already defined as def in inline_compile.ex:#{definition_line}" and
+                   Path.basename(diagnostic.file) == "inline_compile.ex" and
+                   diagnostic_line(diagnostic) == clause_line + 1
+               end)
+      end
+    end
+  end
+
+  test "an earlier body helper with default arguments cannot be replaced by an inline Step" do
+    for visibility <- [:def, :defp] do
+      owner = unique_owner("EarlyDefaultBody")
+      {target, function} = generated_identity(owner, "same")
+      helper = "#{visibility} #{function}(_, _, _ \\\\ []), do: :user_clause"
+      source = flow_source(owner, ~s(step "same", [], do: {:ok, %{}}), helper)
+
+      error =
+        assert_raise CompileError, ~r/reserved Flow function.*#{function}\/2/, fn ->
+          compile_source(source)
+        end
+
+      # The Step is where this computed function name first becomes reserved.
+      assert error.file == "inline_compile.ex"
+      assert error.line == 5
+      refute Code.ensure_loaded?(target)
+    end
+  end
+
+  test "default arguments with no reserved arity remain valid" do
+    owner = unique_owner("AllowedDefaults")
+    helper = "def step_action(name, value, opts \\\\ []), do: {name, value, opts}"
+    compile_source(flow_source(owner, ~s(step "same", [], do: {:ok, %{}}), "", helper))
+
+    assert owner.step_action("same", :value) == {"same", :value, []}
+    assert owner.step_action("same", :value, [:option]) == {"same", :value, [:option]}
+    assert {:ok, %{}} = owner.step_action("same").run(%{}, %{})
   end
 
   test "bounded target names preserve long, punctuation, and Unicode names across owners" do

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -1,11 +1,285 @@
 defmodule Jido.Flow.DSL.InlineStepTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Jido.Flow.DSL.{Expression, InlineStep}
   alias Jido.Flow.Ref
 
   @source_file "inline_header.ex"
   @source_line 40
+
+  test "inline bindings compile and run through ordinary Steps with inferred dependencies" do
+    assert [%Jido.Flow.Step{action: action, params: params}, %Jido.Flow.Step{}] =
+             JidoActionTest.Fixtures.InlineGreetingFlow.flow().components
+
+    assert is_atom(action)
+    assert params == %{name: Ref.input(:name)}
+
+    assert Jido.Exec.run(JidoActionTest.Fixtures.InlineGreetingFlow, %{name: " Ada "}) ==
+             {:ok, %{message: "Hello, Ada!"}}
+
+    assert {:ok, dependencies} =
+             Jido.Flow.dependencies(JidoActionTest.Fixtures.InlineGreetingFlow.flow())
+
+    assert dependencies["greet"] == %{
+             after: [],
+             references: ["normalize"],
+             effective: ["normalize"]
+           }
+  end
+
+  test "bodies retain the declaration's aliases, imports, helpers, module, and attributes" do
+    module = JidoActionTest.Fixtures.InlineLexicalFlow
+    assert {:ok, result} = Jido.Exec.run(module, %{name: " Ada "})
+
+    assert result == %{
+             value: "[ADA!?]",
+             module: module,
+             prefix: "before",
+             qualified: %{name: "body", value: " Ada "},
+             local_import: %{name: "local", value: "[ADA!?]"}
+           }
+
+    assert module.current_prefix() == "after"
+    assert Enum.map(module.flow().components, & &1.name) == ["lexical", "local_import"]
+  end
+
+  test "canonical inline Steps contain only ordinary Action author data" do
+    flow = JidoActionTest.Fixtures.InlineGreetingFlow.flow()
+    map = Jido.Flow.to_map(flow)
+
+    for step <- flow.components do
+      assert Map.keys(Map.from_struct(step)) |> Enum.sort() ==
+               [:action, :after, :meta, :name, :params]
+
+      assert is_atom(step.action)
+      assert step.action.name() == step.name
+      assert step.action.schema() == []
+      assert step.action.output_schema() == []
+    end
+
+    assert canonical_data?(map)
+  end
+
+  test "compiler, validation, and inspection do not run inline work" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.InertFlow do
+      use Jido.Flow, name: "inline_inert"
+      flow do
+        step "mark", ctx <- context() do
+          send(ctx.owner, {:inline_work, ctx.marker})
+          {:ok, %{worked: true}}
+        end
+        output(result("mark"))
+      end
+    end
+    """
+
+    compile_source(source)
+    module = Module.concat(__MODULE__, InertFlow)
+    flow = module.flow()
+    assert {:ok, ^flow} = Jido.Flow.validate(flow)
+    assert {:ok, ^flow} = Jido.Flow.validate_executable(flow)
+    assert {:ok, _} = Jido.Flow.explain(flow)
+    assert {:ok, _} = Jido.Flow.compile(flow)
+    assert is_map(Jido.Flow.to_map(flow))
+    refute_received {:inline_work, _}
+
+    marker = make_ref()
+    assert {:ok, %{worked: true}} = Jido.Exec.run(module, %{}, %{owner: self(), marker: marker})
+    assert_received {:inline_work, ^marker}
+  end
+
+  test "undefined body calls report the user body file and line" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.UndefinedFlow do
+      use Jido.Flow, name: "inline_undefined"
+      flow do
+        step "bad", [] do
+          missing_inline_function()
+        end
+        output(result("bad"))
+      end
+    end
+    """
+
+    {_result, diagnostics} =
+      Code.with_diagnostics(fn ->
+        assert_raise CompileError, fn -> compile_source(source, "inline_undefined.ex") end
+      end)
+
+    assert Enum.any?(diagnostics, fn diagnostic ->
+             diagnostic.severity == :error and
+               diagnostic.message =~ "undefined function missing_inline_function/0" and
+               Path.basename(diagnostic.file) == "inline_undefined.ex" and
+               diagnostic_line(diagnostic) == 5
+           end)
+  end
+
+  test "declaration imports are not available inside the body function" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.NoDeclarationFlow do
+      use Jido.Flow, name: "inline_no_declaration"
+      flow do
+        step "bad", [] do
+          output(%{})
+        end
+        output(result("bad"))
+      end
+    end
+    """
+
+    {_result, diagnostics} =
+      Code.with_diagnostics(fn ->
+        assert_raise CompileError, fn -> compile_source(source, "inline_no_declaration.ex") end
+      end)
+
+    assert Enum.any?(diagnostics, fn diagnostic ->
+             diagnostic.severity == :error and diagnostic.message =~ "undefined function output/1" and
+               diagnostic_line(diagnostic) == 5
+           end)
+  end
+
+  test "unused user variables retain warnings at the header line" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.UnusedFlow do
+      use Jido.Flow, name: "inline_unused"
+      flow do
+        step "unused", user_value <- input(:value) do
+          body_value = :unused
+          {:ok, %{}}
+        end
+        output(result("unused"))
+      end
+    end
+    """
+
+    {_modules, diagnostics} =
+      Code.with_diagnostics(fn -> compile_source(source, "inline_unused.ex") end)
+
+    assert Enum.any?(diagnostics, fn diagnostic ->
+             diagnostic.severity == :warning and diagnostic.message =~ "user_value" and
+               diagnostic.message =~ "unused" and
+               Path.basename(diagnostic.file) == "inline_unused.ex" and
+               diagnostic_line(diagnostic) == 4
+           end)
+
+    assert Enum.any?(diagnostics, fn diagnostic ->
+             diagnostic.severity == :warning and diagnostic.message =~ "body_value" and
+               Path.basename(diagnostic.file) == "inline_unused.ex" and
+               diagnostic_line(diagnostic) == 5
+           end)
+  end
+
+  test "all inline macro arities lower their params, after, and meta through normal Steps" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.BindingFormsFlow do
+      use Jido.Flow, name: "inline_binding_forms"
+      alias URI, as: Address
+
+      flow do
+        step :seed, [] do
+          {:ok, %{ready: true}}
+        end
+
+        step "one", name <- input(:name), after: ["seed"], meta: %{form: "one"} do
+          {:ok, %{name: name}}
+        end
+
+        step "two", name <- result("one", :name), ctx <- context() do
+          {:ok, %{name: name <> ctx.suffix}}
+        end
+
+        step "two_options", name <- result("two", :name), count <- input(:count),
+          after: ["seed"], meta: %{form: "two"} do
+          {:ok, %{name: name, count: count}}
+        end
+
+        step "list", [name <- result("two_options", :name), count <- input(:count), ctx <- context()],
+          meta: %{form: "list"} do
+          repeat = fn value -> String.duplicate(value, count) end
+          {:ok, %{name: repeat.(name), suffix: ctx.suffix}}
+        end
+
+        step "pattern", %{uri: %Address{path: path}, kind: :person} <- input() do
+          {:ok, %{path: path}}
+        end
+
+        output(%{list: result("list"), path: result("pattern", :path)})
+      end
+    end
+    """
+
+    compile_source(source)
+    module = Module.concat(__MODULE__, BindingFormsFlow)
+    assert [seed, one, two, two_options, list, pattern] = module.flow().components
+    assert seed.name == "seed"
+    assert seed.params == %{}
+    assert one.after == ["seed"]
+    assert one.meta == %{form: "one"}
+    assert two.params == %{name: Ref.result("one", :name), ctx: Ref.context()}
+    assert two_options.after == ["seed"]
+    assert two_options.meta == %{form: "two"}
+    assert list.meta == %{form: "list"}
+    assert pattern.params == Ref.input([])
+
+    assert Jido.Exec.run(
+             module,
+             %{name: "Ada", count: 2, uri: URI.parse("/home"), kind: :person},
+             %{suffix: "!"}
+           ) ==
+             {:ok, %{list: %{name: "Ada!Ada!", suffix: "!"}, path: "/home"}}
+  end
+
+  test "a runtime raise keeps the user body file and line" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.RaisingFlow do
+      use Jido.Flow, name: "inline_raising"
+      flow do
+        step "raise", [] do
+          raise "inline body failed"
+        end
+        output(result("raise"))
+      end
+    end
+    """
+
+    compile_source(source, "inline_raise.ex")
+    assert {:error, error} = Jido.Exec.run(__MODULE__.RaisingFlow)
+    assert %Splode.Stacktrace{stacktrace: stacktrace} = error.stacktrace
+
+    assert Enum.any?(stacktrace, fn
+             {__MODULE__.RaisingFlow, _function, _arity, location} ->
+               to_string(location[:file]) == "inline_raise.ex" and location[:line] == 5
+
+             _frame ->
+               false
+           end)
+  end
+
+  test "normal invalid nested patterns are rejected by the owner function compiler" do
+    source = """
+    defmodule Jido.Flow.DSL.InlineStepTest.BadPatternFlow do
+      use Jido.Flow, name: "inline_bad_pattern"
+      flow do
+        step "bad", %{name: String.trim(name)} <- input() do
+          {:ok, %{name: name}}
+        end
+        output(result("bad"))
+      end
+    end
+    """
+
+    {_result, diagnostics} =
+      Code.with_diagnostics(fn ->
+        assert_raise CompileError, fn -> compile_source(source, "inline_pattern.ex") end
+      end)
+
+    assert Enum.any?(diagnostics, fn diagnostic ->
+             diagnostic.severity == :error and diagnostic.message =~ "inside a match" and
+               Path.basename(diagnostic.file) == "inline_pattern.ex" and
+               diagnostic_line(diagnostic) == 4
+           end)
+  end
 
   test "one named binding retains the input and body syntax" do
     {:step, _, [_name, binding, options]} =
@@ -276,4 +550,42 @@ defmodule Jido.Flow.DSL.InlineStepTest do
 
   defp ast(source), do: Code.string_to_quoted!(source, line: @source_line, columns: true)
   defp caller, do: %{__ENV__ | file: @source_file, line: @source_line}
+
+  defp canonical_data?(value) when is_map(value) do
+    not is_struct(value, Macro.Env) and
+      Enum.all?(Map.to_list(value), fn {key, item} ->
+        canonical_data?(key) and canonical_data?(item)
+      end)
+  end
+
+  defp canonical_data?(value) when is_list(value), do: Enum.all?(value, &canonical_data?/1)
+  defp canonical_data?(value) when is_tuple(value), do: false
+  defp canonical_data?(value), do: not is_function(value)
+
+  defp diagnostic_line(%{position: {line, _column}}), do: line
+  defp diagnostic_line(%{position: line}), do: line
+
+  defp compile_source(source, file \\ "inline_compile.ex") do
+    loaded = MapSet.new(:code.all_loaded(), &elem(&1, 0))
+
+    try do
+      Code.compile_string(source, file)
+    after
+      owned =
+        for {module, _} <- :code.all_loaded(),
+            not MapSet.member?(loaded, module),
+            String.starts_with?(Atom.to_string(module), [
+              "Elixir.Jido.Flow.DSL.InlineStepTest.",
+              "Elixir.Jido.Flow.Generated.InlineStep."
+            ]),
+            do: module
+
+      on_exit(fn ->
+        Enum.each(owned, fn module ->
+          :code.purge(module)
+          :code.delete(module)
+        end)
+      end)
+    end
+  end
 end

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -261,6 +261,30 @@ defmodule Jido.Flow.DSL.InlineStepTest do
     assert Enum.map(module.flow().components, & &1.name) == ["lexical", "local_import"]
   end
 
+  for namespace <- [Jido.Flow.DSLHelpers, Spark.DslHelpers] do
+    test "inline bodies retain imports from #{inspect(namespace)}" do
+      helper = Module.concat(unquote(namespace), "Inline#{System.unique_integer([:positive])}")
+      owner = unique_owner("SimilarNamespace")
+
+      on_exit(fn ->
+        :code.purge(helper)
+        :code.delete(helper)
+      end)
+
+      compile_source("""
+      defmodule #{inspect(helper)} do
+        def prefix_marker, do: :retained
+      end
+      """)
+
+      declaration = ~s|step "same", [], do: {:ok, %{marker: prefix_marker()}}|
+      compile_source(flow_source(owner, declaration, "import #{inspect(helper)}"))
+
+      assert owner.step_action("same").run(%{}, %{}) == {:ok, %{marker: :retained}}
+      assert [%Jido.Flow.Step{name: "same"}] = owner.flow().components
+    end
+  end
+
   test "canonical inline Steps contain only ordinary Action author data" do
     flow = JidoActionTest.Fixtures.InlineGreetingFlow.flow()
     map = Jido.Flow.to_map(flow)

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -534,7 +534,6 @@ defmodule Jido.Flow.DSL.InlineStepTest do
     assert parsed.pattern_ast == {:%{}, [line: @source_line], [name: variable]}
     assert parsed.body_ast == options[:do]
     assert parsed.options == []
-    assert parsed.source == %{file: @source_file, line: @source_line}
     assert Expression.parse(parsed.params_ast) == {:ok, %{name: Ref.input(:name)}}
   end
 

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -19,6 +19,27 @@ defmodule Jido.Flow.DSL.InlineStepTest do
     end
   end
 
+  test "the inline compiler's actual exports have BEAM docs and specs" do
+    module = Jido.Flow.DSL.InlineStepCompiler
+    exported = module.__info__(:functions)
+    assert exported != []
+    assert {:docs_v1, _, _, _, :hidden, _, docs} = Code.fetch_docs(module)
+    assert {:ok, specs} = Code.Typespec.fetch_specs(module)
+
+    documented =
+      for {{:function, name, arity}, _, _, doc, _} <- docs,
+          doc != :none,
+          into: MapSet.new(),
+          do: {name, arity}
+
+    specified = MapSet.new(specs, &elem(&1, 0))
+
+    for function <- exported do
+      assert MapSet.member?(documented, function), "missing BEAM doc for #{inspect(function)}"
+      assert MapSet.member?(specified, function), "missing BEAM spec for #{inspect(function)}"
+    end
+  end
+
   test "legacy Step names expand or evaluate once" do
     for {expression, marker, name} <- [
           {"#{inspect(NameSource)}.literal_name()", :inline_name_macro_expanded, "macro_name"},
@@ -134,19 +155,38 @@ defmodule Jido.Flow.DSL.InlineStepTest do
       clause = "#{visibility} #{function}(#{args}), do: :user_clause"
       declaration = ~s(step "same", [], do: {:ok, %{}})
       {before, after_code} = if position == :before, do: {clause, ""}, else: {"", clause}
+      source = flow_source(owner, declaration, before, after_code)
 
-      # Elixir itself rejects a private clause after a public generated body
-      # before it calls the definition callback.
-      message =
-        if position == :after and kind == :body and visibility == :defp,
-          do: ~r/cannot compile file|already defined as def/,
-          else: ~r/reserved Flow function.*#{function}/
+      if kind == :lookup and visibility == :defp do
+        # The forward public head lets Elixir reject a private clause before
+        # the reserved-function callback. Require its source-aware diagnostic.
+        clause_line =
+          source |> String.split("\n") |> Enum.find_index(&(String.trim(&1) == clause))
 
-      ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        assert_raise CompileError, message, fn ->
-          compile_source(flow_source(owner, declaration, before, after_code))
-        end
-      end)
+        {_result, diagnostics} =
+          Code.with_diagnostics(fn ->
+            assert_raise CompileError, fn -> compile_source(source) end
+          end)
+
+        assert Enum.any?(diagnostics, fn diagnostic ->
+                 diagnostic.severity == :error and
+                   diagnostic.message ==
+                     "defp step_action/1 already defined as def in inline_compile.ex:2" and
+                   Path.basename(diagnostic.file) == "inline_compile.ex" and
+                   diagnostic_line(diagnostic) == clause_line + 1
+               end)
+      else
+        # Elixir itself rejects a private clause after a public generated body
+        # before it calls the definition callback.
+        message =
+          if position == :after and kind == :body and visibility == :defp,
+            do: ~r/cannot compile file|already defined as def/,
+            else: ~r/reserved Flow function.*#{function}/
+
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          assert_raise CompileError, message, fn -> compile_source(source) end
+        end)
+      end
     end
   end
 

--- a/test/jido_flow/dsl/inline_step_test.exs
+++ b/test/jido_flow/dsl/inline_step_test.exs
@@ -1,0 +1,279 @@
+defmodule Jido.Flow.DSL.InlineStepTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Flow.DSL.{Expression, InlineStep}
+  alias Jido.Flow.Ref
+
+  @source_file "inline_header.ex"
+  @source_line 40
+
+  test "one named binding retains the input and body syntax" do
+    {:step, _, [_name, binding, options]} =
+      ast("step :greet, name <- input(:name), do: {:ok, %{name: name}}")
+
+    parsed = InlineStep.parse!(binding, options, caller())
+    {:<-, _, [variable, source]} = binding
+
+    assert parsed.params_ast == {:%{}, [line: @source_line], [name: source]}
+    assert parsed.pattern_ast == {:%{}, [line: @source_line], [name: variable]}
+    assert parsed.body_ast == options[:do]
+    assert parsed.options == []
+    assert parsed.source == %{file: @source_file, line: @source_line}
+    assert Expression.parse(parsed.params_ast) == {:ok, %{name: Ref.input(:name)}}
+  end
+
+  test "two bare bindings and larger binding lists use named atom keys" do
+    two = parse("step :sum, left <- input(:left), right <- result(:load), do: :ok")
+    list = parse("step :sum, [a <- input(), b <- context(), _c <- value(3)], do: :ok")
+
+    assert Expression.parse(two.params_ast) ==
+             {:ok, %{left: Ref.input(:left), right: Ref.result(:load)}}
+
+    assert Macro.to_string(two.pattern_ast) == "%{left: left, right: right}"
+
+    assert Expression.parse(list.params_ast) ==
+             {:ok, %{a: Ref.input([]), b: Ref.context([]), _c: 3}}
+
+    assert Macro.to_string(list.pattern_ast) == "%{a: a, b: b, _c: _c}"
+  end
+
+  test "a sole map pattern retains nested matches and uses the whole source as params" do
+    source = """
+    step :read,
+      %{"user" => %{name: name}, :kind => :person, 1 => {head, [first | rest]}} <- input(),
+      do: {:ok, %{name: name, head: head, first: first, rest: rest}}
+    """
+
+    {:step, _, [_name, {:<-, _, [pattern, params]}, options]} = ast(source)
+    parsed = parse(source)
+
+    assert parsed.pattern_ast == pattern
+    assert parsed.params_ast == params
+    assert parsed.body_ast == options[:do]
+    assert Expression.parse(parsed.params_ast) == {:ok, Ref.input([])}
+
+    list = parse("step :read, [%{name: name} <- result(:load)], do: name")
+    assert Macro.to_string(list.pattern_ast) == "%{name: name}"
+    assert Expression.parse(list.params_ast) == {:ok, Ref.result(:load)}
+  end
+
+  test "an explicit empty binding list produces empty params and a map pattern" do
+    parsed = parse("step :ready, [], do: {:ok, %{ready: true}}")
+
+    assert parsed.params_ast == {:%{}, [line: @source_line], []}
+    assert parsed.pattern_ast == {:%{}, [line: @source_line], []}
+  end
+
+  test "all header forms retain after and meta options without body evaluation" do
+    marker = :inline_body_ran
+    body = quote do: send(self(), unquote(marker))
+
+    option_sets = [
+      [],
+      [after: [:first]],
+      [meta: %{owner: :test}],
+      [after: [:first], meta: %{owner: :test}]
+    ]
+
+    for header <- [
+          "name <- input()",
+          "left <- input(), right <- context()",
+          "[a <- input(), b <- context(), c <- 3]",
+          "[]"
+        ],
+        options <- option_sets do
+      {:step, _, [_name | arguments]} = ast("step :read, #{header}, do: :ok")
+      arguments = List.replace_at(arguments, -1, options ++ [do: body])
+      parsed = apply(InlineStep, :parse!, arguments ++ [caller()])
+
+      assert parsed.options == options
+      assert parsed.body_ast == body
+    end
+
+    refute_received ^marker
+  end
+
+  test "body functions and nested after clauses remain normal Elixir syntax" do
+    source = """
+    step :read, names <- input(:names), after: [:load] do
+      try do
+        cleaner = fn name -> String.trim(name) end
+        {:ok, %{names: Enum.map(names, cleaner)}}
+      after
+        cleanup()
+      end
+    end
+    """
+
+    {:step, _, [_name, _binding, _header_options, options]} = ast(source)
+    parsed = parse(source)
+
+    assert parsed.options == [after: [:load]]
+    assert parsed.body_ast == options[:do]
+    assert Macro.to_string(parsed.body_ast) =~ "after"
+  end
+
+  test "native do blocks keep separate header options for all binding forms" do
+    for header <- [
+          "name <- input()",
+          "left <- input(), right <- context()",
+          "[a <- input(), b <- context(), c <- 3]",
+          "[]"
+        ],
+        options <- [
+          "after: [:load]",
+          "meta: %{owner: :test}",
+          "after: [:load], meta: %{owner: :test}"
+        ] do
+      source = "step :read, #{header}, #{options} do\n  {:ok, %{}}\nend"
+      {:step, _, arguments} = ast(source)
+      parsed = parse(source)
+
+      assert parsed.options == Enum.at(arguments, -2)
+      assert Macro.to_string(parsed.body_ast) == "{:ok, %{}}"
+    end
+  end
+
+  test "split header and body options reject duplicate fields" do
+    assert_raise CompileError, ~r/duplicate inline Step field: :after/, fn ->
+      InlineStep.parse!([], [after: [:one]], [after: [:two], do: :ok], caller())
+    end
+  end
+
+  test "invalid bindings fail at the source declaration" do
+    cases = [
+      {"[name <- input(), name <- context()]", ~r/duplicate inline Step binding: :name/},
+      {"[%{name: name} <- input(), other <- context()]", ~r/map pattern must be the only/},
+      {"[%{name: name} <- input(), %{other: other} <- context()]",
+       ~r/map pattern must be the only/},
+      {"%User{name: name} <- input()", ~r/struct patterns are not supported/},
+      {"^name <- input()", ~r/pinned variables are not supported/},
+      {"%{name: ^name} <- input()", ~r/pinned variables are not supported/},
+      {"(name when is_binary(name)) <- input()", ~r/guards are not supported/},
+      {"_ <- input()", ~r/bare _ binding is not supported/},
+      {"[name <- input(), :bad]", ~r/expected a binding/},
+      {"[name: input()]", ~r/expected a binding/},
+      {"[name <- input() | rest]", ~r/unsupported Flow expression/},
+      {"{left, right} <- input()", ~r/named variable or a sole map pattern/},
+      {"%{key => value} <- input()", ~r/map pattern keys must be literals/},
+      {"%{name: name, name: other} <- input()", ~r/duplicate inline Step map key: :name/}
+    ]
+
+    for {header, message} <- cases do
+      error =
+        assert_raise CompileError, message, fn -> parse("step :read, #{header}, do: :ok") end
+
+      assert error.file == @source_file
+      assert error.line == @source_line
+    end
+  end
+
+  test "binding sources use only the existing Flow expression grammar" do
+    for header <- [
+          "name <- String.trim(input(:name))",
+          "[name <- input(), other <- name]",
+          "name <- (input(:name) |> String.trim())",
+          "name <- fn -> :ok end",
+          "name <- %{duplicate: 1, duplicate: 2}"
+        ] do
+      error =
+        assert_raise CompileError, ~r/inline Step binding source:.*Flow/s, fn ->
+          parse("step :read, #{header}, do: :ok")
+        end
+
+      assert error.file == @source_file
+      assert error.line == @source_line
+    end
+  end
+
+  test "source errors retain the offending expression line" do
+    error =
+      assert_raise CompileError, ~r/unsupported Flow expression/, fn ->
+        parse("step :read,\n  name <-\n    String.trim(input(:name)),\n  do: name")
+      end
+
+    assert error.file == @source_file
+    assert error.line == @source_line + 2
+  end
+
+  test "inline options reject explicit target fields, schema fields, and unknown fields" do
+    for field <- [:action, :params, :run, :schema, :output_schema, :unknown] do
+      error =
+        assert_raise CompileError,
+                     "#{@source_file}:#{@source_line}: unsupported inline Step field: #{inspect(field)}; use only after:, meta:, and do:",
+                     fn ->
+                       InlineStep.parse!(
+                         ast("name <- input()"),
+                         [{field, :invalid}, {:do, :ok}],
+                         caller()
+                       )
+                     end
+
+      assert error.file == @source_file
+      assert error.line == @source_line
+    end
+  end
+
+  test "duplicate fields, missing bodies, and malformed options fail before parsing bindings" do
+    for field <- [:after, :meta, :do] do
+      assert_raise CompileError, ~r/duplicate inline Step field/, fn ->
+        InlineStep.parse!([], [{field, :first}, {field, :second}, {:do, :ok}], caller())
+      end
+    end
+
+    assert_raise CompileError, ~r/inline Step requires a do block/, fn ->
+      InlineStep.parse!([], [after: [:first]], caller())
+    end
+
+    assert_raise CompileError, ~r/inline Step options must be a keyword list/, fn ->
+      apply(InlineStep, :parse!, [[], :invalid, caller()])
+    end
+
+    assert parse("step :read, [], do: nil").body_ast == nil
+  end
+
+  test "the two bare binding form does not accept a list argument" do
+    assert_raise CompileError, ~r/expected a binding/, fn ->
+      InlineStep.parse!([ast("name <- input()")], ast("other <- context()"), [do: :ok], caller())
+    end
+  end
+
+  test "map patterns reject nested updates, guards, and dynamic keys" do
+    for pattern <- [
+          "%{name: (name when is_binary(name))}",
+          "%{user: %{base | name: name}}",
+          "%{user: %{key => name}}"
+        ] do
+      assert_raise CompileError, fn ->
+        parse("step :read, #{pattern} <- input(), do: :ok")
+      end
+    end
+  end
+
+  test "map patterns retain normal nested structs, binary matches, aliases, and matches" do
+    pattern =
+      "%{uri: %URI{path: path}, pair: {first, second, _}, bytes: <<head::integer, tail::binary>>, value: value = [item | _], module: String, prefix: \"x\" <> suffix}"
+
+    source = "step :read, #{pattern} <- input(), do: :ok"
+    {:step, _, [_name, {:<-, _, [pattern_ast, _]}, _]} = ast(source)
+    parsed = parse(source)
+    assert parsed.pattern_ast == pattern_ast
+  end
+
+  test "map patterns retain binary size references and signed literal keys" do
+    source =
+      "step :read, %{-1 => name, data: <<width, body::binary-size(width * 8)>>} <- input(), do: :ok"
+
+    {:step, _, [_name, {:<-, _, [pattern_ast, _]}, _]} = ast(source)
+
+    assert parse(source).pattern_ast == pattern_ast
+  end
+
+  defp parse(source) do
+    {:step, _, [_name | arguments]} = ast(source)
+    apply(InlineStep, :parse!, arguments ++ [caller()])
+  end
+
+  defp ast(source), do: Code.string_to_quoted!(source, line: @source_line, columns: true)
+  defp caller, do: %{__ENV__ | file: @source_file, line: @source_line}
+end

--- a/test/jido_flow/graph_identity_test.exs
+++ b/test/jido_flow/graph_identity_test.exs
@@ -3,9 +3,24 @@ defmodule Jido.Flow.GraphIdentityTest do
 
   alias Jido.Flow.Error.InvalidDefinitionError
   alias Jido.Flow
+  alias Jido.Flow.Builder
   alias Jido.Flow.Ref
   alias Jido.Flow.Step
   alias JidoActionTest.Fixtures.Actions.Add
+  alias JidoActionTest.Fixtures.InlineAuthoring
+  alias JidoActionTest.Fixtures.InlineParityFlow
+
+  test "equal inline DSL, Builder, and direct graph data has the same semantic identity" do
+    dsl = InlineParityFlow.flow()
+    direct = InlineAuthoring.direct_flow!()
+    assert {:ok, built} = InlineAuthoring.builder() |> Builder.build()
+    assert {:ok, identity} = Flow.semantic_identity(dsl)
+    assert %{version: 1, algorithm: :sha256, digest: digest, uuid: uuid} = identity
+    assert is_binary(digest)
+    assert is_binary(uuid)
+    assert Flow.semantic_identity(direct) == {:ok, identity}
+    assert Flow.semantic_identity(built) == {:ok, identity}
+  end
 
   test "author order, reference order, and effective order stay separate" do
     first = Step.new!(name: "first", action: Add)

--- a/test/jido_flow/registry_test.exs
+++ b/test/jido_flow/registry_test.exs
@@ -8,8 +8,42 @@ defmodule Jido.Flow.RegistryTest do
   alias Jido.Flow.Registry
   alias Jido.Flow.Step
   alias JidoActionTest.Fixtures.FlowAuthoring
+  alias JidoActionTest.Fixtures.InlineParityFlow
   alias JidoActionTest.Fixtures.NestedFlow
   alias JidoActionTest.Fixtures.Actions.{Add, Multiply}
+
+  test "temporary Registries include inline Actions but their IDs depend on the Flow" do
+    flow = InlineParityFlow.flow()
+    assert {:ok, registry} = Registry.from_flow(flow)
+    assert Registry.from_flow(flow) == {:ok, registry}
+
+    for step <- flow.components do
+      assert {:ok, identifier} = Registry.identifier(registry, :action, step.action)
+      assert String.starts_with?(identifier, "actions/generated-")
+      assert Registry.resolve(registry, identifier, :action) == {:ok, step.action}
+    end
+
+    assert {:ok, document, ^registry} = Codec.encode(flow)
+
+    assert {:ok, ^flow} =
+             document |> Jason.encode!() |> Jason.decode!() |> Codec.decode(registry)
+
+    action = flow.components |> Enum.map(& &1.action) |> Enum.max_by(&Atom.to_string/1)
+
+    subset =
+      Flow.new!(
+        name: "inline_registry_subset",
+        components: [Step.new!(name: "only", action: action)],
+        output: Ref.result("only")
+      )
+
+    assert {:ok, subset_registry} = Registry.from_flow(subset)
+    assert {:ok, original_id} = Registry.identifier(registry, :action, action)
+    assert {:ok, subset_id} = Registry.identifier(subset_registry, :action, action)
+    refute original_id == subset_id
+
+    assert {:error, %InvalidDefinitionError{}} = Codec.decode(document, subset_registry)
+  end
 
   test "from_flow builds a deterministic convenience Registry" do
     flow = FlowAuthoring.mixed_flow!()

--- a/test/support/fixtures/flow/inline.ex
+++ b/test/support/fixtures/flow/inline.ex
@@ -1,0 +1,66 @@
+defmodule JidoActionTest.Fixtures.InlineGreetingFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "inline_greeting"
+
+  flow do
+    step "normalize", name <- input(:name) do
+      {:ok, %{name: String.trim(name)}}
+    end
+
+    step "greet", name <- result("normalize", :name) do
+      {:ok, %{message: "Hello, " <> name <> "!"}}
+    end
+
+    output(result("greet"))
+  end
+end
+
+defmodule JidoActionTest.Fixtures.InlineBodyHelpers do
+  @moduledoc false
+
+  defmacro decorate(value) do
+    quote do: "[" <> unquote(value) <> "]"
+  end
+
+  def step(name, value), do: %{name: name, value: value}
+  def output(value), do: value
+end
+
+defmodule JidoActionTest.Fixtures.InlineLexicalFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "inline_lexical"
+
+  alias String, as: Text
+  import String, only: [upcase: 1]
+  import JidoActionTest.Fixtures.InlineBodyHelpers, only: [decorate: 1]
+
+  @prefix "before"
+  defp before_step(value), do: value <> "!"
+
+  flow do
+    alias JidoActionTest.Fixtures.InlineBodyHelpers, as: Helpers
+
+    step "lexical", name <- input(:name) do
+      {:ok,
+       %{
+         value: name |> Text.trim() |> upcase() |> before_step() |> after_step() |> decorate(),
+         module: __MODULE__,
+         prefix: @prefix,
+         qualified: Helpers.output(Helpers.step("body", name))
+       }}
+    end
+
+    step "local_import", data <- result("lexical") do
+      import JidoActionTest.Fixtures.InlineBodyHelpers, only: [step: 2, output: 1]
+      {:ok, Map.put(data, :local_import, output(step("local", data.value)))}
+    end
+
+    output(result("local_import"))
+  end
+
+  @prefix "after"
+  def current_prefix, do: @prefix
+  defp after_step(value), do: value <> "?"
+end

--- a/test/support/fixtures/flow/inline.ex
+++ b/test/support/fixtures/flow/inline.ex
@@ -187,3 +187,78 @@ defmodule JidoActionTest.Fixtures.InlineLexicalFlow do
   def current_prefix, do: @prefix
   defp after_step(value), do: value <> "?"
 end
+
+defmodule JidoActionTest.Fixtures.InlineResultFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "inline_result"
+
+  alias Jido.Action.Output
+  alias JidoActionTest.Fixtures.Actions.Add
+
+  flow do
+    step "result", %{mode: mode, value: value} <- input() do
+      case mode do
+        :map -> {:ok, %{value: value}}
+        :output -> {:ok, Output.raw(value)}
+        :extras -> {:ok, %{value: value}, %{effect: :already_ran}}
+        :raise -> raise "inline body failed"
+        :throw -> throw({:inline_throw, value})
+        :exit -> exit({:inline_exit, value})
+        :invalid_callback -> :not_a_result_tuple
+        :invalid_output -> {:ok, value}
+        :continue -> {:continue, %{value: value, amount: 2}, Add}
+      end
+    end
+
+    output(result("result"))
+  end
+end
+
+defmodule JidoActionTest.Fixtures.InlineControlledFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "inline_controlled"
+
+  flow do
+    step "third", [value <- input(:third), ctx <- context()] do
+      controlled(value, ctx)
+    end
+
+    step "second", [value <- input(:second), ctx <- context()] do
+      controlled(value, ctx)
+    end
+
+    step "first", [value <- input(:first), ctx <- context()] do
+      controlled(value, ctx)
+    end
+
+    output(%{
+      values: [result("first", :value), result("second", :value), result("third", :value)]
+    })
+  end
+
+  defp controlled(value, %{test_pid: test_pid, token: token} = ctx) do
+    if probe = ctx[:probe] do
+      Agent.update(probe, fn state ->
+        running = state.running + 1
+        %{state | running: running, max: max(state.max, running)}
+      end)
+    end
+
+    send(test_pid, {:inline_started, token, value, self()})
+
+    if Map.get(ctx, :block, true) do
+      receive do
+        {:release, ^token} -> :ok
+      end
+    end
+
+    if probe = ctx[:probe] do
+      Agent.update(probe, &%{&1 | running: &1.running - 1})
+    end
+
+    send(test_pid, {:inline_finished, token, value})
+    {:ok, %{value: value}}
+  end
+end

--- a/test/support/fixtures/flow/inline.ex
+++ b/test/support/fixtures/flow/inline.ex
@@ -16,6 +16,129 @@ defmodule JidoActionTest.Fixtures.InlineGreetingFlow do
   end
 end
 
+defmodule JidoActionTest.Fixtures.InlineParityFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "inline_parity", description: "All inline binding forms"
+
+  flow do
+    step "empty", [] do
+      {:ok, %{ready: true}}
+    end
+
+    step "named", name <- input(:raw_name), after: ["empty"], meta: %{owner: "inline"} do
+      {:ok, %{name: String.trim(name)}}
+    end
+
+    step "multiple", [name <- result("named", :name), prefix <- context(:prefix)],
+      after: ["empty"],
+      meta: %{purpose: "greeting"} do
+      {:ok, %{message: prefix <> ", " <> name <> "!"}}
+    end
+
+    step "sole_map",
+         %{"profile" => %{"city" => city}, "active" => true} <- input(:payload),
+         after: ["multiple"] do
+      {:ok, %{city: city}}
+    end
+
+    output(%{
+      "empty" => result("empty"),
+      "greeting" => result("multiple"),
+      "profile" => result("sole_map")
+    })
+  end
+end
+
+defmodule JidoActionTest.Fixtures.InlineAuthoring do
+  @moduledoc false
+
+  alias Jido.Flow
+  alias Jido.Flow.{Builder, Ref, Registry, Step}
+  alias JidoActionTest.Fixtures.InlineParityFlow
+
+  def direct_flow! do
+    Flow.new!(
+      name: "inline_parity",
+      description: "All inline binding forms",
+      components: [
+        Step.new!(name: "empty", action: InlineParityFlow.step_action("empty"), params: %{}),
+        Step.new!(
+          name: "named",
+          action: InlineParityFlow.step_action("named"),
+          params: %{name: Ref.input(:raw_name)},
+          after: ["empty"],
+          meta: %{owner: "inline"}
+        ),
+        Step.new!(
+          name: "multiple",
+          action: InlineParityFlow.step_action("multiple"),
+          params: %{name: Ref.result("named", :name), prefix: Ref.context(:prefix)},
+          after: ["empty"],
+          meta: %{purpose: "greeting"}
+        ),
+        Step.new!(
+          name: "sole_map",
+          action: InlineParityFlow.step_action("sole_map"),
+          params: Ref.input(:payload),
+          after: ["multiple"]
+        )
+      ],
+      output: %{
+        "empty" => Ref.result("empty"),
+        "greeting" => Ref.result("multiple"),
+        "profile" => Ref.result("sole_map")
+      }
+    )
+  end
+
+  def builder do
+    Builder.new(name: "inline_parity", description: "All inline binding forms")
+    |> Builder.step("empty", InlineParityFlow.step_action("empty"), %{})
+    |> Builder.step(
+      "named",
+      InlineParityFlow.step_action("named"),
+      %{name: Builder.input(:raw_name)},
+      after: ["empty"],
+      meta: %{owner: "inline"}
+    )
+    |> Builder.step(
+      "multiple",
+      InlineParityFlow.step_action("multiple"),
+      %{name: Builder.result("named", :name), prefix: Builder.context(:prefix)},
+      after: ["empty"],
+      meta: %{purpose: "greeting"}
+    )
+    |> Builder.step(
+      "sole_map",
+      InlineParityFlow.step_action("sole_map"),
+      Builder.input(:payload),
+      after: ["multiple"]
+    )
+    |> Builder.output(%{
+      "empty" => Builder.result("empty"),
+      "greeting" => Builder.result("multiple"),
+      "profile" => Builder.result("sole_map")
+    })
+  end
+
+  def registry do
+    Registry.new!(%{
+      "actions/demo/empty/v1" => {:action, InlineParityFlow.step_action("empty")},
+      "actions/demo/named/v1" => {:action, InlineParityFlow.step_action("named")},
+      "actions/demo/multiple/v1" => {:action, InlineParityFlow.step_action("multiple")},
+      "actions/demo/sole-map/v1" => {:action, InlineParityFlow.step_action("sole_map")},
+      "schemas/empty/v1" => {:schema, []},
+      "atoms/name" => {:atom, :name},
+      "atoms/raw-name" => {:atom, :raw_name},
+      "atoms/prefix" => {:atom, :prefix},
+      "atoms/payload" => {:atom, :payload},
+      "atoms/purpose" => {:atom, :purpose},
+      "atoms/owner" => {:atom, :owner}
+    })
+  end
+end
+
 defmodule JidoActionTest.Fixtures.InlineBodyHelpers do
   @moduledoc false
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -66,9 +66,21 @@ Use `jido_action` for validated work and data-first composition:
 - Use `step`, `choice`, `map`, `reduce`, `iterate`, and `dispatch` for graph
   structure.
 - Use `input`, `context`, and `result` references to map data. Put computation
-  in Actions.
+  in Actions or inline Step bodies.
 - Treat DSL expressions as a restricted data grammar, not general Elixir. Do
-  not use assignments, pattern matching, pipes, or application function calls.
+  not use assignments, pattern matching, pipes, or application function calls
+  in binding sources or other data expressions.
+- Use `step "name", value <- input(:value) do ... end` for a small inline
+  body. Use a binding list for more than two inputs, a sole map pattern for
+  complete params, or `[]` for no input. Only `after:` and `meta:` are header
+  options. This is an unreleased v3 feature, not part of `3.0.0-beta.4`.
+- Write normal Elixir inside the body. Bind context explicitly with
+  `ctx <- context()`. Bodies retain the owner's private helpers and lexical
+  scope, not runtime closure captures. Qualify helper calls that conflict with
+  DSL imports, or import those helpers inside the body.
+- Inline bodies compile to ordinary Actions with empty field schemas. Extract
+  a named Action for field schemas, validation hooks, or an independent API.
+- Keep inline bodies limited to `step`. Other components retain Action targets.
 - Let result references create data dependencies. Use `after:` only for
   control order without a data dependency.
 - Do not add a `parallel` block. Independent nodes run concurrently when
@@ -96,6 +108,15 @@ Use `jido_action` for validated work and data-first composition:
   indexes. Invalid values return structured validation errors.
 - Do not parse or evaluate stored Elixir DSL source. AI systems can produce
   stored JSON or Map data instead.
+- Reuse compiled inline Actions with `FlowModule.step_action(name)` after the
+  owner compiles. It returns only the target, not params, `after`, or `meta`.
+  Invalid or unknown names and non-Step components raise `ArgumentError`.
+- Register that target with a stable host-owned Action identifier for JSON.
+  Register named binding keys as atoms. Do not add body, function, or MFA data
+  to Builder, Registry, or Codec input.
+- Deploy the owner and its generated Action BEAM files together. A body-only
+  change can keep the same target and semantic graph identity. Track deployed
+  code versions separately from graph identity.
 - Only `Builder.step/5` and a Spark `step` can derive a Subflow from an
   executable of kind `:flow`. Choice, Map, Reduce, and Iterate target fields
   accept Actions only. Dispatch decision and expander targets also accept


### PR DESCRIPTION
## Description

Simple Flow steps can now bind their inputs and define their body in one place, without a separate Action module. This completes the package change for shorter Jido examples. Converting examples in the separate Jido core repository remains follow-up work.

```elixir
step "greet", name <- result("normalize", :name) do
  {:ok, %{message: "Hello, " <> name <> "!"}}
end
```

- Binding sources retain Flow dependency rules. Bodies use normal Elixir in the owning module, including private helpers and source diagnostics.
- Bodies compile into ordinary Actions. `MyFlow.step_action("greet")` exposes the target for Builder, direct constructors, and trusted Registry reuse. JSON stores identifiers and params, never body code.
- Generated targets use stable identities and normal BEAM build artifacts. Deploy the owner and generated Actions together. A stable target is not a snapshot of its body.
- This version covers inline `step` bodies only. It adds no callable executable kind, stored-format change, dependency, or package-version change.

Session-settled decisions carried from planning: Action compilation over general callables (user-approved); `<-` headers over separate params/run fields (user-approved); step-only scope (user-approved); deployed target reuse over closures or stored code (user-approved).

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [x] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

`use Jido.Flow` now reserves `step_action/1`. Rename an existing application helper with that name before upgrading. Existing keyword and field-block Steps, canonical data, Codec version 1, and execution contracts remain unchanged.

This is unreleased source work, not a new publication of `3.0.0-beta.4`. The updated Livebooks use a local source checkout.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

All 523 tests pass on each required runtime combination:

| Elixir | OTP |
| --- | --- |
| 1.18.4 | 27.3.4.12 |
| 1.18.4 | 28.5 |
| 1.19.5 | 28.5 |
| 1.20.3 | 29.0.5 |

Coverage is 94.38%; the 93% floor is unchanged. Test compilation with warnings as errors and `mix deps.audit` pass. Generated wrappers are excluded from coverage; handwritten compiler code remains measured. A narrow Doctor exception for the quoted compiler template is backed by a test of docs and specs for every actual BEAM export.

Tests execute the real first-Flow guide and produce `%{message: "Hello, Ada!"}`. They also prove independent Builder/DSL/direct/real-JSON parity, cold-VM loading, rebuild cleanup, source diagnostics, inert construction, cancellation, timeout, and bounded concurrency. Existing monitor-race checks now use direct DOWN assertions or controlled worker barriers. Exit checks stay strict.

Code review: complete, run `20260903-212228-b16c2d67`. Five local specialist reviews and independent finding validation left no blocking findings. The signed-key test gap is fixed. The external adversarial pass was unavailable due to execution-context authentication failure.

The branch includes the latest `release/v3` base at `792674f`. Its test-helper conflict was resolved by keeping both sets of tests and the worker-termination assertion. All checks above ran after integration.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

No linked issue.

## Post-Deploy Monitoring & Validation

- Owner and window: the release maintainer checks the first package release; each adopting application owner checks its first deployment and the next 24 hours.
- Run the greeting example and a Registry-loaded Flow in the built release. Expect `Hello, Ada!` and the same canonical graph after a JSON round-trip.
- Search build and runtime logs for `generated inline Step module`, `reserved Flow function`, `UndefinedFunctionError`, and Registry resolution errors involving the registered Action ID.
- Watch the existing `[:jido, :action]`, `[:jido, :flow]`, `[:jido, :flow, :node]`, and `[:jido, :flow, :target]` telemetry spans. Each start must have one stop or error. Compare error and timeout counts with the prior application release.
- Missing wrapper/owner modules, failed Registry lookup, wrong results, or unmatched terminal events trigger rollback of the application release. Roll back owner and wrapper modules together, or return the affected Step to an explicit Action.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791081354&installation_model_id=434874&pr_number=220&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F220&signature=a2ad6bd5ba312832e5bcfe8199805ae2f79fa1ef6b085360119cb317b682af8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->