### PR TITLE
fix(flow): avoid copying compiler and execution state

### DIFF
--- a/lib/jido_exec/flow/adapter.ex
+++ b/lib/jido_exec/flow/adapter.ex
@@ -124,6 +124,8 @@ defmodule Jido.Exec.Flow.Adapter do
            {:ok, context} <- normalize_map(context, :context),
            {:ok, input} <- validate_data(flow.schema, input, "Flow", flow, :flow_input),
            {:ok, input} <- validate_flow_input_shape(flow, input) do
+        flow_name = flow.name
+
         target_runner = fn target, params, target_context, target_execution_id, owner ->
           TargetRunner.run(
             target,
@@ -131,7 +133,7 @@ defmodule Jido.Exec.Flow.Adapter do
             target_context,
             target_execution_id,
             run_opts,
-            flow.name,
+            flow_name,
             owner
           )
         end

--- a/lib/jido_exec/flow/runnable_executor.ex
+++ b/lib/jido_exec/flow/runnable_executor.ex
@@ -10,7 +10,11 @@ defmodule Jido.Exec.Flow.RunnableExecutor do
   @doc "Executes one native Runnable and records its node telemetry."
   @spec execute(Execution.t(), Runnable.t()) :: Runnable.t()
   def execute(%Execution{} = execution, %Runnable{} = runnable) do
-    span = start_span(execution, runnable)
+    execute_with_metadata(runnable, node_metadata(execution, runnable))
+  end
+
+  defp execute_with_metadata(runnable, metadata) do
+    span = start_span(metadata)
     executed = safely_execute(runnable)
     finish_span(span, executed)
     executed
@@ -39,11 +43,11 @@ defmodule Jido.Exec.Flow.RunnableExecutor do
     group_leader = Process.group_leader()
     stopped = :atomics.new(1, [])
 
-    execute = fn {runnable, index} ->
+    execute = fn {runnable, index, metadata} ->
       Process.group_leader(self(), group_leader)
       Logger.metadata(logger_metadata)
       Telemetry.put_tracker(telemetry_tracker)
-      executed = execute(execution, runnable)
+      executed = execute_with_metadata(runnable, metadata)
       if executed.status == :failed, do: :atomics.put(stopped, 1, 1)
       {index, executed}
     end
@@ -53,6 +57,10 @@ defmodule Jido.Exec.Flow.RunnableExecutor do
     runnables
     |> Enum.with_index()
     |> Stream.take_while(fn _runnable -> :atomics.get(stopped, 1) == 0 end)
+    # Resolve telemetry in the caller. Workers must not capture the execution.
+    |> Stream.map(fn {runnable, index} ->
+      {runnable, index, node_metadata(execution, runnable)}
+    end)
     |> Task.async_stream(execute,
       max_concurrency: Keyword.fetch!(execution.options, :max_concurrency),
       ordered: false,
@@ -63,7 +71,7 @@ defmodule Jido.Exec.Flow.RunnableExecutor do
       {:ok, indexed_result} ->
         indexed_result
 
-      {:exit, {{runnable, index}, reason}} ->
+      {:exit, {{runnable, index, _metadata}, reason}} ->
         :atomics.put(stopped, 1, 1)
         {index, fail_exited_runnable(runnable, reason)}
     end)
@@ -87,15 +95,18 @@ defmodule Jido.Exec.Flow.RunnableExecutor do
       )
   end
 
-  defp start_span(execution, runnable) do
+  defp start_span(nil), do: nil
+  defp start_span(metadata), do: Telemetry.start([:jido, :flow, :node], metadata)
+
+  defp node_metadata(execution, runnable) do
     case authored_component(execution, runnable) do
       {name, kind} ->
-        Telemetry.start([:jido, :flow, :node], %{
+        %{
           execution_id: execution.id,
           flow: execution.flow_name,
           node: name,
           kind: kind
-        })
+        }
 
       nil ->
         nil

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -303,6 +303,8 @@ defmodule Jido.Flow.Compiler do
   end
 
   defp add_component(%FlowStep{} = component, state) do
+    namespace = state.namespace
+
     step =
       runtime_step(state, component.name, :step, fn parent, runtime ->
         local = component_state(component, parent, runtime)
@@ -311,7 +313,7 @@ defmodule Jido.Flow.Compiler do
         |> resolve_and_run(
           component.params,
           component.action,
-          Target.at(Target.node(component), state.namespace)
+          Target.at(Target.node(component), namespace)
         )
         |> wrap_result()
       end)
@@ -320,10 +322,12 @@ defmodule Jido.Flow.Compiler do
   end
 
   defp add_component(%Choice{} = component, state) do
+    namespace = state.namespace
+
     step =
       runtime_step(state, component.name, :choice, fn parent, runtime ->
         local = component_state(component, parent, runtime)
-        result = ChoiceRuntime.run(component, Map.put(local, :namespace, state.namespace))
+        result = ChoiceRuntime.run(component, Map.put(local, :namespace, namespace))
         output = unwrap_component_result(result)
         value(local.input_frame, output)
       end)
@@ -332,10 +336,12 @@ defmodule Jido.Flow.Compiler do
   end
 
   defp add_component(%Iterate{} = component, state) do
+    namespace = state.namespace
+
     step =
       runtime_step(state, component.name, :iterate, fn parent, runtime ->
         local = component_state(component, parent, runtime)
-        result = IterateRuntime.run(component, Map.put(local, :namespace, state.namespace))
+        result = IterateRuntime.run(component, Map.put(local, :namespace, namespace))
         output = unwrap_component_result(result)
         value(local.input_frame, output)
       end)
@@ -456,6 +462,7 @@ defmodule Jido.Flow.Compiler do
 
   defp map_item_step(state, map, native_name) do
     name = "#{native_name}/item"
+    namespace = state.namespace
 
     runtime_step_named(name, state, :map_item, fn
       %{kind: :empty} = token, _runtime ->
@@ -475,7 +482,7 @@ defmodule Jido.Flow.Compiler do
             item_index: token.index,
             item_id: token.id
           })
-          |> Target.at(state.namespace)
+          |> Target.at(namespace)
 
         span =
           runtime.observer.({
@@ -886,12 +893,15 @@ defmodule Jido.Flow.Compiler do
   end
 
   defp child_output_step(subflow, child_state) do
+    namespace = child_state.namespace
+    output = child_state.flow.output
+
     data_step(
-      name: scoped(child_state.namespace, "$output"),
-      hash: stable_hash({child_state.namespace, :output_validator}),
+      name: scoped(namespace, "$output"),
+      hash: stable_hash({namespace, :output_validator}),
       work: fn parent ->
-        local = component_state_from(child_state.flow.output, parent)
-        output = Expression.resolve(child_state.flow.output, local) |> unwrap_ok!()
+        local = component_state_from(output, parent)
+        output = Expression.resolve(output, local) |> unwrap_ok!()
 
         validated =
           case subflow.flow.validate_output(output) do
@@ -899,7 +909,7 @@ defmodule Jido.Flow.Compiler do
               value
 
             {:error, error} ->
-              raise flow_boundary_error(error, subflow, :subflow_output, child_state.namespace)
+              raise flow_boundary_error(error, subflow, :subflow_output, namespace)
           end
 
         {:jido_flow_input, _input, parent_input} = local.input_frame

--- a/test/jido_exec/native_runtime_policy_test.exs
+++ b/test/jido_exec/native_runtime_policy_test.exs
@@ -132,24 +132,31 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
   alias JidoActionTest.Fixtures.Actions.{Add, EchoParamsAction, RecorderAction}
   alias Runic.Workflow.Runnable
 
-  test "preserves caller Logger metadata in a concurrent runnable" do
+  test "preserves caller Logger metadata in serial and concurrent runnables" do
     flow =
       Flow.new!(
         name: "async_logger_metadata",
         components: [
-          Step.new!(name: "metadata", action: LoggerMetadataAction, params: %{id: :metadata})
+          Step.new!(name: "first", action: LoggerMetadataAction, params: %{id: :first}),
+          Step.new!(name: "second", action: LoggerMetadataAction, params: %{id: :second})
         ],
-        output: Ref.result("metadata")
+        output: %{first: Ref.result("first"), second: Ref.result("second")}
       )
 
     metadata_key = :jido_test_request_id
     Logger.metadata([{metadata_key, "request-123"}])
 
-    assert Exec.run(flow, %{}, %{test_pid: self()}, max_concurrency: 1) ==
-             {:ok, %{id: :metadata}}
+    for concurrency <- [1, 2] do
+      assert Exec.run(flow, %{}, %{test_pid: self()}, max_concurrency: concurrency) ==
+               {:ok, %{first: %{id: :first}, second: %{id: :second}}}
 
-    assert_receive {:action_logger_metadata, :metadata, metadata}
-    assert metadata[metadata_key] == "request-123"
+      for id <- [:first, :second] do
+        assert_receive {:action_logger_metadata, ^id, metadata}
+        assert metadata[metadata_key] == "request-123"
+      end
+    end
+
+    refute_received {:action_logger_metadata, _, _}
   end
 
   @tag timeout: 5_000

--- a/test/jido_exec/runnable_capture_test.exs
+++ b/test/jido_exec/runnable_capture_test.exs
@@ -1,0 +1,65 @@
+defmodule JidoActionTest.Exec.RunnableCaptureTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.{Exec, Flow}
+  alias Jido.Flow.{Ref, Step}
+  alias JidoActionTest.Fixtures.Actions.EchoParamsAction
+
+  test "concurrent workers do not copy unrelated Flow data or execution indexes" do
+    retained = Enum.to_list(1..100_000)
+
+    flow =
+      Flow.new!(
+        name: "worker_capture",
+        components: [
+          Step.new!(name: "a", action: EchoParamsAction, params: %{value: "a"}),
+          Step.new!(name: "b", action: EchoParamsAction, params: %{value: "b"}),
+          Step.new!(
+            name: "later",
+            action: EchoParamsAction,
+            after: ["a", "b"],
+            meta: %{retained: retained}
+          )
+        ],
+        output: %{a: Ref.result("a"), b: Ref.result("b")}
+      )
+
+    ref = make_ref()
+    handler = {__MODULE__, ref}
+    assert {:ok, execution} = Exec.start(flow, %{}, %{}, max_concurrency: 2)
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        [:jido, :flow, :node, :start],
+        &__MODULE__.measure_worker/4,
+        {self(), ref, execution.id}
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    assert {:ok, runnables, finished} = Exec.wave(execution)
+    assert Enum.map(runnables, & &1.node.name) == ["a", "b"]
+    assert {:ok, finished} = Exec.continue(finished)
+    assert Exec.result(finished) == {:ok, %{a: %{value: "a"}, b: %{value: "b"}}}
+
+    # One copy of this unrelated metadata would already exceed the bound.
+    limit = :erts_debug.flat_size(retained) * :erlang.system_info(:wordsize)
+
+    for name <- ["a", "b"] do
+      assert_receive {^ref, ^name, worker, memory}, 1_000
+      refute worker == self()
+      refute Process.alive?(worker)
+      assert memory < limit
+    end
+
+    refute_received {^ref, _, _, _}
+  end
+
+  @doc false
+  def measure_worker(_event, _measurements, metadata, {owner, ref, execution_id}) do
+    if metadata.execution_id == execution_id and metadata.node in ["a", "b"] do
+      {:memory, memory} = Process.info(self(), :memory)
+      send(owner, {ref, metadata.node, self(), memory})
+    end
+  end
+end

--- a/test/jido_flow/compiler/capture_test.exs
+++ b/test/jido_flow/compiler/capture_test.exs
@@ -2,8 +2,8 @@ defmodule JidoActionTest.Flow.Compiler.CaptureTest do
   use ExUnit.Case, async: true
 
   alias Jido.Flow
-  alias Jido.Flow.{Ref, Step}
-  alias JidoActionTest.Fixtures.FlowAuthoring
+  alias Jido.Flow.{Ref, Step, Subflow}
+  alias JidoActionTest.Fixtures.{FlowAuthoring, TelemetryParentFlow}
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
 
   test "compiler callbacks do not retain the compiler state" do
@@ -19,29 +19,65 @@ defmodule JidoActionTest.Flow.Compiler.CaptureTest do
     assert retained == []
   end
 
-  test "independent Steps have bounded size after transfer to another process" do
-    measurements =
-      for count <- [1, 2, 4, 6] do
-        steps =
-          for index <- 1..count do
-            Step.new!(name: "s#{index}", action: EchoParamsAction, params: %{value: index})
-          end
+  for shape <- [:independent, :chained, :nested, :map, :reduce] do
+    test "#{shape} graphs have bounded size after transfer to another process" do
+      measurements =
+        for count <- [1, 2, 4, 6] do
+          assert {:ok, compiled} = Flow.compile(flow(unquote(shape), count))
 
-        flow = Flow.new!(name: "capture_size", components: steps, output: Ref.result("s#{count}"))
-        assert {:ok, compiled} = Flow.compile(flow)
-        local_words = :erts_debug.flat_size(compiled)
-        {copied_words, memory} = transfer_size(compiled)
-        assert copied_words == local_words
-        {count, local_words, memory}
-      end
+          # Stop before copying if a nested capture returns. Collection graphs
+          # can otherwise expand much faster than the small Step reproduction.
+          refute retains_compiler_state?(compiled)
+          local_words = :erts_debug.flat_size(compiled)
+          {copied_words, memory} = transfer_size(compiled)
+          assert copied_words == local_words
+          assert copied_words >= :erts_debug.size(compiled)
+          {count, local_words, memory}
+        end
 
-    {2, small_words, small_memory} = Enum.find(measurements, &(elem(&1, 0) == 2))
-    {6, large_words, large_memory} = List.last(measurements)
+      {2, small_words, small_memory} = Enum.find(measurements, &(elem(&1, 0) == 2))
+      {6, large_words, large_memory} = List.last(measurements)
 
-    # Allow graph overhead and different heap sizes across supported runtimes.
-    # Tripling this graph must not multiply its copied size exponentially.
-    assert large_words < small_words * 4
-    assert large_memory < small_memory * 6
+      # Allow graph overhead and different heap sizes across supported runtimes.
+      # Tripling this graph must not multiply its copied size exponentially.
+      assert large_words < small_words * 4
+      assert large_memory < small_memory * 6
+    end
+  end
+
+  defp flow(shape, count) do
+    components = Enum.map(1..count, &component(shape, "s#{&1}", &1))
+    Flow.new!(name: "capture_size", components: components, output: Ref.result("s#{count}"))
+  end
+
+  defp component(:independent, name, index),
+    do: Step.new!(name: name, action: EchoParamsAction, params: %{value: index})
+
+  defp component(:chained, name, index) do
+    value = if index == 1, do: 7, else: Ref.result("s#{index - 1}", :value)
+    Step.new!(name: name, action: EchoParamsAction, params: %{value: value})
+  end
+
+  defp component(:nested, name, index),
+    do: Subflow.new!(name: name, flow: TelemetryParentFlow, params: %{value: index})
+
+  defp component(:map, name, _index) do
+    Jido.Flow.Map.new!(
+      name: name,
+      collection: [1, 2],
+      action: EchoParamsAction,
+      params: %{value: Ref.item()}
+    )
+  end
+
+  defp component(:reduce, name, _index) do
+    Jido.Flow.Reduce.new!(
+      name: name,
+      collection: [1, 2],
+      initial: %{},
+      action: EchoParamsAction,
+      params: %{value: Ref.item()}
+    )
   end
 
   defp transfer_size(value) do

--- a/test/jido_flow/compiler/capture_test.exs
+++ b/test/jido_flow/compiler/capture_test.exs
@@ -1,0 +1,88 @@
+defmodule JidoActionTest.Flow.Compiler.CaptureTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Flow
+  alias Jido.Flow.{Ref, Step}
+  alias JidoActionTest.Fixtures.FlowAuthoring
+  alias JidoActionTest.Fixtures.Actions.EchoParamsAction
+
+  test "compiler callbacks do not retain the compiler state" do
+    assert {:ok, compiled} = Flow.compile(FlowAuthoring.mixed_flow!())
+
+    retained =
+      compiled.workflow.graph.vertices
+      |> Map.values()
+      |> Enum.filter(&retains_compiler_state?/1)
+      |> Enum.map(& &1.name)
+
+    # Includes Step, Choice, Iterate, Subflow output, Map item, and Reduce.
+    assert retained == []
+  end
+
+  test "independent Steps have bounded size after transfer to another process" do
+    measurements =
+      for count <- [1, 2, 4, 6] do
+        steps =
+          for index <- 1..count do
+            Step.new!(name: "s#{index}", action: EchoParamsAction, params: %{value: index})
+          end
+
+        flow = Flow.new!(name: "capture_size", components: steps, output: Ref.result("s#{count}"))
+        assert {:ok, compiled} = Flow.compile(flow)
+        local_words = :erts_debug.flat_size(compiled)
+        {copied_words, memory} = transfer_size(compiled)
+        assert copied_words == local_words
+        {count, local_words, memory}
+      end
+
+    {2, small_words, small_memory} = Enum.find(measurements, &(elem(&1, 0) == 2))
+    {6, large_words, large_memory} = List.last(measurements)
+
+    # Allow graph overhead and different heap sizes across supported runtimes.
+    # Tripling this graph must not multiply its copied size exponentially.
+    assert large_words < small_words * 4
+    assert large_memory < small_memory * 6
+  end
+
+  defp transfer_size(value) do
+    owner = self()
+    ref = make_ref()
+
+    {receiver, monitor} =
+      spawn_monitor(fn ->
+        receive do
+          {^ref, copied} ->
+            {:memory, memory} = Process.info(self(), :memory)
+            send(owner, {ref, :erts_debug.flat_size(copied), memory})
+        end
+      end)
+
+    try do
+      send(receiver, {ref, value})
+      assert_receive {^ref, words, memory}, 5_000
+      assert_receive {:DOWN, ^monitor, :process, ^receiver, :normal}, 5_000
+      {words, memory}
+    after
+      Process.exit(receiver, :kill)
+      Process.demonitor(monitor, [:flush])
+    end
+  end
+
+  defp retains_compiler_state?(%{workflow: _, namespace: _, outputs: _}), do: true
+
+  defp retains_compiler_state?(fun) when is_function(fun) do
+    {:env, environment} = :erlang.fun_info(fun, :env)
+    retains_compiler_state?(environment)
+  end
+
+  defp retains_compiler_state?(map) when is_map(map),
+    do: map |> Map.to_list() |> retains_compiler_state?()
+
+  defp retains_compiler_state?(tuple) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> retains_compiler_state?()
+
+  defp retains_compiler_state?(list) when is_list(list),
+    do: Enum.any?(list, &retains_compiler_state?/1)
+
+  defp retains_compiler_state?(_value), do: false
+end


### PR DESCRIPTION
Small compiled Flows retain earlier compiler states in callback closures. Sending the compiled value to another process loses sharing and can multiply the copy size exponentially. Concurrent Runnable workers also copy the full execution and retain the authored Flow through the target callback.

This change extracts namespace and child output values before it creates compiler callbacks. It resolves node telemetry metadata in the caller and sends each worker its Runnable, index, and node metadata. The target callback captures the Flow name. Reduce and the other compiler callbacks were inspected; they do not retain compiler state. Scheduling, ownership, cleanup, failure admission, node identity, and public results keep the same contracts.

Closes #230.

Validation:

- Baseline: 83 nearest tests passed.
- Before the fix, regression tests failed for the reported reasons: compiler state remained in the closure environment; the six-Step copy had 2,230,205 words; a concurrent worker used 147,853,496 bytes for a Flow with unrelated metadata (limit: 1,600,000 bytes).
- The capture regressions now pass. The tests inspect closure environments, transfer compiled values to a monitored process, and measure workers through node telemetry. A separate worker probe after the fix measured 13,744 bytes per worker. Bounds use growth ratios and word size, not exact byte counts.
- Focused contract checks: 149 tests passed. These include collection order and identity, nested errors, telemetry, admission failure, cancellation, and execution revision interruption.
- Full default suite: 742 tests passed.
- `mix test --cover --warnings-as-errors`: 742 tests passed, 94.53% coverage (required: 93%).
- `MIX_ENV=test mix compile --warnings-as-errors`: passed.
- `mix quality`: passed (format, compile, Doctor, ExDoc, Credo, and Dialyzer). Doctor reports 100% documentation and spec coverage. Dialyzer reports zero errors.

The tests cover copied growth for independent Steps, chained Steps, two nested Subflow boundaries, Map, and Reduce at 1, 2, 4, and 6 components. They check for retained state before transfer so a new collection capture fails before it can create an excessive copy. The Logger metadata test now runs two independent nodes at concurrency 1 and 2; its earlier single-node form did not reach concurrent dispatch.

A separate probe checked callback environments, runtime context in nested and collection work, and native node names and hashes. Compilation digests and node identities match the base compiler for all five shapes. The compiled worker callback captures only the group leader, Logger metadata, telemetry tracker, and stop flag. The metadata lookup callback retains execution state in the caller.

Merge order: review and merge #247 before #245. PR #245 is based on this PR's final branch at `c4cfc037bf3f70a0a1d9f4e4d899f13279870bb6`. Its conflict resolution preserves both runtime context and the small `namespace` and `output` captures. The parent capture tests and Subflow context tests pass together on that dependent branch. After #247 merges, retarget/rebase #245 onto `release/v3` and verify its checks before merging it.

Local measurements use Elixir 1.20.3 / OTP 29.0.5, with `ERL_FLAGS='+S 2:2 +SDcpu 1 +SDio 1'`. Dependencies, builds, and writable PLTs are separate copies in this worktree.

| Steps | Copied words before → after | Receiving process bytes before → after | Median Exec time, µs before → after |
| ---: | ---: | ---: | ---: |
| 1 | 1,826 → 1,258 | 11,536 → 9,456 | 148 → 131 |
| 2 | 7,681 → 2,203 | 39,720 → 14,616 | 424 → 311 |
| 4 | 129,743 → 4,093 | 628,120 → 24,936 | 3,565 → 564 |
| 6 | 2,230,205 → 5,983 | 10,826,120 → 35,256 | 78,144 → 558 |

The six-Step compile measurement was 75 → 83 µs. The transfer and reply measurement was 12,143 → 37 µs. Exec measurements are the median of five complete calls with `max_concurrency: 2`. The copy probe uses the issue's 1, 2, 4, and 6 independent Echo Steps. Flattened words and process memory are different measurements. These small local measurements show the removed copy cost; they are not a production benchmark or a throughput guarantee.

This PR does not add the separate benchmark suite or change the execution owner design. It does not change the separate Subflow context defect. Large authored node data and runtime inputs can still have a copy cost.

Human QA:

1. Run the two new capture test files on the deployment toolchain.
2. Run a representative nested Flow with Choice, Iterate, Map, and Reduce at concurrency 1 and greater than 1. Check values, item order, error paths, and telemetry IDs.
3. Trigger a node failure and cancel a blocked asynchronous call. Check worker cleanup and that pending work does not start again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791214008&installation_model_id=434874&pr_number=247&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F247&signature=c02a76d68131b728598bf8acffe414ace7face3165d08a4fe4d88ee5e3cad54c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

