### PR TITLE
fix(flow): preserve runtime context in Subflow output

### DIFF
--- a/guides/nested-flows.livemd
+++ b/guides/nested-flows.livemd
@@ -75,6 +75,12 @@ does not hide these native runnables.
 The child inherits the parent context, `max_concurrency`, `jido` routing, and
 execution ID. Its Action calls share the parent execution budget.
 
+Child output uses the same caller context as root Flow output. This includes
+context references inside expressions, maps, and lists. Input references read
+the validated child input. Result references read components in that child.
+A missing context key returns a reference error. A key with a `nil` value is
+present and resolves to `nil`. These rules also apply to step-wise execution.
+
 An Action failure keeps its typed error and leaf details. Its
 `details.node_path` identifies the authored Subflow path, for example
 `["child", "add"]`. Child input and output validation failures identify the

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -34,7 +34,7 @@ defmodule Jido.Flow.Compiler do
   alias Runic.Workflow.Map, as: RunicMap
   alias Runic.Workflow.Reduce, as: RunicReduce
 
-  @compiler_version 5
+  @compiler_version 6
   @runtime_ref %{
     kind: :context,
     target: :jido,
@@ -166,7 +166,7 @@ defmodule Jido.Flow.Compiler do
     end)
     |> case do
       {:ok, results} ->
-        Expression.resolve(compiled.output, %{input: input, context: context, results: results})
+        resolve_output(compiled.output, input, context, results)
 
       {:continue, %Transition{} = transition} ->
         {:continue, transition}
@@ -174,6 +174,10 @@ defmodule Jido.Flow.Compiler do
       {:error, error} ->
         {:error, error}
     end
+  end
+
+  defp resolve_output(output, input, context, results) do
+    Expression.resolve(output, %{input: input, context: context, results: results})
   end
 
   @doc false
@@ -896,12 +900,16 @@ defmodule Jido.Flow.Compiler do
     namespace = child_state.namespace
     output = child_state.flow.output
 
-    data_step(
-      name: scoped(namespace, "$output"),
-      hash: stable_hash({namespace, :output_validator}),
-      work: fn parent ->
-        local = component_state_from(output, parent)
-        output = Expression.resolve(output, local) |> unwrap_ok!()
+    runtime_step_named(
+      scoped(namespace, "$output"),
+      child_state,
+      :output_validator,
+      fn parent, runtime ->
+        local = output_state(output, parent, runtime)
+
+        output =
+          resolve_output(output, local.input, local.context, local.results)
+          |> unwrap_ok!()
 
         validated =
           case subflow.flow.validate_output(output) do
@@ -928,20 +936,8 @@ defmodule Jido.Flow.Compiler do
     end
   end
 
-  defp component_state_from(output, parent) do
+  defp output_state(output, parent, runtime) do
     deps = output |> Flow.Expression.result_refs() |> Enum.uniq() |> Enum.sort()
-
-    runtime = %{
-      input: nil,
-      context: %{},
-      options: [],
-      execution_id: "",
-      target_runner: nil,
-      observer: nil,
-      flow_digest: "",
-      flow: ""
-    }
-
     dependency_state(deps, deps, parent, runtime)
   end
 

--- a/test/jido_exec/subflow_output_test.exs
+++ b/test/jido_exec/subflow_output_test.exs
@@ -1,6 +1,7 @@
 defmodule JidoActionTest.Exec.SubflowOutputTest do
   use ExUnit.Case, async: true
 
+  alias Jido.Action.Output
   alias Jido.Exec
   alias Jido.Flow
   alias Jido.Flow.{Builder, Codec, Ref, Step, Subflow}
@@ -76,6 +77,15 @@ defmodule JidoActionTest.Exec.SubflowOutputTest do
         tenant: context([:account, :tenant]),
         nil?: context([:account, :tenant]) == nil
       }
+    end
+  end
+
+  defmodule ContextOutput do
+    use Jido.Flow, name: "complete_context_output"
+
+    flow do
+      step "work", action: EchoParamsAction, params: %{}
+      output context(:output)
     end
   end
 
@@ -214,6 +224,32 @@ defmodule JidoActionTest.Exec.SubflowOutputTest do
 
     assert Exec.run(Parent, %{value: 7}, %{tenant: nil}) ==
              {:ok, %{work: %{value: 7}, tenant: nil}}
+  end
+
+  test "context can select a complete map or list output envelope" do
+    values = [%{value: 7}, nil]
+
+    for output <- [
+          %{items: values},
+          Output.batch(values, meta: %{source: "context"}),
+          Output.batch([])
+        ],
+        flow <- [ContextOutput, parent_flow(ContextOutput)],
+        mode <- [:run, :step, :wave, :continue] do
+      assert execute(flow, %{value: 7}, %{output: output}, mode) == {:ok, output}
+    end
+  end
+
+  test "a bare list from context still requires an output envelope" do
+    for {flow, message} <- [
+          {ContextOutput, "Flow returned a value that requires an output envelope"},
+          {parent_flow(ContextOutput), "Action output validation must return a map"}
+        ],
+        output <- [[], [%{value: 7}]],
+        mode <- [:run, :step, :wave, :continue] do
+      assert {:error, error} = execute(flow, %{value: 7}, %{output: output}, mode)
+      assert Exception.message(error) == message
+    end
   end
 
   test "missing context keys remain structured errors in root and child outputs" do

--- a/test/jido_exec/subflow_output_test.exs
+++ b/test/jido_exec/subflow_output_test.exs
@@ -1,0 +1,310 @@
+defmodule JidoActionTest.Exec.SubflowOutputTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Exec
+  alias Jido.Flow
+  alias Jido.Flow.{Builder, Codec, Ref, Step, Subflow}
+  alias JidoActionTest.Fixtures.Actions.EchoParamsAction
+
+  defmodule Child do
+    use Jido.Flow, name: "context_output_child"
+
+    flow do
+      step "work", action: EchoParamsAction, params: %{value: input(:value)}
+      output %{work: result("work"), tenant: context(:tenant)}
+    end
+  end
+
+  defmodule Parent do
+    use Jido.Flow, name: "context_output_parent"
+
+    flow do
+      step "child", action: Child, params: %{value: input(:value)}
+      output result("child")
+    end
+  end
+
+  defmodule ExpressionChild do
+    use Jido.Flow, name: "expression_output_child"
+
+    flow do
+      step "work", action: EchoParamsAction, params: %{value: input(:value) + 1}
+      step "other", action: EchoParamsAction, params: %{value: input(:value) * 2}
+
+      output %{
+        input: input(:value),
+        work: result("work"),
+        context: context(),
+        nested: %{
+          values: [
+            context([:accounts, 0, :tenant]),
+            context(:prefix) <> input(:label) <> context(:suffix)
+          ],
+          total: result("work", :value) + result("other", :value) + context(:adjustment)
+        }
+      }
+    end
+  end
+
+  defmodule Nested do
+    use Jido.Flow, name: "nested_context_output"
+
+    flow do
+      step "work", action: EchoParamsAction, params: %{value: input(:value) + 100}
+
+      step "child",
+        action: ExpressionChild,
+        params: %{value: input(:value) + 1, label: input(:label)}
+
+      output %{
+        input: input(:value),
+        work: result("work"),
+        child: result("child"),
+        tenant: context([:accounts, 0, :tenant])
+      }
+    end
+  end
+
+  defmodule NoResultChild do
+    use Jido.Flow, name: "no_result_context_output"
+
+    flow do
+      step "work", action: EchoParamsAction, params: %{}
+
+      output %{
+        input: input(:value),
+        tenant: context([:account, :tenant]),
+        nil?: context([:account, :tenant]) == nil
+      }
+    end
+  end
+
+  test "root and child outputs use the same caller context" do
+    parent =
+      Flow.new!(
+        name: "context_output_parent",
+        components: [
+          Subflow.new!(name: "child", flow: Child, params: %{value: Ref.input(:value)})
+        ],
+        output: Ref.result("child")
+      )
+
+    expected = {:ok, %{work: %{value: 7}, tenant: "acme"}}
+    assert Exec.run(Child, %{value: 7}, %{tenant: "acme"}) == expected
+    assert Exec.run(parent, %{value: 7}, %{tenant: "acme"}) == expected
+  end
+
+  test "all authoring forms preserve root and child output context" do
+    child =
+      Flow.new!(
+        name: "context_output_child",
+        components: [
+          Step.new!(name: "work", action: EchoParamsAction, params: %{value: Ref.input(:value)})
+        ],
+        output: %{work: Ref.result("work"), tenant: Ref.context(:tenant)}
+      )
+
+    {:ok, built_child} =
+      Builder.new(name: child.name)
+      |> Builder.step("work", EchoParamsAction, %{value: Ref.input(:value)})
+      |> Builder.output(child.output)
+      |> Builder.build()
+
+    parent = parent_flow(Child)
+
+    {:ok, built_parent} =
+      Builder.new(name: parent.name)
+      |> Builder.step("child", Child, %{value: Ref.input(:value)})
+      |> Builder.output(parent.output)
+      |> Builder.build()
+
+    assert child == Child.flow()
+    assert child == built_child
+    assert parent == Parent.flow()
+    assert parent == built_parent
+
+    for flow <- [
+          Child,
+          child,
+          built_child,
+          from_json(child),
+          Parent,
+          parent,
+          built_parent,
+          from_json(parent)
+        ] do
+      assert Exec.run(flow, %{value: 7}, %{tenant: "acme"}) ==
+               {:ok, %{work: %{value: 7}, tenant: "acme"}}
+    end
+  end
+
+  test "nested expressions keep local input and results with the full caller context" do
+    context = expression_context()
+    input = %{value: 7, label: "child"}
+    parent = parent_flow(ExpressionChild, Ref.input([]))
+    expected = {:ok, expression_output(7, "child", context)}
+
+    for flow <- [ExpressionChild, parent, from_json(parent)],
+        mode <- [:run, :step, :wave, :continue] do
+      assert execute(flow, input, context, mode) == expected
+    end
+  end
+
+  test "two child levels and repeated calls keep each input and result scope" do
+    parent =
+      Flow.new!(
+        name: "repeated_nested_context_output",
+        components: [
+          Step.new!(name: "work", action: EchoParamsAction, params: %{value: 999}),
+          Subflow.new!(
+            name: "left",
+            flow: Nested,
+            params: %{value: Ref.input(:left), label: "left"}
+          ),
+          Subflow.new!(
+            name: "right",
+            flow: Nested,
+            params: %{value: Ref.input(:right), label: "right"}
+          )
+        ],
+        output: %{
+          input: Ref.input(:value),
+          work: Ref.result("work"),
+          left: Ref.result("left"),
+          right: Ref.result("right")
+        }
+      )
+
+    context = expression_context()
+
+    expected =
+      {:ok,
+       %{
+         input: 500,
+         work: %{value: 999},
+         left: %{
+           input: 2,
+           work: %{value: 102},
+           child: expression_output(3, "left", context),
+           tenant: "acme"
+         },
+         right: %{
+           input: 8,
+           work: %{value: 108},
+           child: expression_output(9, "right", context),
+           tenant: "acme"
+         }
+       }}
+
+    for mode <- [:run, :step, :wave, :continue] do
+      assert execute(parent, %{value: 500, left: 2, right: 8}, context, mode) == expected
+    end
+  end
+
+  test "output without result references uses child input and preserves present nil" do
+    for tenant <- ["acme", nil],
+        flow <- [NoResultChild, parent_flow(NoResultChild)],
+        mode <- [:run, :step, :wave, :continue] do
+      assert execute(flow, %{value: 7}, %{account: %{tenant: tenant}}, mode) ==
+               {:ok, %{input: 7, tenant: tenant, nil?: is_nil(tenant)}}
+    end
+
+    assert Exec.run(Child, %{value: 7}, %{tenant: nil}) ==
+             {:ok, %{work: %{value: 7}, tenant: nil}}
+
+    assert Exec.run(Parent, %{value: 7}, %{tenant: nil}) ==
+             {:ok, %{work: %{value: 7}, tenant: nil}}
+  end
+
+  test "missing context keys remain structured errors in root and child outputs" do
+    for flow <- [Child, Parent], mode <- [:run, :step, :wave, :continue] do
+      assert {:error, %Jido.Flow.Error.ExecutionFailureError{} = error} =
+               execute(flow, %{value: 7}, %{}, mode)
+
+      assert error.message == "flow reference path does not exist"
+      assert error.details.ref_type == :context
+      assert error.details.reason == :missing_key
+      assert error.details.path == [:tenant]
+      assert error.details.retry == false
+    end
+  end
+
+  test "missing context inside an expression keeps the same reference error" do
+    context = Map.delete(expression_context(), :suffix)
+
+    for flow <- [ExpressionChild, parent_flow(ExpressionChild, Ref.input([]))],
+        mode <- [:run, :step, :wave, :continue] do
+      assert {:error, %Jido.Flow.Error.ExecutionFailureError{} = error} =
+               execute(flow, %{value: 7, label: "child"}, context, mode)
+
+      assert error.details.ref_type == :context
+      assert error.details.reason == :missing_key
+      assert error.details.path == [:suffix]
+      assert error.details.expression_path == [:nested, :values, 1, :operands, 1, :operands, 1]
+      assert error.details.retry == false
+    end
+  end
+
+  defp parent_flow(child, params \\ %{value: Ref.input(:value)}) do
+    Flow.new!(
+      name: "context_output_parent",
+      components: [Subflow.new!(name: "child", flow: child, params: params)],
+      output: Ref.result("child")
+    )
+  end
+
+  defp from_json(flow) do
+    {:ok, document, registry} = Codec.encode(flow)
+    {:ok, restored} = Codec.decode(JSON.decode!(JSON.encode!(document)), registry)
+    restored
+  end
+
+  defp expression_context do
+    %{
+      accounts: [%{tenant: "acme"}],
+      prefix: "<",
+      suffix: ">",
+      adjustment: 10,
+      token: make_ref()
+    }
+  end
+
+  defp expression_output(value, label, context) do
+    %{
+      input: value,
+      work: %{value: value + 1},
+      context: context,
+      nested: %{values: ["acme", "<#{label}>"], total: value * 3 + 11}
+    }
+  end
+
+  defp execute(flow, input, context, :run), do: Exec.run(flow, input, context)
+
+  defp execute(flow, input, context, mode) do
+    {:ok, execution} = Exec.start(flow, input, context)
+    finish(execution, mode)
+  end
+
+  defp finish(execution, mode) do
+    if Exec.status(execution) in [:succeeded, :failed] do
+      Exec.result(execution)
+    else
+      execution =
+        case mode do
+          :step ->
+            {:ok, _runnable, next} = Exec.step(execution)
+            next
+
+          :wave ->
+            {:ok, _runnables, next} = Exec.wave(execution)
+            next
+
+          :continue ->
+            {:ok, next} = Exec.continue(execution)
+            next
+        end
+
+      finish(execution, mode)
+    end
+  end
+end

--- a/test/jido_instruction/instruction_test.exs
+++ b/test/jido_instruction/instruction_test.exs
@@ -1,5 +1,6 @@
 defmodule JidoActionTest.InstructionTest do
-  use ExUnit.Case, async: true
+  # Negative log assertions must not capture warnings from concurrent Exec tests.
+  use ExUnit.Case, async: false
 
   import ExUnit.CaptureLog
 


### PR DESCRIPTION
## Description

A Flow output that reads `context(:tenant)` succeeds as a root call but fails as a Subflow because child output used an empty context. Child output now uses the real runtime context and the same output resolver as root output. Input and result references keep their child-local scopes.

For input `%{value: 7}` and context `%{tenant: "acme"}`, both entry paths return `{:ok, %{work: %{value: 7}, tenant: "acme"}}`.

This PR depends on #247 at `c4cfc037bf3f70a0a1d9f4e4d899f13279870bb6` and targets `fix/issue-230-compiler-captures`. **Merge #247 before #245.** The diff against this base contains only the Subflow fix, its tests and guide, and the narrow Instruction test-isolation correction.

The child output callback keeps the extracted output and namespace values from #247. It does not retain the complete child compiler state. The rebase preserves the Subflow namespace and identity rules from this fix.

Tests cover direct and calculated context references, maps and lists inside output, two child levels, repeated children, missing keys versus present `nil`, all four authoring forms, and `run`, `step`, `wave`, and `continue`. Two added checks cover context selecting a complete map or list output envelope, including empty lists, and rejection of bare list output.

CI exposed an existing shared-log race in `InstructionTest`. With seed `417162`, its negative log assertion captured an `:opts` warning from a concurrent Exec test. That module now runs serially. Production Instruction behavior and the log assertions are unchanged.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Breaking Changes

No public API change. The compiler version increases because the native output node now reads runtime context. Compiled identities can change; they remain opaque and are not a storage format. Nested error-path work remains separate.

## Testing

- Confirmed the original regression before the fix: the root call passed; the Subflow call returned `ExecutionFailureError` with `reason: :missing_key`, `ref_type: :context`, and `path: [:tenant]`.
- Combined baseline after the rebase: 93 focused tests passed.
- Final focused run: 95 tests passed, including both parent capture test files, Subflow tests, native compilation tests, expression tests, Flow contracts, and Instruction tests.
- Parent capture checks passed: callbacks retain no compiler state; copied independent, chained, nested, Map, and Reduce graphs stay within growth bounds; worker copies exclude unrelated Flow data.
- [x] `mix test`: 751 tests passed.
- [x] `mix quality`: formatter, compilation, Doctor, docs, Credo, and Dialyzer passed.
- [x] `MIX_ENV=test mix compile --warnings-as-errors` passed.
- [x] `mix test --cover --warnings-as-errors`: 751 tests passed; total coverage is 94.59% against the 93% threshold.

Local checks used Elixir 1.20.3 / OTP 29.0.5 with `ERL_FLAGS='+S 2:2'`. Dependencies, build files, and writable PLTs are isolated in this worktree. CI supplies the complete OTP 27/28/29 test matrix. The branch-specific Jido Review workflow does not apply to this temporary base branch.

## Checklist

- [x] Code follows the project style.
- [x] Documentation is updated.
- [x] Tests prove the fix after a confirmed failing regression.
- [x] All new and existing default tests pass.
- [x] Commits use the conventional commit format.
- [x] `CHANGELOG.md` is unchanged; it is generated by git_ops.

## Related Issues

Closes #231
