### PR TITLE
fix(exec): safely encode runtime error details

### DIFF
--- a/guides/execution.md
+++ b/guides/execution.md
@@ -69,9 +69,10 @@ the same map. All three error families use the bounded conversion rules in
 
 The conversion keeps scalar values, converts tuples to lists, and represents
 PIDs, references, and other runtime values as diagnostic strings. Exceptions
-in details become struct labels. Large or deeply nested values use truncation
-markers. These external values are for diagnostics. Use the original error
-for complete details and cause inspection.
+in ordinary details become struct labels. Declared Flow causes keep their
+error maps and share the containing details' limits. Large or deeply nested
+values use truncation markers. These external values are for diagnostics.
+Use the original error for complete details and cause inspection.
 
 A runtime error can keep a `Splode.Stacktrace` in memory. Conversion does not
 change it. The stable map omits the exception's top-level stacktrace.

--- a/guides/execution.md
+++ b/guides/execution.md
@@ -62,9 +62,27 @@ Flow boundary errors use:
 - `Jido.Flow.Error.InternalError`.
 
 An Action failure inside a Flow keeps its Action error when possible. Use
-`Jido.Action.Error.to_map/1` or `Jido.Flow.Error.to_map/1` for deterministic
-external data. A runtime error can keep a `Splode.Stacktrace` in memory. The
-stable map does not include it.
+`Jido.Action.Error.to_map/1`, `Jido.Flow.Error.to_map/1`, or
+`Jido.Exec.Error.to_map/1` for deterministic external data. JSON encoding uses
+the same map. All three error families use the bounded conversion rules in
+`Jido.Action.Error.to_map/1`.
+
+The conversion keeps scalar values, converts tuples to lists, and represents
+PIDs, references, and other runtime values as diagnostic strings. Exceptions
+in details become struct labels. Large or deeply nested values use truncation
+markers. These external values are for diagnostics. Use the original error
+for complete details and cause inspection.
+
+A runtime error can keep a `Splode.Stacktrace` in memory. Conversion does not
+change it. The stable map omits the exception's top-level stacktrace.
+
+For example, an error from a public cancellation call can be encoded directly:
+
+```elixir
+{:error, error} = Jido.Exec.cancel(self())
+json = JSON.encode!(error)
+%{"type" => "async_invalid_handle"} = JSON.decode!(json)
+```
 
 Exec does not retry work. Retryability in an error is information for a
 higher-level caller.

--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -200,6 +200,9 @@ defmodule Jido.Action.Error do
   - Conversion stops at depth 16 or after 1,024 terms per converted value.
     Map keys count toward this budget. Lists and tuples keep at most 64 items,
     with a final `"#Truncated"` marker when more items remain.
+    Declared Flow causes keep their error maps and share the containing
+    details' depth and term budget. They are converted once. Malformed cause
+    lists use the same fallback as other unsupported diagnostic values.
   - A map above 64 entries becomes
     `%{"__truncated__" => "map exceeds 64 entries"}`. A map that exhausts the
     term budget uses the reserved `"__truncated__"` key. A depth or term limit
@@ -214,77 +217,45 @@ defmodule Jido.Action.Error do
   strings describe the current runtime; they are not persistent identifiers.
   """
   @spec to_map(term()) :: error_map()
-  def to_map({:error, reason, _effects}), do: to_map(reason)
-  def to_map({:error, reason}), do: to_map(reason)
+  def to_map(error), do: error |> external_data() |> ExternalData.to_map()
 
-  def to_map(%InvalidInputError{} = error) do
-    %{
-      type: :validation_error,
-      message: ExternalData.message(error.message),
-      details:
-        error.details
-        |> ExternalData.details()
-        |> maybe_put(:field, ExternalData.value(error.field))
-        |> maybe_put(:value, ExternalData.value(error.value)),
-      retryable?: false
-    }
+  @doc false
+  @spec external_data(term()) :: map()
+  def external_data({:error, reason, _effects}), do: external_data(reason)
+  def external_data({:error, reason}), do: external_data(reason)
+
+  def external_data(%InvalidInputError{} = error) do
+    ExternalData.error_data(:validation_error, error.message, error.details, false,
+      field: error.field,
+      value: error.value
+    )
   end
 
-  def to_map(%ExecutionFailureError{} = error) do
-    %{
-      type: :execution_error,
-      message: ExternalData.message(error.message),
-      details: ExternalData.details(error.details),
-      retryable?: retryable?(error)
-    }
+  def external_data(%ExecutionFailureError{} = error) do
+    ExternalData.error_data(:execution_error, error.message, error.details, retryable?(error))
   end
 
-  def to_map(%TimeoutError{} = error) do
-    %{
-      type: :timeout,
-      message: ExternalData.message(error.message),
-      details:
-        error.details
-        |> ExternalData.details()
-        |> maybe_put(:timeout, ExternalData.value(error.timeout)),
-      retryable?: retryable?(error)
-    }
+  def external_data(%TimeoutError{} = error) do
+    ExternalData.error_data(:timeout, error.message, error.details, retryable?(error),
+      timeout: error.timeout
+    )
   end
 
-  def to_map(%ConfigurationError{} = error) do
-    %{
-      type: :configuration_error,
-      message: ExternalData.message(error.message),
-      details: ExternalData.details(error.details),
-      retryable?: false
-    }
+  def external_data(%ConfigurationError{} = error) do
+    ExternalData.error_data(:configuration_error, error.message, error.details, false)
   end
 
-  def to_map(%InternalError{} = error) do
-    %{
-      type: :internal_error,
-      message: ExternalData.message(error.message),
-      details: ExternalData.details(error.details),
-      retryable?: false
-    }
+  def external_data(%InternalError{} = error) do
+    ExternalData.error_data(:internal_error, error.message, error.details, false)
   end
 
-  def to_map(%Internal.UnknownError{} = error) do
-    %{
-      type: :internal_error,
-      message: error |> Exception.message() |> ExternalData.message(),
-      details: ExternalData.details(error.details),
-      retryable?: false
-    }
+  def external_data(%Internal.UnknownError{} = error) do
+    message = if is_nil(error.error), do: error.message, else: error.error
+    ExternalData.error_data(:internal_error, message, error.details, false)
   end
 
-  def to_map(reason) do
-    %{
-      type: :execution_error,
-      message: ExternalData.message(reason),
-      details: %{},
-      retryable?: false
-    }
+  def external_data(reason) do
+    ExternalData.error_data(:execution_error, reason, %{}, false)
   end
 
   @doc """
@@ -320,9 +291,6 @@ defmodule Jido.Action.Error do
   end
 
   defp normalize_constructor_details(_details), do: %{}
-
-  defp maybe_put(map, _key, nil), do: map
-  defp maybe_put(map, key, value), do: Map.put(map, key, value)
 end
 
 defimpl JSON.Encoder,

--- a/lib/jido_action/error.ex
+++ b/lib/jido_action/error.ex
@@ -19,7 +19,7 @@ defmodule Jido.Action.Error do
     ],
     unknown_error: __MODULE__.Internal.UnknownError
 
-  @inspect_opts [charlists: :as_lists]
+  alias Jido.Action.Error.ExternalData
 
   @type details_input :: map() | keyword()
   @type error_map :: %{
@@ -181,6 +181,37 @@ defmodule Jido.Action.Error do
 
   Unsupported values become conservative execution errors. They cannot select
   a canonical type, add structured details, or request a retry.
+
+  Action, Flow, and Exec error maps and JSON use the same external conversion:
+
+  - Atoms, numbers, Boolean values, and `nil` stay unchanged. JSON converts
+    atoms to strings, except for Boolean values and `nil`.
+  - Valid UTF-8 binaries stay unchanged. Other binaries become `base64:`
+    strings. Binaries above 4,096 bytes become `"#Truncated<binary>"`.
+  - Lists keep their order. Tuples become lists. Maps keep scalar keys;
+    other keys become diagnostic strings. Map entries use Erlang term order.
+    If converted keys collide, the last entry wins.
+  - Structs, including exceptions, become `"#Struct<Module>"`. Valid Runic
+    identities become full `runic:sha256:v1:...` strings.
+  - PIDs, references, ports, functions, bitstrings, and short improper lists
+    use inspected text. Inspection does not call custom struct protocols. It
+    uses a limit of 50 entries and 1,024 printable characters. The binary limit
+    also applies to the resulting text.
+  - Conversion stops at depth 16 or after 1,024 terms per converted value.
+    Map keys count toward this budget. Lists and tuples keep at most 64 items,
+    with a final `"#Truncated"` marker when more items remain.
+  - A map above 64 entries becomes
+    `%{"__truncated__" => "map exceeds 64 entries"}`. A map that exhausts the
+    term budget uses the reserved `"__truncated__"` key. A depth or term limit
+    replaces the affected value with `"#Truncated"`.
+  - Integers with more than 100 decimal digits become `"#Truncated<integer>"`.
+    Unsupported detail containers become an empty map. Direct keyword detail
+    containers must have at most 64 entries.
+
+  This conversion is lossy. It does not change the original exception, its
+  details, or its stacktrace. The map omits the exception's top-level
+  stacktrace. Use the in-memory error for full cause inspection. Diagnostic
+  strings describe the current runtime; they are not persistent identifiers.
   """
   @spec to_map(term()) :: error_map()
   def to_map({:error, reason, _effects}), do: to_map(reason)
@@ -189,12 +220,12 @@ defmodule Jido.Action.Error do
   def to_map(%InvalidInputError{} = error) do
     %{
       type: :validation_error,
-      message: normalize_message(error.message),
+      message: ExternalData.message(error.message),
       details:
         error.details
-        |> normalize_details()
-        |> maybe_put(:field, error.field)
-        |> maybe_put(:value, normalize_detail_value(error.value)),
+        |> ExternalData.details()
+        |> maybe_put(:field, ExternalData.value(error.field))
+        |> maybe_put(:value, ExternalData.value(error.value)),
       retryable?: false
     }
   end
@@ -202,8 +233,8 @@ defmodule Jido.Action.Error do
   def to_map(%ExecutionFailureError{} = error) do
     %{
       type: :execution_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
+      message: ExternalData.message(error.message),
+      details: ExternalData.details(error.details),
       retryable?: retryable?(error)
     }
   end
@@ -211,8 +242,11 @@ defmodule Jido.Action.Error do
   def to_map(%TimeoutError{} = error) do
     %{
       type: :timeout,
-      message: normalize_message(error.message),
-      details: error.details |> normalize_details() |> maybe_put(:timeout, error.timeout),
+      message: ExternalData.message(error.message),
+      details:
+        error.details
+        |> ExternalData.details()
+        |> maybe_put(:timeout, ExternalData.value(error.timeout)),
       retryable?: retryable?(error)
     }
   end
@@ -220,8 +254,8 @@ defmodule Jido.Action.Error do
   def to_map(%ConfigurationError{} = error) do
     %{
       type: :configuration_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
+      message: ExternalData.message(error.message),
+      details: ExternalData.details(error.details),
       retryable?: false
     }
   end
@@ -229,8 +263,8 @@ defmodule Jido.Action.Error do
   def to_map(%InternalError{} = error) do
     %{
       type: :internal_error,
-      message: normalize_message(error.message),
-      details: normalize_details(error.details),
+      message: ExternalData.message(error.message),
+      details: ExternalData.details(error.details),
       retryable?: false
     }
   end
@@ -238,8 +272,8 @@ defmodule Jido.Action.Error do
   def to_map(%Internal.UnknownError{} = error) do
     %{
       type: :internal_error,
-      message: error |> Exception.message() |> normalize_message(),
-      details: normalize_details(error.details),
+      message: error |> Exception.message() |> ExternalData.message(),
+      details: ExternalData.details(error.details),
       retryable?: false
     }
   end
@@ -247,7 +281,7 @@ defmodule Jido.Action.Error do
   def to_map(reason) do
     %{
       type: :execution_error,
-      message: normalize_message(reason),
+      message: ExternalData.message(reason),
       details: %{},
       retryable?: false
     }
@@ -287,65 +321,8 @@ defmodule Jido.Action.Error do
 
   defp normalize_constructor_details(_details), do: %{}
 
-  defp normalize_message(message) when is_binary(message), do: json_safe_binary(message)
-  defp normalize_message(message) when is_atom(message), do: Atom.to_string(message)
-  defp normalize_message(message), do: safe_inspect(message)
-
-  defp normalize_details(details) when is_map(details) and not is_struct(details) do
-    Map.new(details, fn {key, value} ->
-      {normalize_detail_key(key), normalize_detail_value(value)}
-    end)
-  end
-
-  defp normalize_details(details) when is_list(details) do
-    if Keyword.keyword?(details), do: details |> Map.new() |> normalize_details(), else: %{}
-  end
-
-  defp normalize_details(_details), do: %{}
-
-  defp normalize_detail_value(value)
-       when is_nil(value) or is_boolean(value) or is_number(value) or is_atom(value),
-       do: value
-
-  defp normalize_detail_value(value) when is_binary(value), do: json_safe_binary(value)
-  defp normalize_detail_value(%_{} = value), do: "#Struct<#{inspect(value.__struct__)}>"
-  defp normalize_detail_value(value) when is_map(value), do: normalize_details(value)
-
-  defp normalize_detail_value(value) when is_list(value) do
-    if proper_list?(value),
-      do: Enum.map(value, &normalize_detail_value/1),
-      else: safe_inspect(value)
-  end
-
-  defp normalize_detail_value(value) when is_tuple(value) do
-    value
-    |> Tuple.to_list()
-    |> Enum.map(&normalize_detail_value/1)
-  end
-
-  defp normalize_detail_value(value), do: safe_inspect(value)
-
-  defp normalize_detail_key(key) when is_binary(key), do: json_safe_binary(key)
-
-  defp normalize_detail_key(key)
-       when is_atom(key) or is_number(key) or is_boolean(key) or is_nil(key),
-       do: key
-
-  defp normalize_detail_key(key), do: safe_inspect(key)
-
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
-
-  defp proper_list?(list), do: proper_list_tail?(list)
-  defp proper_list_tail?([]), do: true
-  defp proper_list_tail?([_head | tail]), do: proper_list_tail?(tail)
-  defp proper_list_tail?(_tail), do: false
-
-  defp safe_inspect(value), do: inspect(value, @inspect_opts)
-
-  defp json_safe_binary(value) do
-    if String.valid?(value), do: value, else: "base64:" <> Base.encode64(value)
-  end
 end
 
 defimpl JSON.Encoder,

--- a/lib/jido_action/error_external_data.ex
+++ b/lib/jido_action/error_external_data.ex
@@ -9,15 +9,73 @@ defmodule Jido.Action.Error.ExternalData do
   @truncated "#Truncated"
   @inspect_opts [charlists: :as_lists, structs: false, limit: 50, printable_limit: 1_024]
 
-  @doc false
-  @spec details(term()) :: map()
-  def details(value) when is_map(value) and not is_struct(value), do: value(value)
+  # Only declared Flow causes use this marker. Other nested exceptions remain
+  # opaque. Expand causes inside the shared traversal so they cannot reset its
+  # depth or term budget, or convert already-encoded binaries a second time.
+  defmodule NestedError do
+    @moduledoc false
+    defstruct [:error]
 
-  def details(value) when is_list(value) do
-    if bounded_keyword?(value, @max_items), do: value |> Map.new() |> details(), else: %{}
+    @type t :: %__MODULE__{error: term()}
   end
 
-  def details(_value), do: %{}
+  @doc false
+  @spec error_data(atom(), term(), term(), boolean(), keyword()) :: map()
+  def error_data(type, message, details, retryable?, fields \\ []) do
+    %{
+      type: type,
+      message: if(is_binary(message), do: message, else: message(message)),
+      details: detail_fields(details, fields),
+      retryable?: retryable?
+    }
+  end
+
+  @doc false
+  @spec to_map(map()) :: map()
+  def to_map(data) do
+    %{data | message: message(data.message), details: details(data.details)}
+  end
+
+  @doc false
+  @spec map_items(term(), (term() -> term())) :: term()
+  def map_items(items, mapper) do
+    case map_items(items, mapper, @max_items + 1) do
+      {:ok, mapped} -> mapped
+      :improper -> items
+    end
+  end
+
+  defp map_items(_items, _mapper, 0), do: {:ok, []}
+  defp map_items([], _mapper, _remaining), do: {:ok, []}
+
+  defp map_items([head | tail], mapper, remaining) do
+    case map_items(tail, mapper, remaining - 1) do
+      {:ok, mapped} -> {:ok, [mapper.(head) | mapped]}
+      :improper -> :improper
+    end
+  end
+
+  defp map_items(_tail, _mapper, _remaining), do: :improper
+
+  @doc false
+  @spec details(term()) :: map()
+  def details(value), do: value |> detail_map() |> value()
+
+  defp detail_fields(value, fields) do
+    fields
+    |> Enum.reduce(detail_map(value), fn
+      {_key, nil}, acc -> acc
+      {key, value}, acc -> Map.put(acc, key, value)
+    end)
+  end
+
+  defp detail_map(value) when is_map(value) and not is_struct(value), do: value
+
+  defp detail_map(value) when is_list(value) do
+    if bounded_keyword?(value, @max_items), do: Map.new(value), else: %{}
+  end
+
+  defp detail_map(_value), do: %{}
 
   @doc false
   @spec message(term()) :: String.t()
@@ -43,6 +101,12 @@ defmodule Jido.Action.Error.ExternalData do
     do: {value, budget}
 
   defp convert(value, _depth, budget) when is_binary(value), do: {binary(value), budget}
+
+  defp convert(%NestedError{error: error}, depth, budget) do
+    error
+    |> Jido.Flow.Error.external_data()
+    |> convert(depth, budget)
+  end
 
   defp convert(
          %Runic.Identity{scheme: :sha256, version: 1, domain: domain, digest: digest} = identity,
@@ -72,11 +136,9 @@ defmodule Jido.Action.Error.ExternalData do
   end
 
   defp convert(value, depth, budget) when is_tuple(value) do
-    size = min(tuple_size(value), @max_items)
+    size = min(tuple_size(value), @max_items + 1)
     items = for index <- 0..(size - 1)//1, do: elem(value, index)
-    {items, budget} = list_items(items, depth + 1, budget, @max_items, [])
-    items = if tuple_size(value) > @max_items, do: items ++ [@truncated], else: items
-    {items, budget}
+    list_items(items, depth + 1, budget, @max_items, [])
   end
 
   defp convert(value, _depth, budget), do: {safe_inspect(value), budget}

--- a/lib/jido_action/error_external_data.ex
+++ b/lib/jido_action/error_external_data.ex
@@ -1,0 +1,128 @@
+defmodule Jido.Action.Error.ExternalData do
+  @moduledoc false
+
+  @max_depth 16
+  @max_items 64
+  @max_nodes 1_024
+  @max_bytes 4_096
+  @max_integer Integer.pow(10, 100) - 1
+  @truncated "#Truncated"
+  @inspect_opts [charlists: :as_lists, structs: false, limit: 50, printable_limit: 1_024]
+
+  @doc false
+  @spec details(term()) :: map()
+  def details(value) when is_map(value) and not is_struct(value), do: value(value)
+
+  def details(value) when is_list(value) do
+    if bounded_keyword?(value, @max_items), do: value |> Map.new() |> details(), else: %{}
+  end
+
+  def details(_value), do: %{}
+
+  @doc false
+  @spec message(term()) :: String.t()
+  def message(value) when is_binary(value), do: binary(value)
+  def message(value) when is_atom(value), do: Atom.to_string(value)
+  def message(value), do: safe_inspect(value)
+
+  @doc false
+  @spec value(term()) :: term()
+  def value(value), do: value |> sanitize(0, @max_nodes) |> elem(0)
+
+  defp sanitize(_value, _depth, budget) when budget <= 0, do: {@truncated, 0}
+
+  defp sanitize(_value, depth, budget) when depth >= @max_depth,
+    do: {@truncated, budget - 1}
+
+  defp sanitize(value, depth, budget), do: convert(value, depth, budget - 1)
+
+  defp convert(value, _depth, budget) when is_integer(value) and abs(value) > @max_integer,
+    do: {"#Truncated<integer>", budget}
+
+  defp convert(value, _depth, budget) when is_atom(value) or is_number(value),
+    do: {value, budget}
+
+  defp convert(value, _depth, budget) when is_binary(value), do: {binary(value), budget}
+
+  defp convert(
+         %Runic.Identity{scheme: :sha256, version: 1, domain: domain, digest: digest} = identity,
+         _depth,
+         budget
+       )
+       when is_atom(domain) and is_binary(digest) and byte_size(digest) == 32,
+       do: {Runic.Identity.to_string(identity), budget}
+
+  defp convert(%_{} = value, _depth, budget),
+    do: {"#Struct<#{inspect(value.__struct__)}>", budget}
+
+  defp convert(value, _depth, budget) when is_map(value) and map_size(value) > @max_items,
+    do: {%{"__truncated__" => "map exceeds #{@max_items} entries"}, budget}
+
+  defp convert(value, depth, budget) when is_map(value) do
+    value
+    |> Enum.sort()
+    |> map_entries(depth + 1, budget, %{})
+  end
+
+  defp convert(value, depth, budget) when is_list(value) do
+    case list_items(value, depth + 1, budget, @max_items, []) do
+      {:improper, budget} -> {safe_inspect(value), budget}
+      result -> result
+    end
+  end
+
+  defp convert(value, depth, budget) when is_tuple(value) do
+    size = min(tuple_size(value), @max_items)
+    items = for index <- 0..(size - 1)//1, do: elem(value, index)
+    {items, budget} = list_items(items, depth + 1, budget, @max_items, [])
+    items = if tuple_size(value) > @max_items, do: items ++ [@truncated], else: items
+    {items, budget}
+  end
+
+  defp convert(value, _depth, budget), do: {safe_inspect(value), budget}
+
+  defp map_entries([], _depth, budget, acc), do: {acc, budget}
+
+  defp map_entries(_entries, _depth, budget, acc) when budget <= 1,
+    do: {Map.put(acc, "__truncated__", @truncated), 0}
+
+  defp map_entries([{key, value} | rest], depth, budget, acc) do
+    key = key(key)
+    {value, budget} = sanitize(value, depth, budget - 1)
+    map_entries(rest, depth, budget, Map.put(acc, key, value))
+  end
+
+  defp list_items([], _depth, budget, _remaining, acc), do: {Enum.reverse(acc), budget}
+
+  defp list_items([_head | _tail], _depth, budget, remaining, acc)
+       when budget <= 0 or remaining <= 0,
+       do: {Enum.reverse([@truncated | acc]), budget}
+
+  defp list_items([head | tail], depth, budget, remaining, acc) do
+    {head, budget} = sanitize(head, depth, budget)
+    list_items(tail, depth, budget, remaining - 1, [head | acc])
+  end
+
+  defp list_items(_tail, _depth, budget, _remaining, _acc), do: {:improper, budget}
+
+  defp key(value) when is_binary(value), do: binary(value)
+  defp key(value) when is_atom(value), do: value
+  defp key(value) when is_number(value), do: value(value)
+  defp key(%_{} = value), do: "#Struct<#{inspect(value.__struct__)}>"
+  defp key(value), do: safe_inspect(value)
+
+  defp bounded_keyword?([], _remaining), do: true
+
+  defp bounded_keyword?([{key, _value} | tail], remaining) when is_atom(key) and remaining > 0,
+    do: bounded_keyword?(tail, remaining - 1)
+
+  defp bounded_keyword?(_value, _remaining), do: false
+
+  defp safe_inspect(value), do: value |> inspect(@inspect_opts) |> binary()
+
+  defp binary(value) when byte_size(value) > @max_bytes, do: "#Truncated<binary>"
+
+  defp binary(value) do
+    if String.valid?(value), do: value, else: "base64:" <> Base.encode64(value)
+  end
+end

--- a/lib/jido_exec/error.ex
+++ b/lib/jido_exec/error.ex
@@ -98,12 +98,7 @@ defmodule Jido.Exec.Error do
     do: error_map(:async_invalid_handle, error.message, error.details)
 
   def to_map(%AsyncTimeoutError{} = error) do
-    details =
-      if is_nil(error.timeout),
-        do: error.details,
-        else: Map.put(error.details, :timeout, error.timeout)
-
-    error_map(:async_timeout, error.message, details)
+    error_map(:async_timeout, error.message, error.details, timeout: error.timeout)
   end
 
   def to_map(%AsyncExecutionError{} = error),
@@ -112,13 +107,10 @@ defmodule Jido.Exec.Error do
   def to_map(%CancelledError{} = error),
     do: error_map(:async_cancelled, error.message, error.details)
 
-  defp error_map(type, message, details) do
-    %{
-      type: type,
-      message: ExternalData.message(message),
-      details: ExternalData.details(details),
-      retryable?: false
-    }
+  defp error_map(type, message, details, fields \\ []) do
+    type
+    |> ExternalData.error_data(message, details, false, fields)
+    |> ExternalData.to_map()
   end
 
   defp normalize_details(details) when is_map(details) and not is_struct(details), do: details

--- a/lib/jido_exec/error.ex
+++ b/lib/jido_exec/error.ex
@@ -7,6 +7,8 @@ defmodule Jido.Exec.Error do
   failures of the managed asynchronous execution process.
   """
 
+  alias Jido.Action.Error.ExternalData
+
   @type details_input :: map() | keyword()
   @type error_map :: %{
           type: atom(),
@@ -85,7 +87,12 @@ defmodule Jido.Exec.Error do
   def owned?(%CancelledError{}), do: true
   def owned?(_error), do: false
 
-  @doc "Converts an async execution error into stable external data."
+  @doc """
+  Converts an async execution error into stable external data.
+
+  Uses the bounded conversion rules in `Jido.Action.Error.to_map/1`.
+  The original error retains its complete details in memory.
+  """
   @spec to_map(Exception.t()) :: error_map()
   def to_map(%InvalidHandleError{} = error),
     do: error_map(:async_invalid_handle, error.message, error.details)
@@ -106,7 +113,12 @@ defmodule Jido.Exec.Error do
     do: error_map(:async_cancelled, error.message, error.details)
 
   defp error_map(type, message, details) do
-    %{type: type, message: message, details: details, retryable?: false}
+    %{
+      type: type,
+      message: ExternalData.message(message),
+      details: ExternalData.details(details),
+      retryable?: false
+    }
   end
 
   defp normalize_details(details) when is_map(details) and not is_struct(details), do: details

--- a/lib/jido_flow/error.ex
+++ b/lib/jido_flow/error.ex
@@ -167,7 +167,12 @@ defmodule Jido.Flow.Error do
     InternalError.exception(message: message, details: normalize_input(details))
   end
 
-  @doc "Converts a Flow or Action error into its stable public map."
+  @doc """
+  Converts a Flow or Action error into its stable public map.
+
+  Uses the bounded conversion rules in `Jido.Action.Error.to_map/1`.
+  The original error retains its complete details and stacktrace in memory.
+  """
   @spec to_map(term()) :: error_map()
   def to_map({:error, reason, _effects}), do: to_map(reason)
   def to_map({:error, reason}), do: to_map(reason)
@@ -256,34 +261,10 @@ defmodule Jido.Flow.Error do
 
   defp error_map(type, message, details, retryable?) do
     normalized =
-      ActionError.to_map(ActionError.execution_error(message, normalize_identities(details)))
+      ActionError.to_map(ActionError.execution_error(message, details))
 
     %{normalized | type: type, retryable?: retryable?}
   end
-
-  # Preserve native IDs before the shared error encoder replaces opaque structs.
-  # Invalid caller-supplied IDs still use the shared encoder's safe fallback.
-  defp normalize_identities(
-         %Runic.Identity{
-           scheme: :sha256,
-           version: 1,
-           domain: domain,
-           digest: digest
-         } = identity
-       )
-       when is_atom(domain) and is_binary(digest) and byte_size(digest) == 32,
-       do: Runic.Identity.to_string(identity)
-
-  defp normalize_identities(value) when is_map(value) and not is_struct(value),
-    do: Map.new(value, fn {key, value} -> {key, normalize_identities(value)} end)
-
-  defp normalize_identities([head | tail]),
-    do: [normalize_identities(head) | normalize_identities(tail)]
-
-  defp normalize_identities(value) when is_tuple(value),
-    do: value |> Tuple.to_list() |> Enum.map(&normalize_identities/1) |> List.to_tuple()
-
-  defp normalize_identities(value), do: value
 
   defp error_list_details(errors), do: %{errors: Enum.map(errors, &to_map/1)}
 

--- a/lib/jido_flow/error.ex
+++ b/lib/jido_flow/error.ex
@@ -18,6 +18,7 @@ defmodule Jido.Flow.Error do
     merge_with: [Jido.Action.Error]
 
   alias Jido.Action.Error, as: ActionError
+  alias Jido.Action.Error.ExternalData
 
   @type details_input :: map() | keyword()
   @type runnable_failure :: %{
@@ -174,56 +175,80 @@ defmodule Jido.Flow.Error do
   The original error retains its complete details and stacktrace in memory.
   """
   @spec to_map(term()) :: error_map()
-  def to_map({:error, reason, _effects}), do: to_map(reason)
-  def to_map({:error, reason}), do: to_map(reason)
+  def to_map(error), do: error |> external_data() |> ExternalData.to_map()
 
-  def to_map(%InvalidDefinitionError{} = error) do
-    error_map(:flow_definition_error, error.message, error.details, false)
+  @doc false
+  @spec external_data(term()) :: map()
+  def external_data({:error, reason, _effects}), do: external_data(reason)
+  def external_data({:error, reason}), do: external_data(reason)
+
+  def external_data(%InvalidDefinitionError{} = error) do
+    ExternalData.error_data(:flow_definition_error, error.message, error.details, false)
   end
 
-  def to_map(%InvalidExecutionError{} = error) do
-    error_map(:flow_invalid_execution, error.message, error.details, false)
+  def external_data(%InvalidExecutionError{} = error) do
+    ExternalData.error_data(:flow_invalid_execution, error.message, error.details, false)
   end
 
-  def to_map(%ExecutionFailureError{} = error) do
-    details =
-      error.details
+  def external_data(%ExecutionFailureError{} = error) do
+    fields =
+      %{}
       |> maybe_put(:flow, error.flow)
       |> maybe_put_failures(error.failures)
 
-    error_map(:flow_execution_error, error.message, details, retryable?(error))
+    ExternalData.error_data(
+      :flow_execution_error,
+      error.message,
+      error.details,
+      retryable?(error),
+      Map.to_list(fields)
+    )
   end
 
-  def to_map(%TimeoutError{} = error) do
-    details =
-      error.details
-      |> maybe_put(:flow, error.flow)
-      |> maybe_put(:timeout, error.timeout)
-
-    error_map(:flow_timeout, error.message, details, retryable?(error))
+  def external_data(%TimeoutError{} = error) do
+    ExternalData.error_data(:flow_timeout, error.message, error.details, retryable?(error),
+      flow: error.flow,
+      timeout: error.timeout
+    )
   end
 
-  def to_map(%InternalError{} = error) do
-    error_map(:flow_internal_error, error.message, error.details, false)
+  def external_data(%InternalError{} = error) do
+    ExternalData.error_data(:flow_internal_error, error.message, error.details, false)
   end
 
-  def to_map(%Internal.UnknownError{} = error) do
-    error_map(:flow_internal_error, Exception.message(error), error.details, false)
+  def external_data(%Internal.UnknownError{} = error) do
+    message = if is_nil(error.error), do: error.message, else: error.error
+    ExternalData.error_data(:flow_internal_error, message, error.details, false)
   end
 
-  def to_map(%Invalid{errors: errors}) do
-    error_map(:flow_definition_error, "Invalid Flow", error_list_details(errors), false)
+  def external_data(%Invalid{errors: errors}) do
+    ExternalData.error_data(
+      :flow_definition_error,
+      "Invalid Flow",
+      error_list_details(errors),
+      false
+    )
   end
 
-  def to_map(%Execution{errors: errors}) do
-    error_map(:flow_execution_error, "Flow execution failed", error_list_details(errors), false)
+  def external_data(%Execution{errors: errors}) do
+    ExternalData.error_data(
+      :flow_execution_error,
+      "Flow execution failed",
+      error_list_details(errors),
+      false
+    )
   end
 
-  def to_map(%Internal{errors: errors}) do
-    error_map(:flow_internal_error, "Internal Flow error", error_list_details(errors), false)
+  def external_data(%Internal{errors: errors}) do
+    ExternalData.error_data(
+      :flow_internal_error,
+      "Internal Flow error",
+      error_list_details(errors),
+      false
+    )
   end
 
-  def to_map(error), do: ActionError.to_map(error)
+  def external_data(error), do: ActionError.external_data(error)
 
   @doc "Returns whether a Flow or Action error is retryable."
   @spec retryable?(term()) :: boolean()
@@ -259,14 +284,8 @@ defmodule Jido.Flow.Error do
   def owned?(%Internal{}), do: true
   def owned?(_error), do: false
 
-  defp error_map(type, message, details, retryable?) do
-    normalized =
-      ActionError.to_map(ActionError.execution_error(message, details))
-
-    %{normalized | type: type, retryable?: retryable?}
-  end
-
-  defp error_list_details(errors), do: %{errors: Enum.map(errors, &to_map/1)}
+  defp error_list_details(errors),
+    do: %{errors: ExternalData.map_items(errors, &nested_error/1)}
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
@@ -274,12 +293,16 @@ defmodule Jido.Flow.Error do
   defp maybe_put_failures(details, []), do: details
 
   defp maybe_put_failures(details, failures) do
-    Map.put(details, :failures, Enum.map(failures, &failure_to_map/1))
+    Map.put(details, :failures, ExternalData.map_items(failures, &failure_to_map/1))
   end
 
   defp failure_to_map(%{node: node, runnable_id: runnable_id, error: error}) do
-    %{node: node, runnable_id: runnable_id, error: to_map(error)}
+    %{node: node, runnable_id: runnable_id, error: nested_error(error)}
   end
+
+  defp failure_to_map(value), do: value
+
+  defp nested_error(error), do: %ExternalData.NestedError{error: error}
 
   defp normalize_input(details) when is_map(details) and not is_struct(details), do: details
 

--- a/test/external_error_data_test.exs
+++ b/test/external_error_data_test.exs
@@ -5,8 +5,117 @@ defmodule JidoActionTest.ExternalErrorDataTest do
   alias Jido.Exec.Error, as: ExecError
   alias Jido.Flow.Error, as: FlowError
   alias JidoActionTest.Support.RaisingInspectStruct
+  alias JidoActionTest.Support.InspectProbe
 
   @families [ActionError, ExecError, FlowError]
+
+  test "external conversion never calls a custom Inspect implementation" do
+    probe = %InspectProbe{owner: self()}
+
+    for family <- @families do
+      details = %{probe => :struct_key, {probe, :key} => :tuple_key, improper: [probe | probe]}
+      error = family.execution_error({:unsupported, probe}, details)
+      assert is_binary(JSON.encode!(error))
+
+      assert family.to_map(error).details["#Struct<JidoActionTest.Support.InspectProbe>"] ==
+               :struct_key
+
+      refute_received :unsafe_inspect_called
+    end
+
+    for {family, module} <- [
+          {ActionError, ActionError.Internal.UnknownError},
+          {FlowError, FlowError.Internal.UnknownError}
+        ] do
+      for reason <- [probe, {:nested, probe}] do
+        error = module.exception(error: reason)
+        assert is_binary(JSON.encode!(error))
+        assert is_binary(family.to_map(error).message)
+        refute_received :unsafe_inspect_called
+        assert error.error === reason
+      end
+    end
+  end
+
+  test "malformed direct timeout details use the same fallback in each family" do
+    for {family, module} <- [
+          {ActionError, ActionError.TimeoutError},
+          {ExecError, ExecError.AsyncTimeoutError},
+          {FlowError, FlowError.TimeoutError}
+        ] do
+      for details <- [nil, self(), [entry: self()] ++ [:bad], [{:entry, self()} | :tail]] do
+        error = module.exception(message: "late", timeout: 25, details: details)
+        assert family.to_map(error).details == %{timeout: 25}
+        assert is_binary(JSON.encode!(error))
+        assert error.details === details
+      end
+    end
+  end
+
+  test "direct keyword details have the same item limit across error families" do
+    for family <- @families do
+      error = family.execution_error("failed")
+      within_limit = %{error | details: List.duplicate({:entry, self()}, 64)}
+      above_limit = %{error | details: List.duplicate({:entry, self()}, 65)}
+
+      assert family.to_map(within_limit).details == %{entry: inspect(self())}
+      assert family.to_map(above_limit).details == %{}
+    end
+  end
+
+  test "list and tuple limits produce one marker when the term budget also expires" do
+    branch = List.duplicate(List.duplicate(self(), 64), 64)
+    items = [branch | Enum.to_list(1..64)]
+
+    for family <- @families do
+      list = family.to_map(family.execution_error("failed", items: items)).details.items
+
+      tuple =
+        family.to_map(family.execution_error("failed", items: List.to_tuple(items))).details.items
+
+      assert tuple == list
+      assert Enum.count(tuple, &(&1 == "#Truncated")) == 1
+    end
+  end
+
+  test "Flow error groups convert each source value once within shared limits" do
+    bytes = :binary.copy(<<255>>, 4_096)
+    leaf = ActionError.execution_error(bytes, payload: bytes)
+    group = %FlowError.Invalid{errors: [leaf]}
+    mapped = FlowError.to_map(group)
+    assert mapped.details.errors == [ActionError.to_map(leaf)]
+
+    failure = %{node: "first", runnable_id: make_ref(), error: leaf}
+    error = FlowError.flow_failure("probe", [failure])
+    assert hd(FlowError.to_map(error).details.failures).error == ActionError.to_map(leaf)
+
+    deep = Enum.reduce(1..100, leaf, fn _, child -> %FlowError.Invalid{errors: [child]} end)
+
+    wide =
+      Enum.reduce(1..5, leaf, fn _, child ->
+        %FlowError.Invalid{errors: List.duplicate(child, 64)}
+      end)
+
+    for error <- [deep, wide] do
+      encoded = JSON.encode!(error)
+      assert encoded =~ "#Truncated"
+      assert byte_size(encoded) < 6_000_000
+    end
+
+    for errors <- [[leaf | :tail], :invalid] do
+      group = %FlowError.Invalid{errors: errors}
+      encoded = JSON.encode!(group)
+      refute encoded =~ "ExternalData.NestedError"
+      assert group.errors === errors
+    end
+
+    for failures <- [[failure | :tail], [:invalid], :invalid] do
+      error = %FlowError.ExecutionFailureError{failures: failures, details: nil}
+      encoded = JSON.encode!(error)
+      refute encoded =~ "ExternalData.NestedError"
+      assert error.failures === failures
+    end
+  end
 
   test "all error families use the same conversion without changing rich details" do
     ref = make_ref()

--- a/test/external_error_data_test.exs
+++ b/test/external_error_data_test.exs
@@ -1,0 +1,171 @@
+defmodule JidoActionTest.ExternalErrorDataTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Action.Error, as: ActionError
+  alias Jido.Exec.Error, as: ExecError
+  alias Jido.Flow.Error, as: FlowError
+  alias JidoActionTest.Support.RaisingInspectStruct
+
+  @families [ActionError, ExecError, FlowError]
+
+  test "all error families use the same conversion without changing rich details" do
+    ref = make_ref()
+    function = &__MODULE__.__info__/1
+    exception = RuntimeError.exception("original failure")
+    stacktrace = [{__MODULE__, :diagnostic, [self(), ref], [file: ~c"probe.ex", line: 42]}]
+    identity = Runic.Identity.digest(:activation, :diagnostic)
+    port = Port.open({:spawn_executable, :os.find_executable(~c"cat")}, [:binary])
+
+    try do
+      details = %{
+        <<255>> => :binary_key,
+        self() => :pid_key,
+        ref => :reference_key,
+        5 => :integer_key,
+        1.5 => :float_key,
+        nested: [%{tuple: {self(), ref, [nil, true, false, :atom, 12, 1.5]}}],
+        empty_tuple: {},
+        exception: exception,
+        stacktrace: stacktrace,
+        function: function,
+        port: port,
+        hostile: %RaisingInspectStruct{value: :untouched},
+        improper: [1 | 2],
+        payload: <<255>>,
+        bits: <<1::1>>,
+        identity: identity,
+        retry: true
+      }
+
+      maps =
+        for family <- @families do
+          error = family.execution_error("failed", details)
+          mapped = family.to_map(error)
+          decoded = error |> JSON.encode!() |> JSON.decode!()
+
+          assert error.details === details
+          assert error.details.exception === exception
+          assert error.details.stacktrace === stacktrace
+          assert decoded == mapped |> JSON.encode!() |> JSON.decode!()
+
+          assert mapped.details.nested == [
+                   %{tuple: [inspect(self()), inspect(ref), [nil, true, false, :atom, 12, 1.5]]}
+                 ]
+
+          assert mapped.details.empty_tuple == []
+          assert mapped.details.exception == "#Struct<RuntimeError>"
+          assert mapped.details.hostile == "#Struct<JidoActionTest.Support.RaisingInspectStruct>"
+          assert mapped.details.function == inspect(function)
+          assert mapped.details.port == inspect(port)
+          assert mapped.details.improper == "[1 | 2]"
+          assert mapped.details.bits == "<<1::size(1)>>"
+          assert mapped.details.identity == Runic.Identity.to_string(identity)
+          assert mapped.details.payload == "base64:/w=="
+          assert mapped.details["base64:/w=="] == :binary_key
+          assert mapped.details[inspect(self())] == :pid_key
+          assert mapped.details[inspect(ref)] == :reference_key
+          assert mapped.details[5] == :integer_key
+          assert mapped.details[1.5] == :float_key
+          assert mapped.retryable? == (family != ExecError)
+          mapped.details
+        end
+
+      assert Enum.uniq(maps) |> length() == 1
+    after
+      Port.close(port)
+    end
+  end
+
+  test "all families bound depth, collection size, strings, and large integers" do
+    deep = Enum.reduce(1..100, :leaf, fn _, acc -> [acc] end)
+    large_map = Map.new(1..65, &{&1, self()})
+    large_integer = Integer.pow(10, 100)
+
+    details = %{
+      deep: deep,
+      list: Enum.to_list(1..65),
+      tuple: List.to_tuple(Enum.to_list(1..65)),
+      map: large_map,
+      binary: String.duplicate("x", 4_097),
+      valid_binary: String.duplicate("x", 4_096),
+      integer: large_integer,
+      valid_integer: large_integer - 1
+    }
+
+    for family <- @families do
+      error = family.execution_error("failed", details)
+      mapped = family.to_map(error)
+
+      assert error.details === details
+      assert mapped.details.deep == Enum.reduce(1..15, "#Truncated", fn _, acc -> [acc] end)
+      assert mapped.details.list == Enum.to_list(1..64) ++ ["#Truncated"]
+      assert mapped.details.tuple == mapped.details.list
+      assert mapped.details.map == %{"__truncated__" => "map exceeds 64 entries"}
+      assert mapped.details.binary == "#Truncated<binary>"
+      assert mapped.details.valid_binary == details.valid_binary
+      assert mapped.details.integer == "#Truncated<integer>"
+      assert mapped.details.valid_integer == large_integer - 1
+      assert is_binary(JSON.encode!(error))
+
+      assert family.to_map(family.execution_error("failed", large_map)).details ==
+               %{"__truncated__" => "map exceeds 64 entries"}
+    end
+  end
+
+  test "the term budget bounds broad nested data and gives deterministic output" do
+    branch = List.duplicate(List.duplicate(self(), 64), 64)
+    details = %{b: branch, a: branch}
+    reversed = Map.new(Enum.reverse(Enum.to_list(details)))
+
+    for family <- @families do
+      error = family.execution_error("failed", details)
+      mapped = family.to_map(error)
+      encoded = JSON.encode!(error)
+
+      assert mapped == family.to_map(family.execution_error("failed", reversed))
+      assert encoded == JSON.encode!(family.execution_error("failed", reversed))
+      assert encoded =~ "#Truncated"
+      assert byte_size(encoded) < 30_000
+      assert error.details === details
+    end
+  end
+
+  test "external conversion preserves a caught exception and its stacktrace" do
+    {exception, stacktrace} =
+      try do
+        raise "original failure"
+      rescue
+        exception -> {exception, __STACKTRACE__}
+      end
+
+    for family <- @families do
+      error = family.execution_error("failed", original: exception, stacktrace: stacktrace)
+      assert is_binary(JSON.encode!(error))
+      assert error.details.original === exception
+      assert error.details.stacktrace === stacktrace
+    end
+
+    error = ActionError.execution_error("failed", original: exception)
+    error = %{error | stacktrace: %Splode.Stacktrace{stacktrace: stacktrace}}
+    assert is_binary(JSON.encode!(error))
+    refute Map.has_key?(ActionError.to_map(error), :stacktrace)
+    assert error.stacktrace.stacktrace === stacktrace
+    assert error.details.original === exception
+  end
+
+  test "all families convert invalid messages and unsafe concrete detail fields" do
+    for family <- @families do
+      error = family.timeout_error(<<255>>, timeout: self())
+      mapped = family.to_map(error)
+      assert mapped.message == "base64:/w=="
+      assert mapped.details.timeout == inspect(self())
+      assert error.message == <<255>>
+      assert error.details.timeout == self()
+      assert is_binary(JSON.encode!(error))
+    end
+
+    error = ActionError.validation_error("invalid", field: self(), value: {make_ref(), self()})
+    assert ActionError.to_map(error).details.field == inspect(self())
+    assert is_binary(JSON.encode!(error))
+  end
+end

--- a/test/jido_exec/async_error_test.exs
+++ b/test/jido_exec/async_error_test.exs
@@ -2,6 +2,82 @@ defmodule JidoActionTest.Exec.AsyncErrorTest do
   use ExUnit.Case, async: true
 
   alias Jido.Exec.Error
+  alias JidoActionTest.Fixtures.Actions.Add
+  alias JidoActionTest.Fixtures.Execution.BlockingAction
+
+  test "encodes the PID error returned by cancel" do
+    assert {:error, %Error.InvalidHandleError{} = error} = Jido.Exec.cancel(self())
+
+    decoded = error |> JSON.encode!() |> JSON.decode!()
+
+    assert decoded["type"] == "async_invalid_handle"
+    assert decoded["message"] == error.message
+    assert decoded["details"]["pid"] == inspect(self())
+    assert error.details.pid == self()
+  end
+
+  test "encodes nested invalid values from each public handle operation" do
+    ref = make_ref()
+    invalid = %{nested: [self(), {ref, %{exception: RuntimeError.exception("failed")}}]}
+
+    for result <- [
+          Jido.Exec.await(invalid),
+          Jido.Exec.cancel(invalid),
+          Jido.Exec.handle_message(invalid, :unrelated)
+        ] do
+      assert {:error, %Error.InvalidHandleError{} = error} = result
+      assert error.details.value === invalid
+
+      assert Error.to_map(error).details.value == %{
+               nested: [inspect(self()), [inspect(ref), %{exception: "#Struct<RuntimeError>"}]]
+             }
+
+      assert_external_map(error)
+    end
+  end
+
+  test "encodes PID and reference details from a consumed await handle" do
+    handle = Jido.Exec.run_async(Add, %{value: 2})
+    assert {:ok, %{value: 3}} = Jido.Exec.await(handle, 1_000)
+    assert {:error, %Error.InvalidHandleError{} = error} = Jido.Exec.await(handle)
+
+    assert error.details.pid == handle.pid
+    assert error.details.ref == handle.ref
+    assert Error.to_map(error).details.pid == inspect(handle.pid)
+    assert Error.to_map(error).details.ref == inspect(handle.ref)
+    assert_external_map(error)
+  end
+
+  test "encodes an actual await timeout and a stopped execution error" do
+    for mode <- [:timeout, :exit] do
+      handle = Jido.Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
+      assert_receive {:blocking_flow_node_started, worker}, 1_000
+      worker_monitor = Process.monitor(worker)
+      handle_monitor = Process.monitor(handle.pid)
+
+      error =
+        case mode do
+          :timeout ->
+            assert {:error, %Error.AsyncTimeoutError{} = error} = Jido.Exec.await(handle, 0)
+            error
+
+          :exit ->
+            Process.exit(handle.pid, :kill)
+            assert_receive {:DOWN, ^handle_monitor, :process, _, :killed}, 1_000
+            assert {:error, %Error.AsyncExecutionError{} = error} = Jido.Exec.await(handle)
+            assert error.details.pid == handle.pid
+            assert Error.to_map(error).details.pid == inspect(handle.pid)
+            error
+        end
+
+      assert_external_map(error)
+      assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
+      Process.demonitor(handle_monitor, [:flush])
+      refute Process.alive?(handle.pid)
+      refute_received {:jido_exec_async_result, _, _, _}
+      refute_received {:DOWN, _, :process, _, _}
+    end
+  end
 
   test "constructs and maps target-neutral async errors" do
     invalid = Error.invalid_handle_error("invalid", operation: :await)
@@ -53,5 +129,14 @@ defmodule JidoActionTest.Exec.AsyncErrorTest do
     end
 
     assert Error.execution_error("failed", :invalid).details == %{}
+  end
+
+  defp assert_external_map(error) do
+    mapped = Error.to_map(error)
+    decoded = error |> JSON.encode!() |> JSON.decode!()
+
+    assert decoded == mapped |> JSON.encode!() |> JSON.decode!()
+    assert decoded["type"] == Atom.to_string(mapped.type)
+    assert decoded["message"] == error.message
   end
 end

--- a/test/support/fixtures/action/failures.ex
+++ b/test/support/fixtures/action/failures.ex
@@ -310,3 +310,15 @@ end
 defimpl Inspect, for: JidoActionTest.Support.RaisingInspectStruct do
   def inspect(_term, _opts), do: raise("boom")
 end
+
+defmodule JidoActionTest.Support.InspectProbe do
+  @moduledoc false
+  defstruct [:owner]
+end
+
+defimpl Inspect, for: JidoActionTest.Support.InspectProbe do
+  def inspect(%{owner: owner}, _opts) do
+    send(owner, :unsafe_inspect_called)
+    "unsafe inspection"
+  end
+end


### PR DESCRIPTION
`Jido.Exec.cancel(self())` returns an `InvalidHandleError` with a PID in its details. JSON encoding previously raised `Protocol.UndefinedError`. Action, Flow, and Exec errors now use one bounded external conversion. Error types, normal messages, and retry rules stay intact. Original exception details and stacktraces stay in memory.

The conversion handles nested maps, lists, tuples, PIDs, references, ports, functions, bitstrings, invalid UTF-8, and exceptions. It keeps full Runic identity strings. Declared Flow causes retain their error maps and share one depth and term budget. Each source value is converted once, so nested errors do not lose valid encoded binary data through a second conversion.

The public contract defines depth, term, collection, binary, and integer limits. Malformed detail containers and cause lists use safe fallbacks. Unknown-error messages, non-string keys, and improper lists do not call custom struct inspection code. Lists and tuples use one truncation marker when limits overlap. Flow formats errors directly through the shared conversion.

Reproduction:

```elixir
{:error, error} = Jido.Exec.cancel(self())
JSON.encode!(error)
```

Validation:

- Baseline: 30 existing error tests passed. The new cancellation regression then failed because `JSON.Encoder` did not support PID values.
- The hardening regressions confirmed unsafe custom inspection, malformed timeout details, inconsistent keyword limits, duplicate tuple truncation, and repeated conversion of nested Flow causes before their fixes.
- Final focused error tests: 44 passed. These include real invalid-handle, consumed-await, timeout, and stopped-worker errors; map/JSON parity; original details and stacktraces; and malformed, deeply nested, and broad Flow error groups.
- Default suite: 749 passed.
- `mix test --cover --warnings-as-errors`: 749 passed; 94.43% coverage (required: 93%).
- `MIX_ENV=test mix compile --warnings-as-errors`: passed.
- `mix quality`: passed (format, compile, Doctor, docs, Credo, and Dialyzer). The updated guide also passed `mix docs --warnings-as-errors`.

Local checks use Elixir 1.20.3 / OTP 29.0.5 with `ERL_FLAGS='+S 2:2'`. Dependency, build, and writable PLT files are separate copies in this worktree.

The external format is lossy. Large values use documented markers. Callers use the original error for full cause inspection. Runtime diagnostic strings are not persistent identifiers.

Closes #233
