### PR TITLE
fix(flow): reject nil and malformed reference paths

### DIFF
--- a/guides/flow-references.livemd
+++ b/guides/flow-references.livemd
@@ -74,6 +74,10 @@ empty path; it is different from `[nil]`, which is invalid.
 A valid path can select a present `nil` value. Missing keys and invalid list
 indexes return structured execution errors.
 
+`Builder.select/2` validates its source reference before it appends a path.
+An invalid source raises `Jido.Flow.Error.InvalidDefinitionError`. The next
+component or Flow constructor validates the complete selected path.
+
 A result reference creates an inferred dependency on the named component.
 Input and context references do not.
 

--- a/guides/flow-references.livemd
+++ b/guides/flow-references.livemd
@@ -66,8 +66,13 @@ output
 | `select(ref, path)` | same as source | A deeper path on a reference. |
 
 A path can be one atom, string, non-negative integer, or a list of these
-segments. Missing keys and invalid list indexes return structured execution
-errors.
+segments. A path list must be proper and must not contain `nil`. Constructors,
+Builder, the DSL, and Codec reject invalid paths before execution. An empty
+path selects the complete source value. The `nil` path argument is also an
+empty path; it is different from `[nil]`, which is invalid.
+
+A valid path can select a present `nil` value. Missing keys and invalid list
+indexes return structured execution errors.
 
 A result reference creates an inferred dependency on the named component.
 Input and context references do not.

--- a/lib/jido_flow/builder.ex
+++ b/lib/jido_flow/builder.ex
@@ -102,10 +102,13 @@ defmodule Jido.Flow.Builder do
   @spec result(atom() | String.t(), term()) :: Ref.t()
   def result(component, path \\ []), do: Ref.result(component, path)
 
-  @doc "Appends a path to a reference."
-  @spec select(Ref.t(), term()) :: Ref.t()
+  @doc "Appends a path to a reference or raises a validation error for an invalid source."
+  @spec select(Ref.t(), term()) :: Ref.t() | no_return()
   def select(%Ref{} = source, path) do
-    %{source | path: source.path ++ Ref.normalize_path(path)}
+    case Ref.validate(source, :any) do
+      :ok -> %{source | path: source.path ++ Ref.normalize_path(path)}
+      {:error, error} -> raise error
+    end
   end
 
   @doc "Builds a scoped Map or Reduce item reference."

--- a/lib/jido_flow/ref.ex
+++ b/lib/jido_flow/ref.ex
@@ -173,9 +173,14 @@ defmodule Jido.Flow.Ref do
   defp validate_scope(source, scope), do: {:error, :scope, %{source: source, scope: scope}}
 
   defp validate_path(path) when is_list(path) do
-    case Enum.find(path, &(not valid_path_segment?(&1))) do
-      nil -> :ok
-      segment -> {:error, :path, %{segment: segment}}
+    if List.improper?(path) do
+      {:error, :path, %{segment: path}}
+    else
+      Enum.reduce_while(path, :ok, fn segment, :ok ->
+        if valid_path_segment?(segment),
+          do: {:cont, :ok},
+          else: {:halt, {:error, :path, %{segment: segment}}}
+      end)
     end
   end
 

--- a/test/jido_flow/component_validation_test.exs
+++ b/test/jido_flow/component_validation_test.exs
@@ -95,4 +95,97 @@ defmodule Jido.Flow.ComponentValidationTest do
     step = Step.new!(name: "step", action: Add, after: ["second", "first"])
     assert step.after == ["second", "first"]
   end
+
+  test "constructors reject invalid paths inside nested params" do
+    constructors = [
+      {Step, [name: "step", action: Add]},
+      {Subflow, [name: "child", flow: NestedFlow]},
+      {Choice.Option, [name: "option", condition: Condition.eq(1, 1), action: Add]},
+      {Choice.Fallback, [action: Add]},
+      {FlowMap, [name: "map", collection: [], action: Add]},
+      {Reduce, [name: "reduce", collection: [], initial: %{}, action: Add]},
+      {Iterate,
+       [
+         name: "iterate",
+         action: Add,
+         state: [schema: [], initial: %{}, update: %{}],
+         completion: Condition.eq(true, true),
+         max_iterations: 1
+       ]},
+      {Dispatch, [name: "dispatch", decision: Add, expander: Add]}
+    ]
+
+    for {module, attrs} <- constructors do
+      for ref <- [Ref.input(:value), Ref.context(:value), Ref.result("load", :value)] do
+        assert {:ok, _component} = module.new(Keyword.put(attrs, :params, %{nested: [ref]}))
+
+        for path <- [[nil], [:value, nil, "key"], [:value, nil], [:value | :tail], [%{}]] do
+          params = %{nested: [%{value: %{ref | path: path}}]}
+
+          assert {:error,
+                  %InvalidDefinitionError{
+                    message: "flow expression contains an invalid reference path",
+                    details: %{path: [:nested, 0, :value]}
+                  }} = module.new(Keyword.put(attrs, :params, params))
+        end
+      end
+    end
+  end
+
+  test "constructors reject invalid local paths in their valid scopes" do
+    for path <- [[nil], [:value, nil], [:value | :tail], [-1]] do
+      for ref <- [Ref.item(path), Ref.accumulator(path)] do
+        assert {:error, %InvalidDefinitionError{details: %{segment: _}}} =
+                 Reduce.new(
+                   name: "reduce",
+                   collection: [],
+                   initial: %{},
+                   action: Add,
+                   params: %{nested: [ref]}
+                 )
+      end
+
+      assert {:error, %InvalidDefinitionError{details: %{segment: _}}} =
+               FlowMap.new(
+                 name: "map",
+                 collection: [],
+                 action: Add,
+                 params: %{nested: [Ref.item(path)]}
+               )
+
+      for ref <- [Ref.state(path), Ref.body_result(path)] do
+        assert {:error, %InvalidDefinitionError{details: %{segment: _}}} =
+                 Iterate.State.new(schema: [], initial: %{}, update: %{nested: [ref]})
+      end
+    end
+  end
+
+  test "constructors reject invalid paths inside conditions and expression operands" do
+    for path <- [[nil], [:value | :tail]] do
+      ref = Ref.input(path)
+
+      assert {:error, %InvalidDefinitionError{details: %{segment: _}}} =
+               Step.new(
+                 name: "step",
+                 action: Add,
+                 params: %{value: Jido.Expr.new!(:add, [ref, 1])}
+               )
+
+      assert {:error, %InvalidDefinitionError{details: %{segment: _}}} =
+               Condition.new(:eq, [ref, 1])
+
+      assert {:error, %InvalidDefinitionError{details: %{segment: _}}} =
+               Choice.new(
+                 name: "choice",
+                 options: [
+                   [
+                     name: "option",
+                     condition: %Condition{operator: :eq, operands: [ref, 1]},
+                     action: Add
+                   ]
+                 ],
+                 fallback: [action: Add]
+               )
+    end
+  end
 end

--- a/test/jido_flow/ref_path_authoring_test.exs
+++ b/test/jido_flow/ref_path_authoring_test.exs
@@ -1,0 +1,128 @@
+defmodule Jido.Flow.RefPathAuthoringTest.ValidFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "reference_paths"
+
+  flow do
+    step "echo",
+      action: JidoActionTest.Fixtures.Actions.EchoParamsAction,
+      params: %{
+        input: input([]),
+        selected: input([:payload, "items", 0]),
+        context: context(:optional),
+        literal: nil
+      }
+
+    output(%{echo: result("echo"), selected: select(result("echo"), :selected)})
+  end
+end
+
+defmodule Jido.Flow.RefPathAuthoringTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Flow
+  alias Jido.Flow.{Builder, Codec, Ref, Step}
+  alias Jido.Flow.Error.InvalidDefinitionError
+  alias JidoActionTest.Fixtures.Actions.EchoParamsAction
+
+  test "all authoring forms preserve supported paths and present nil values" do
+    params = %{
+      input: Ref.input([]),
+      selected: Ref.input([:payload, "items", 0]),
+      context: Ref.context(:optional),
+      literal: nil
+    }
+
+    output = %{echo: Ref.result("echo"), selected: Ref.result("echo", :selected)}
+
+    direct =
+      Flow.new!(
+        name: "reference_paths",
+        components: [Step.new!(name: "echo", action: EchoParamsAction, params: params)],
+        output: output
+      )
+
+    assert {:ok, built} =
+             Builder.new(name: "reference_paths")
+             |> Builder.step("echo", EchoParamsAction, params)
+             |> Builder.output(output)
+             |> Builder.build()
+
+    assert {:ok, document, registry} = Codec.encode(direct)
+
+    assert {:ok, decoded} =
+             document |> Jason.encode!() |> Jason.decode!() |> Codec.decode(registry)
+
+    input = %{payload: %{"items" => [nil]}}
+    expected = %{echo: %{input: input, selected: nil, context: nil, literal: nil}, selected: nil}
+
+    for flow <- [direct, built, decoded, __MODULE__.ValidFlow.flow()] do
+      assert flow == direct
+      assert Jido.Exec.run(flow, input, %{optional: nil}) == {:ok, expected}
+    end
+  end
+
+  test "Flow, Builder, and Codec reject malformed reference paths" do
+    step = Step.new!(name: "echo", action: EchoParamsAction)
+    valid = Flow.new!(name: "invalid_paths", components: [step], output: Ref.input([]))
+    assert {:ok, document, registry} = Codec.encode(valid)
+
+    for path <- [[nil], ["value", nil, 0], ["value", nil], ["value" | :tail], [-1], [1.5]] do
+      ref = Ref.input(path)
+
+      assert {:error, %InvalidDefinitionError{}} =
+               Flow.new(name: "invalid_paths", components: [step], output: %{nested: [ref]})
+
+      assert {:error, %InvalidDefinitionError{}} =
+               Builder.new(name: "invalid_paths")
+               |> Builder.step("echo", EchoParamsAction, %{nested: [Builder.input(path)]})
+               |> Builder.output(Builder.result("echo"))
+               |> Builder.build()
+
+      assert {:error, %InvalidDefinitionError{}} =
+               Builder.new(name: "invalid_paths")
+               |> Builder.step("echo", EchoParamsAction, %{})
+               |> Builder.output(%{nested: [Builder.select(Builder.input([]), path)]})
+               |> Builder.build()
+
+      invalid_flow = %{valid | output: ref}
+      assert {:error, %InvalidDefinitionError{}} = Codec.encode(invalid_flow, registry)
+
+      stored_ref = %{"$ref" => %{"source" => "input", "component" => nil, "path" => path}}
+
+      assert {:error, %InvalidDefinitionError{}} =
+               Codec.decode(%{document | "output" => stored_ref}, registry)
+    end
+  end
+
+  test "the module DSL rejects nil segments and malformed paths before execution" do
+    for {path, index} <-
+          Enum.with_index([
+            "[nil]",
+            "[nil, :value]",
+            "[:value, nil, 0]",
+            "[:value, nil]",
+            "[:value | :tail]",
+            "[-1]",
+            "[%{}]"
+          ]) do
+      code = """
+      defmodule #{__MODULE__}.Invalid#{index} do
+        use Jido.Flow, name: "invalid_reference_path"
+
+        flow do
+          step "echo",
+            action: JidoActionTest.Fixtures.Actions.EchoParamsAction,
+            params: %{nested: [input(#{path})]}
+
+          output(result("echo"))
+        end
+      end
+      """
+
+      assert_raise CompileError, ~r/invalid reference path|unsupported Flow expression/, fn ->
+        Code.compile_string(code)
+      end
+    end
+  end
+end

--- a/test/jido_flow/ref_path_authoring_test.exs
+++ b/test/jido_flow/ref_path_authoring_test.exs
@@ -21,9 +21,19 @@ defmodule Jido.Flow.RefPathAuthoringTest do
   use ExUnit.Case, async: true
 
   alias Jido.Flow
-  alias Jido.Flow.{Builder, Codec, Ref, Step}
+  alias Jido.Flow.{Builder, Codec, Iterate, Reduce, Ref, Step}
+  alias Jido.Flow.Map, as: FlowMap
   alias Jido.Flow.Error.InvalidDefinitionError
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
+
+  defmodule CountedAction do
+    use Jido.Action, name: "counted_reference_action"
+
+    def run(params, %{calls: calls}) do
+      Agent.update(calls, &(&1 + 1))
+      {:ok, params}
+    end
+  end
 
   test "all authoring forms preserve supported paths and present nil values" do
     params = %{
@@ -59,6 +69,11 @@ defmodule Jido.Flow.RefPathAuthoringTest do
     for flow <- [direct, built, decoded, __MODULE__.ValidFlow.flow()] do
       assert flow == direct
       assert Jido.Exec.run(flow, input, %{optional: nil}) == {:ok, expected}
+
+      assert {:error,
+              %Jido.Flow.Error.ExecutionFailureError{
+                details: %{reason: :missing_index, path: [:payload, "items", 0]}
+              }} = Jido.Exec.run(flow, %{payload: %{"items" => []}}, %{optional: nil})
     end
   end
 
@@ -93,6 +108,117 @@ defmodule Jido.Flow.RefPathAuthoringTest do
       assert {:error, %InvalidDefinitionError{}} =
                Codec.decode(%{document | "output" => stored_ref}, registry)
     end
+  end
+
+  test "Builder.select rejects an invalid source with a structured error" do
+    for path <- [[:payload | :tail], [:payload, :value | nil], [nil], nil, :payload, 0, %{}] do
+      source = %Ref{source: :input, path: path}
+
+      error =
+        assert_raise InvalidDefinitionError, "invalid flow ref", fn ->
+          Builder.select(source, :value)
+        end
+
+      assert error.details.reason == :path
+      assert error.details.ref == source
+    end
+  end
+
+  test "Builder.select preserves valid global and local reference sources" do
+    for source <- [
+          Ref.input([]),
+          Ref.context(),
+          Ref.result("echo"),
+          Ref.item(),
+          Ref.accumulator(),
+          Ref.state(),
+          Ref.body_result()
+        ] do
+      assert Builder.select(source, [:payload, "items", 0]) ==
+               %{source | path: [:payload, "items", 0]}
+
+      assert Builder.select(source, nil) == source
+    end
+
+    for source <- [Ref.item_index(), Ref.item_id(), Ref.iteration_index()] do
+      assert Builder.select(source, []) == source
+    end
+  end
+
+  test "Exec rejects invalid paths for every source before any Action work" do
+    calls = start_supervised!({Agent, fn -> 0 end})
+    first = Step.new!(name: "first", action: CountedAction)
+
+    components =
+      for ref <- [Ref.input([]), Ref.context(), Ref.result("first")] do
+        Step.new!(name: "node", action: EchoParamsAction, params: %{value: ref})
+      end
+
+    components =
+      components ++
+        for ref <- [Ref.item(), Ref.item_index(), Ref.item_id()] do
+          FlowMap.new!(
+            name: "node",
+            action: EchoParamsAction,
+            collection: [],
+            params: %{value: ref}
+          )
+        end
+
+    components =
+      components ++
+        [
+          Reduce.new!(
+            name: "node",
+            action: EchoParamsAction,
+            collection: [],
+            initial: %{},
+            params: %{value: Ref.accumulator()}
+          )
+        ] ++
+        for ref <- [Ref.state(), Ref.iteration_index()] do
+          Iterate.new!(
+            name: "node",
+            action: EchoParamsAction,
+            params: %{value: ref},
+            state: [schema: [], initial: %{}, update: %{}],
+            completion: true,
+            max_iterations: 1
+          )
+        end
+
+    for path <- [[nil], [:value, nil, 0], [:value, nil], [:value | :tail], [-1], [0.0]],
+        component <- components do
+      invalid = put_in(component.params.value.path, path)
+
+      flow = %Flow{
+        name: "invalid_paths",
+        components: [first, invalid],
+        output: Ref.result("node")
+      }
+
+      assert {:error, %InvalidDefinitionError{}} = Jido.Exec.run(flow, %{}, %{calls: calls})
+      assert {:error, %InvalidDefinitionError{}} = Jido.Exec.start(flow, %{}, %{calls: calls})
+    end
+
+    iterate =
+      Iterate.new!(
+        name: "node",
+        action: EchoParamsAction,
+        state: [schema: [], initial: %{}, update: %{value: Ref.body_result()}],
+        completion: true,
+        max_iterations: 1
+      )
+
+    invalid = put_in(iterate.state.update.value.path, [nil])
+    flow = %Flow{name: "invalid_update", components: [first, invalid], output: Ref.result("node")}
+
+    assert {:error, %InvalidDefinitionError{}} = Jido.Exec.run(flow, %{}, %{calls: calls})
+    assert {:error, %InvalidDefinitionError{}} = Jido.Exec.start(flow, %{}, %{calls: calls})
+    assert Agent.get(calls, & &1) == 0
+
+    assert {:ok, %{}} = Jido.Exec.run(CountedAction, %{}, %{calls: calls})
+    assert Agent.get(calls, & &1) == 1
   end
 
   test "the module DSL rejects nil segments and malformed paths before execution" do

--- a/test/jido_flow/ref_test.exs
+++ b/test/jido_flow/ref_test.exs
@@ -39,4 +39,69 @@ defmodule Jido.Flow.RefTest do
     assert {:error, %InvalidDefinitionError{}} = Ref.validate(Ref.input([-1]))
     assert {:error, %InvalidDefinitionError{}} = Ref.validate(Ref.input([%{}]))
   end
+
+  test "nil is rejected at each path position for every source with a path" do
+    for path <- [[nil], [nil, :value], [:payload, nil, :value], [:payload, nil]],
+        ref <- path_refs(path) do
+      assert {:error,
+              %InvalidDefinitionError{
+                details: %{reason: :path, segment: nil, ref: ^ref}
+              }} = Ref.validate(ref, :any)
+    end
+  end
+
+  test "improper paths return a structured error for every source with a path" do
+    for path <- [[:payload | :tail], [:payload, :value | nil]],
+        ref <- path_refs(path) do
+      assert {:error,
+              %InvalidDefinitionError{
+                details: %{reason: :path, segment: ^path, ref: ^ref}
+              }} = Ref.validate(ref, :any)
+    end
+  end
+
+  test "supported segments and empty paths remain valid for every source with a path" do
+    for path <- [nil, [], :value, "value", 0, [:payload, "items", 0, true, false]],
+        ref <- path_refs(path) do
+      assert :ok = Ref.validate(ref, :any)
+    end
+
+    assert Ref.input(nil) == Ref.input([])
+  end
+
+  test "unsupported segments and non-list canonical paths return structured errors" do
+    for segment <- [-1, 1.5, %{}, [], {:value}, self(), make_ref(), fn -> :value end],
+        ref <- path_refs([:payload, segment]) do
+      assert {:error, %InvalidDefinitionError{details: %{reason: :path, segment: ^segment}}} =
+               Ref.validate(ref, :any)
+    end
+
+    for path <- [nil, :value, "value", 0, %{}], ref <- path_refs([]) do
+      assert {:error, %InvalidDefinitionError{details: %{reason: :path, segment: ^path}}} =
+               Ref.validate(%{ref | path: path}, :any)
+    end
+  end
+
+  test "index and identifier sources require an empty path" do
+    for ref <- [Ref.item_index(), Ref.item_id(), Ref.iteration_index()] do
+      assert :ok = Ref.validate(ref, :any)
+
+      for path <- [[nil], [:value], [:value | :tail], :value] do
+        assert {:error, %InvalidDefinitionError{details: %{reason: :shape}}} =
+                 Ref.validate(%{ref | path: path}, :any)
+      end
+    end
+  end
+
+  defp path_refs(path) do
+    [
+      Ref.input(path),
+      Ref.context(path),
+      Ref.result("load", path),
+      Ref.item(path),
+      Ref.accumulator(path),
+      Ref.state(path),
+      Ref.body_result(path)
+    ]
+  end
 end


### PR DESCRIPTION
## Description

`Ref.validate(Ref.input([nil]))` returned `:ok`, so component constructors accepted an invalid path. An improper path such as `[:payload | :tail]` raised `FunctionClauseError` during enumeration.

Check that the path is a proper list before enumeration. Return a tagged validation error for the first invalid segment, including `nil`. Preserve supported atom, string, and index segments, empty paths, and present `nil` values. The existing constructor validation applies the Ref fix across authoring forms.

`Builder.select/2` also uses the existing Ref validator before it appends a path. An invalid source raises `InvalidDefinitionError`; an improper source path no longer raises `ArgumentError` from list concatenation. Valid global and local sources retain their behavior. The next component or Flow constructor validates the complete selected path.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Breaking Changes

Previously accepted invalid paths now fail before execution. `Ref.input(nil)` still selects the complete input; `[nil]` is invalid. This change does not alter valid Flow execution.

## Testing

- Baseline: 19 nearby tests passed.
- Regression evidence before the fix: 4 of 6 Ref tests passed. The nil test failed because validation returned `:ok`. The improper-list test raised `FunctionClauseError` in `Enum.find_list/3`.
- Builder regression before its fix: an improper source path raised `ArgumentError` instead of `InvalidDefinitionError`.
- Final focused run: 122 tests passed across Ref, component constructors, authoring parity, Codec, DSL, and execution test files.
- [x] `mix test`: 749 passed.
- [x] `MIX_ENV=test mix compile --warnings-as-errors`.
- [x] `mix quality`: format, compilation, Doctor, docs, Credo, and Dialyzer passed. Doctor reported 100% documentation and spec coverage. Dialyzer reported zero errors.
- [x] `mix test --cover --warnings-as-errors`: 749 passed; total coverage 94.65% (required 93%); Ref coverage 97.62%; Builder coverage 97.73%.

Local checks used Elixir 1.20.3 / OTP 29.0.5 with `ERL_FLAGS="+S 2:2"`. Dependencies, build data, and writable PLTs are local copies in this issue worktree. No mutable cache points outside it. The default exclusions for integration, flaky, and skip tags apply.

The tests cover each reference source, nil at each path position, improper paths, unsupported segments, nested component parameters, local scopes, conditions, expression operands, and all four authoring forms. A JSON round trip and execution test distinguish a present nil value from a missing index. A supervised counter confirms that invalid references fail before any Action call in both run-to-completion and step-wise startup.

## Checklist

- [x] The code follows the project style.
- [x] The reference guide describes the path rules.
- [x] Regression tests prove the fix.
- [x] New and existing local tests pass.
- [x] The commit uses conventional commit format.
- [x] `CHANGELOG.md` is unchanged, as required by CI.

Human QA: repeat the issue reproduction; try an improper path through a Step constructor and as the source of `Builder.select/2`; compare a valid path that selects a present nil value with a missing index. One refinement and hardening pass is complete. Human QA is pending.

## Related Issues

Closes #234

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791213933&installation_model_id=434874&pr_number=244&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F244&signature=5ebbc62fdf84d804aa790221a3c048c654f9407f6bf07636b1dbc9639ce2cd5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
