### PR TITLE
fix(schema): validate top-level Zoi unions

### DIFF
--- a/guides/schemas-validation.md
+++ b/guides/schemas-validation.md
@@ -22,6 +22,31 @@ compatibility bridge:
 - Known key extraction is atom-safe: it only uses existing atoms and never creates new ones from property names.
 - Tool conversion preserves unknown keys and still prefers atom input keys over string keys when both are provided.
 
+### Top-Level Zoi Unions
+
+An action can use a union of object schemas for `schema` or `output_schema`:
+
+```elixir
+Zoi.union([
+  Zoi.object(%{name: Zoi.string(), resource_id: Zoi.string()}),
+  Zoi.object(%{name: Zoi.string(), path: Zoi.string()})
+])
+```
+
+Validation collects the root keys from all branches, including nested unions.
+Zoi selects the matching branch and applies its validation and transformations.
+Keys not declared by any branch pass through unchanged.
+
+For Zoi schemas, `Jido.Exec.run/4` accepts string forms of known root atom keys.
+For example, `"name"` becomes `:name` before validation. If both forms are supplied,
+the atom key takes precedence. Explicit string fields remain string fields.
+If branches declare both `:name` and `"name"`, they remain distinct fields;
+callers must use the key type required by the selected branch.
+This conversion does not create atoms or coerce field values. Nested key
+conversion remains the responsibility of the schema or `Jido.Action.Tool`.
+For a root union, nested values pass to Zoi unchanged. Use schema-level key
+coercion when nested objects must accept JSON string keys.
+
 ## NimbleOptions Schemas
 
 NimbleOptions is the traditional choice for Elixir configuration validation. Use keyword lists to define your schema:

--- a/lib/jido_action/runtime.ex
+++ b/lib/jido_action/runtime.ex
@@ -5,6 +5,10 @@ defmodule Jido.Action.Runtime do
   This module applies action lifecycle hooks around parameter and output
   validation, preserving unknown keys so composable action chains can pass
   through additional data.
+
+  For Zoi schemas, known root string keys are normalized to schema-declared
+  atom keys. Atom input keys take precedence unless the schema also declares
+  the corresponding string key as a separate field. Unknown keys are unchanged.
   """
 
   alias Jido.Action.Schema
@@ -83,10 +87,44 @@ defmodule Jido.Action.Runtime do
 
         Map.split(data, known_keys)
 
+      :zoi ->
+        known_keys = Schema.known_keys(schema)
+
+        data
+        |> normalize_zoi_keys(known_keys)
+        |> Map.split(known_keys)
+
       _ ->
         known_keys = Schema.known_keys(schema)
         Map.split(data, known_keys)
     end
+  end
+
+  defp normalize_zoi_keys(data, known_keys) do
+    declared_keys = MapSet.new(known_keys)
+
+    Enum.reduce(known_keys, data, fn
+      key, acc when is_atom(key) ->
+        string_key = Atom.to_string(key)
+
+        cond do
+          MapSet.member?(declared_keys, string_key) ->
+            acc
+
+          Map.has_key?(acc, key) ->
+            Map.delete(acc, string_key)
+
+          Map.has_key?(acc, string_key) ->
+            {value, rest} = Map.pop(acc, string_key)
+            Map.put(rest, key, value)
+
+          true ->
+            acc
+        end
+
+      _key, acc ->
+        acc
+    end)
   end
 
   defp struct_to_map(value) when is_struct(value), do: Map.from_struct(value)

--- a/lib/jido_action/schema.ex
+++ b/lib/jido_action/schema.ex
@@ -76,9 +76,9 @@ defmodule Jido.Action.Schema do
     * `schema` - NimbleOptions schema or Zoi schema
 
   ## Returns
-    * List of atom keys defined in the schema
+    * List of keys defined in the schema, including all union branches
   """
-  @spec known_keys(t()) :: [atom()]
+  @spec known_keys(t()) :: [atom() | String.t()]
   def known_keys([]), do: []
   def known_keys(schema) when is_list(schema), do: Keyword.keys(schema)
 
@@ -228,7 +228,7 @@ defmodule Jido.Action.Schema do
   end
 
   defp extract_zoi_keys(%{__struct__: Zoi.Types.Map, fields: fields}) when is_list(fields) do
-    Keyword.keys(fields)
+    Enum.map(fields, &elem(&1, 0))
   end
 
   defp extract_zoi_keys(%{__struct__: Zoi.Types.Struct, fields: fields}) when is_map(fields) do
@@ -236,7 +236,13 @@ defmodule Jido.Action.Schema do
   end
 
   defp extract_zoi_keys(%{__struct__: Zoi.Types.Struct, fields: fields}) when is_list(fields) do
-    Keyword.keys(fields)
+    Enum.map(fields, &elem(&1, 0))
+  end
+
+  defp extract_zoi_keys(%{__struct__: Zoi.Types.Union, schemas: schemas}) do
+    schemas
+    |> Enum.flat_map(&extract_zoi_keys/1)
+    |> Enum.uniq()
   end
 
   defp extract_zoi_keys(_), do: []

--- a/test/jido_action/zoi_union_test.exs
+++ b/test/jido_action/zoi_union_test.exs
@@ -1,0 +1,285 @@
+defmodule Jido.Action.ZoiUnionTest do
+  use JidoTest.ActionCase, async: true
+
+  alias Jido.Action.{Error, Schema, Tool}
+  alias Jido.Exec
+
+  defmodule UnionAction do
+    use Jido.Action,
+      name: "union_action",
+      schema:
+        Zoi.union([
+          Zoi.object(%{name: Zoi.string() |> Zoi.trim(), resource_id: Zoi.string()}),
+          Zoi.object(%{name: Zoi.string() |> Zoi.trim(), path: Zoi.string()})
+        ])
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule UnionOutputAction do
+    use Jido.Action,
+      name: "union_output_action",
+      output_schema:
+        Zoi.union([
+          Zoi.object(%{name: Zoi.string() |> Zoi.trim(), resource_id: Zoi.string()}),
+          Zoi.object(%{name: Zoi.string() |> Zoi.trim(), path: Zoi.string()})
+        ])
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule OptionalUnionAction do
+    use Jido.Action,
+      name: "optional_union_action",
+      schema:
+        Zoi.union([
+          Zoi.object(%{name: Zoi.string() |> Zoi.optional()}),
+          Zoi.object(%{count: Zoi.integer()})
+        ])
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule StringUnionAction do
+    use Jido.Action,
+      name: "string_union_action",
+      schema:
+        Zoi.union([
+          Zoi.object(%{"name" => Zoi.string(), "resource_id" => Zoi.string()}),
+          Zoi.object(%{"name" => Zoi.string(), "path" => Zoi.string()})
+        ])
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule ObjectAction do
+    use Jido.Action,
+      name: "object_key_action",
+      schema: Zoi.object(%{name: Zoi.string()})
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule MixedKeyAction do
+    use Jido.Action,
+      name: "mixed_key_action",
+      schema: Zoi.object(%{"name" => Zoi.integer(), :name => Zoi.string()})
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule NestedAction do
+    use Jido.Action,
+      name: "nested_union_action",
+      schema:
+        Zoi.object(%{
+          request:
+            Zoi.union([
+              Zoi.object(%{name: Zoi.string(), resource_id: Zoi.string()}),
+              Zoi.object(%{name: Zoi.string(), path: Zoi.string()})
+            ])
+        })
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule MapPayloadAction do
+    use Jido.Action,
+      name: "map_payload_union_action",
+      schema:
+        Zoi.union([
+          Zoi.object(%{
+            kind: Zoi.literal("object"),
+            payload: Zoi.object(%{name: Zoi.string()})
+          }),
+          Zoi.object(%{
+            kind: Zoi.literal("map"),
+            payload: Zoi.map(Zoi.string(), Zoi.string())
+          })
+        ])
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule MixedBranchAction do
+    use Jido.Action,
+      name: "mixed_branch_union_action",
+      schema:
+        Zoi.union([
+          Zoi.object(%{kind: Zoi.literal("atom"), name: Zoi.string()}),
+          Zoi.object(%{"name" => Zoi.string(), :kind => Zoi.literal("string")})
+        ])
+
+    def run(params, _context), do: {:ok, params}
+  end
+
+  describe "union key extraction" do
+    test "collects unique keys from all branches" do
+      assert Enum.sort(Schema.known_keys(UnionAction.schema())) == [:name, :path, :resource_id]
+    end
+
+    test "collects keys recursively from nested unions" do
+      schema = Zoi.union([UnionAction.schema(), Zoi.object(%{count: Zoi.integer()})])
+      assert Enum.sort(Schema.known_keys(schema)) == [:count, :name, :path, :resource_id]
+    end
+
+    test "does not collect nested object fields as root keys" do
+      schema =
+        Zoi.union([
+          Zoi.object(%{nested: Zoi.object(%{inner: Zoi.string()})}),
+          Zoi.object(%{name: Zoi.string()})
+        ])
+
+      assert Enum.sort(Schema.known_keys(schema)) == [:name, :nested]
+    end
+
+    test "keeps schema-declared string keys" do
+      assert Enum.sort(Schema.known_keys(StringUnionAction.schema())) ==
+               ["name", "path", "resource_id"]
+    end
+  end
+
+  describe "union validation through Exec" do
+    for selector <- [:resource_id, :path], key_form <- [:atom, :string] do
+      test "validates #{selector} with #{key_form} keys and preserves unknown values" do
+        params = %{unquote(selector) => "resource", :name => " example "}
+        params = input_keys(params, unquote(key_form))
+        params = Map.merge(params, %{"extra_string" => 7, extra_atom: 8})
+
+        expected = %{
+          "extra_string" => 7,
+          :extra_atom => 8,
+          :name => "example",
+          unquote(selector) => "resource"
+        }
+
+        assert {:ok, ^expected} = Exec.run(UnionAction, params)
+      end
+    end
+
+    test "rejects missing selectors and invalid field types" do
+      for params <- [
+            %{name: "example"},
+            %{"name" => "example"},
+            %{name: 123, resource_id: "resource"},
+            %{"name" => 123, "path" => "readme.md"}
+          ] do
+        assert {:error, %Error.InvalidInputError{}} = Exec.run(UnionAction, params)
+      end
+    end
+
+    test "does not bypass invalid values when a branch accepts an empty map" do
+      assert {:error, _} = Zoi.parse(OptionalUnionAction.schema(), %{name: 123})
+
+      for params <- [%{name: 123}, %{"name" => 123}] do
+        assert {:error, %Error.InvalidInputError{}} = Exec.run(OptionalUnionAction, params)
+      end
+
+      assert {:ok, %{}} = Exec.run(OptionalUnionAction, %{})
+      assert {:ok, %{name: "example"}} = Exec.run(OptionalUnionAction, %{name: "example"})
+    end
+
+    test "prefers atom keys and removes duplicate string keys" do
+      params = %{"name" => 123, :name => "example", :path => "readme.md"}
+      assert {:ok, %{name: "example", path: "readme.md"}} = Exec.run(UnionAction, params)
+    end
+
+    test "does not replace an invalid atom value with a valid string value" do
+      params = %{"name" => "example", :name => nil, :path => "readme.md"}
+      assert {:error, %Error.InvalidInputError{}} = Exec.run(UnionAction, params)
+    end
+
+    test "does not create atoms from unknown JSON keys" do
+      unknown = "unknown_union_key_#{System.unique_integer([:positive])}"
+      assert_raise ArgumentError, fn -> String.to_existing_atom(unknown) end
+      params = %{"name" => "example", "path" => "readme.md", unknown => 42}
+      assert {:ok, result} = Exec.run(UnionAction, params)
+      assert result[unknown] == 42
+      assert_raise ArgumentError, fn -> String.to_existing_atom(unknown) end
+    end
+
+    test "preserves schema-declared string keys" do
+      params = %{"name" => "example", "path" => "readme.md", "extra" => true}
+      assert {:ok, ^params} = Exec.run(StringUnionAction, params)
+    end
+
+    test "normalizes known root keys for ordinary Zoi objects as well" do
+      assert {:ok, %{name: "example"}} = Exec.run(ObjectAction, %{"name" => "example"})
+    end
+
+    test "does not consume separately declared string fields" do
+      params = %{"name" => 123, :name => "example"}
+      assert {:ok, ^params} = Exec.run(MixedKeyAction, params)
+      assert {:error, %Error.InvalidInputError{}} = Exec.run(MixedKeyAction, %{name: "example"})
+    end
+
+    test "keeps conflicting key declarations across branches distinct" do
+      atom_params = %{kind: "atom", name: "example"}
+      assert {:ok, ^atom_params} = Exec.run(MixedBranchAction, atom_params)
+
+      assert {:ok, %{"name" => "example", :kind => "string"}} =
+               Exec.run(MixedBranchAction, %{"kind" => "string", "name" => "example"})
+
+      assert {:error, %Error.InvalidInputError{}} =
+               Exec.run(MixedBranchAction, %{"kind" => "atom", "name" => "example"})
+    end
+
+    test "keeps unions nested in object fields working" do
+      params = %{request: %{name: "example", path: "readme.md"}, extra: true}
+      assert {:ok, ^params} = Exec.run(NestedAction, params)
+    end
+  end
+
+  describe "union output validation" do
+    test "validates both branches and key forms" do
+      for selector <- [:resource_id, :path], key_form <- [:atom, :string] do
+        output = %{selector => "resource", :name => " example ", :extra => 42}
+        expected = %{selector => "resource", :name => "example", :extra => 42}
+        params = input_keys(Map.delete(output, :extra), key_form) |> Map.put(:extra, 42)
+
+        assert {:ok, ^expected} =
+                 Exec.run(UnionOutputAction, params, %{}, max_retries: 0)
+      end
+    end
+
+    test "rejects invalid output" do
+      assert {:error, %Error.InvalidInputError{}} =
+               Exec.run(UnionOutputAction, %{name: "example"}, %{}, max_retries: 0)
+    end
+  end
+
+  describe "union tool conversion" do
+    test "executes JSON arguments for every root union branch" do
+      for selector <- ["resource_id", "path"] do
+        params = %{"name" => "example", selector => "resource", "extra" => 42}
+        assert {:ok, json} = Tool.execute_action(UnionAction, params, %{})
+        assert Jason.decode!(json) == params
+      end
+    end
+
+    test "does not convert nested keys using a rejected root union branch" do
+      params = %{"kind" => "map", "payload" => %{"name" => "keep string"}}
+
+      assert {:ok, %{kind: "map", payload: %{"name" => "keep string"}}} =
+               Exec.run(MapPayloadAction, params)
+
+      assert {:ok, json} = Tool.execute_action(MapPayloadAction, params, %{})
+      assert Jason.decode!(json) == params
+
+      object_params = %{"kind" => "object", "payload" => %{name: "example"}}
+      assert {:ok, json} = Tool.execute_action(MapPayloadAction, object_params, %{})
+      assert Jason.decode!(json) == %{"kind" => "object", "payload" => %{"name" => "example"}}
+    end
+
+    test "keeps nested union conversion working" do
+      params = %{"request" => %{"name" => "example", "path" => "readme.md"}}
+      assert {:ok, json} = Tool.execute_action(NestedAction, params, %{})
+      assert Jason.decode!(json) == params
+    end
+  end
+
+  defp input_keys(params, :atom), do: params
+
+  defp input_keys(params, :string),
+    do: Map.new(params, fn {key, value} -> {to_string(key), value} end)
+end


### PR DESCRIPTION
## Description

Actions with a top-level `Zoi.union/1` of object schemas now validate their supplied input and output. Previously, the runtime removed all fields before validation. Valid calls failed, and a branch that accepted an empty map could let invalid values pass.

Both atom keys and JSON string forms of known root keys work through `Jido.Exec` and tool execution. Unknown fields are preserved. Field values remain subject to strict Zoi validation. No Zoi dependency change is needed.

Root string-key normalization also applies to ordinary Zoi object schemas. It does not create atoms. Atom keys take precedence unless a string key is separately declared. Root unions leave nested keys unchanged; schemas with conflicting atom/string declarations require the declared key type. These limits are documented and tested. The tool adapter is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None intended. Invalid values that previously bypassed validation through an empty-map union branch now return validation errors.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Verified with Elixir 1.19.5, OTP 28.5, and locked Zoi 0.18.7:

- `mix coveralls --include flaky`: 897 tests and one property, no failures. This includes 23 new regression tests.
- The same coverage command on unchanged `main` passed 874 tests and one property. Total coverage increases from 81.1% to 81.6%. The repository remains below the documented 90% target.
- `MIX_ENV=test mix quality`: passes, including formatting, compilation, configured Credo, and Dialyzer.
- Strict Credo on the three changed code/test files: no findings. Unrestricted `mix credo --strict` reports 73 findings in unchanged files.
- `mix docs --no-open`: passes.
- The initial regression tests reproduced the failure before the fix. Final tests cover both branches, input/output validation, missing and invalid values, unknown fields, key precedence, atom safety, and nested map payload preservation.
- Code review completed; the one actionable finding was fixed and checked again. Review run: `20260904-061807-d7e97a9b`. The external review could not authenticate; seven local reviewer passes completed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

Fixes #221

Related: agentjido/jido#335

## Post-Deploy Monitoring & Validation

The release owner should run one valid call per union branch, then calls with a missing selector and an invalid field type, during the first downstream upgrade. Repeat with JSON keys and confirm that extra fields survive. Healthy results are successful valid calls and validation errors for invalid calls.

During the first 24 hours, check application logs for `InvalidInputError` on these actions and compare validation-failure counts with the prior release. No repository-owned production dashboard is available. If valid calls fail or invalid values reach `run/2`, stop the rollout and pin the prior release while the regression is investigated.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113321&installation_model_id=434874&pr_number=222&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F222&signature=41fe774b138a119e4dd298ecd26160dbc8dd209b5eb8cec094b399807c78e0bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->