### PR TITLE
fix(executable): formalize the shared validation contract

### DIFF
--- a/guides/actions.md
+++ b/guides/actions.md
@@ -30,6 +30,12 @@ end
 
 The module must implement `run/2`.
 
+`Jido.Action` declares the `run/2` callback and the optional input-preparation
+hook. `Jido.Executable` declares the descriptor, `validate_params/1`, and
+`validate_output/1` callbacks shared by Action and Flow modules. The generators
+implement both behaviours. Runtime contract checks remain in place for all
+module targets, including modules that do not declare the behaviours.
+
 ## Use An Inline Step For Small Local Work
 
 A Flow module can define a small Step body without a separate Action module:

--- a/lib/jido_action.ex
+++ b/lib/jido_action.ex
@@ -334,15 +334,18 @@ defmodule Jido.Action do
           def output_schema, do: @__jido_output_schema__
 
           @doc false
+          @impl Jido.Executable
           @spec __jido_executable__() :: Jido.Executable.t()
           def __jido_executable__, do: Jido.Executable.action(__MODULE__)
 
           @doc unquote(validate_params_doc)
+          @impl Jido.Executable
           @spec validate_params(map()) ::
                   {:ok, map()} | {:error, term()}
           def validate_params(params), do: Action.validate_params_for(params, __MODULE__)
 
           @doc unquote(validate_output_doc)
+          @impl Jido.Executable
           @spec validate_output(map() | Jido.Action.Output.t()) ::
                   {:ok, map() | Jido.Action.Output.t()}
                   | {:error, Jido.Action.Error.InvalidInputError.t()}

--- a/lib/jido_executable.ex
+++ b/lib/jido_executable.ex
@@ -16,6 +16,11 @@ defmodule Jido.Executable do
   `resolve/1` keeps the exact target and returns one small descriptor.
   A module callback must identify the module that owns the callback.
 
+  This behaviour declares the module descriptor and data validation callbacks.
+  `Jido.Action` owns the `run/2` callback. Both Action and Flow module generators
+  implement these behaviours. `validate/1` also checks the required functions
+  at runtime; a behaviour declaration alone does not make a module executable.
+
   A Flow module must return one stable `%Jido.Flow{}` from `flow/0` for the life
   of the loaded module version. Each validation or execution operation
   materializes the value once.
@@ -31,7 +36,7 @@ defmodule Jido.Executable do
   This module does not define a map or JSON format for executable targets.
   """
 
-  alias Jido.Action.Error
+  alias Jido.Action.{Error, Output}
   alias Jido.Flow
 
   @typedoc "The executable kind."
@@ -57,6 +62,13 @@ defmodule Jido.Executable do
 
   @doc false
   @callback __jido_executable__() :: t()
+
+  @doc "Validates input parameters without running executable work."
+  @callback validate_params(map()) :: {:ok, map()} | {:error, term()}
+
+  @doc "Validates normal output or an explicit output envelope."
+  @callback validate_output(map() | Output.t()) ::
+              {:ok, map() | Output.t()} | {:error, term()}
 
   @doc false
   @spec action(module()) :: t()
@@ -97,14 +109,14 @@ defmodule Jido.Executable do
   @spec validate(t() | target() | term()) :: :ok | {:error, Exception.t()}
   def validate(%__MODULE__{kind: :action, target: target})
       when is_atom(target) and not is_nil(target) do
-    validate_action_compatible_callbacks(target)
+    validate_module_callbacks(target)
   end
 
   def validate(%__MODULE__{kind: :flow, target: %Flow{}}), do: :ok
 
   def validate(%__MODULE__{kind: :flow, target: target})
       when is_atom(target) and not is_nil(target) do
-    with :ok <- validate_action_compatible_callbacks(target) do
+    with :ok <- validate_module_callbacks(target) do
       if function_exported?(target, :flow, 0) do
         :ok
       else
@@ -127,7 +139,7 @@ defmodule Jido.Executable do
     end
   end
 
-  defp validate_action_compatible_callbacks(module) do
+  defp validate_module_callbacks(module) do
     cond do
       not function_exported?(module, :run, 2) ->
         invalid_executable_contract(module, "missing run/2")

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -43,11 +43,13 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       def output_schema, do: @__jido_output_schema__
 
       @doc "Validates Flow input parameters."
+      @impl Jido.Executable
       @spec validate_params(map()) ::
               {:ok, map()} | {:error, Jido.Action.Error.InvalidInputError.t()}
       def validate_params(params), do: Jido.Action.validate_params_for(params, __MODULE__)
 
       @doc "Validates a Flow output value."
+      @impl Jido.Executable
       @spec validate_output(map() | Jido.Action.Output.t()) ::
               {:ok, map() | Jido.Action.Output.t()}
               | {:error, Jido.Action.Error.InvalidInputError.t()}
@@ -201,6 +203,7 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
           do: {name, action}
 
     quote generated: true do
+      @impl Jido.Executable
       def __jido_executable__, do: Jido.Executable.flow(__MODULE__)
       def flow, do: unquote(escaped_flow)
       def __jido_flow_source_map__, do: unquote(escaped_source_map)
@@ -222,6 +225,8 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       def compiled,
         do: Jido.Flow.compile!(flow(), source_map: __jido_flow_source_map__())
 
+      # This is a convenience entry point. Exec selects native Flow execution
+      # from the descriptor and does not call this through the Action runner.
       @impl Jido.Action
       def run(params, context), do: Jido.Exec.run(__MODULE__, params, context)
     end

--- a/test/jido_executable_test.exs
+++ b/test/jido_executable_test.exs
@@ -27,6 +27,27 @@ defmodule JidoActionTest.ExecutableTest do
     def __jido_executable__, do: raise("descriptor failed")
   end
 
+  test "the Executable behaviour declares identity and validation callbacks" do
+    assert Enum.sort(Executable.behaviour_info(:callbacks)) ==
+             [__jido_executable__: 0, validate_output: 1, validate_params: 1]
+
+    assert Executable.behaviour_info(:optional_callbacks) == []
+    assert {:run, 2} in Jido.Action.behaviour_info(:callbacks)
+  end
+
+  test "generated Action and Flow modules implement the Executable behaviour" do
+    for module <- [Add, MathFlow] do
+      behaviours =
+        module.__info__(:attributes) |> Keyword.get_values(:behaviour) |> List.flatten()
+
+      assert Executable in behaviours
+
+      for {callback, arity} <- Executable.behaviour_info(:callbacks) do
+        assert function_exported?(module, callback, arity)
+      end
+    end
+  end
+
   test "Action modules expose and resolve one Action descriptor" do
     assert %Executable{
              kind: :action,
@@ -70,7 +91,7 @@ defmodule JidoActionTest.ExecutableTest do
     assert :ok = Executable.validate(MathFlow.flow())
   end
 
-  test "validation checks the common Action-compatible module callbacks" do
+  test "validation checks the common module callbacks" do
     assert {:error, missing_run} = Executable.validate(MissingRun)
     assert missing_run.message == "module is not a valid Jido executable"
     assert missing_run.details.executable == MissingRun


### PR DESCRIPTION
## Description

Refines the existing v3 execution contract without changing the architecture or runtime behavior. `Jido.Executable` now declares the validation callbacks that runtime checks already require from Action and Flow modules. This makes the shared contract visible to the compiler and documentation tools.

`Jido.Action` still owns `run/2`. Flow modules still use native Flow execution. Custom module targets remain supported, and runtime checks do not depend on behaviour declarations. This PR does not introduce a protocol or a new execution layer.

Targets `release/v3`.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Breaking Changes

None for valid executable targets. Modules that declare `Jido.Executable` must implement `validate_params/1` and `validate_output/1`; these functions were already required by runtime validation.

## Testing

- [x] Tests pass (`mix test`)
- [x] Quality checks pass (`mix quality`)

Validation on Elixir 1.20.3 / OTP 29.0.5:

- The new callback contract test failed before the implementation change and passed after it.
- Focused Executable, Instruction execution, and Flow contract tests: 52 passed.
- `mix test --cover --warnings-as-errors`: 536 passed; 94.44% total coverage.
- `mix quality`: passed formatting, compilation, Doctor, ExDoc, Credo, and Dialyzer.
- `MIX_ENV=test mix compile --warnings-as-errors`: passed.
- `mix deps.audit`: no vulnerabilities found.

Code review completed with no actionable findings from correctness, project rules, test coverage, and API compatibility reviews. The additional Claude review produced no result because its execution context could not authenticate. Review receipt: `20260904-103347-7d88c07a` (`status: complete`).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove my fix/feature works
- [x] All new and existing tests pass
- [x] My commits follow conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md` (it is auto-generated by git_ops)

## Related Issues

None.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. The change clarifies the existing module contract and leaves runtime validation and execution unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791128305&installation_model_id=434874&pr_number=225&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F225&signature=5c200e208c2cbec33d4dd200d25fdfbec87aa1b85348a0cc98419e24ae7fad28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->