### PR TITLE
fix(exec): bound telemetry cleanup for timeout and cancellation

### DIFF
--- a/guides/execution.md
+++ b/guides/execution.md
@@ -221,13 +221,17 @@ in order. The tracker keeps span records separately from handler execution.
 Timeout and cancellation stop execution work before telemetry cleanup. Nested
 work continues to use the same complete-call deadline.
 
-Terminal cleanup allows up to 100 milliseconds for pending event delivery,
+The delivery process uses the caller's Logger metadata and group leader.
+Tracker exit also stops delivery, including handlers that trap exit signals.
+
+Terminal cleanup allows up to 100 milliseconds for the full pending event queue,
 then stops the delivery process. Normal handlers retain start/terminal pairing.
 If a handler blocks, runs too slowly, or kills the delivery process, some
-handlers can miss events, including terminal events. Exec cannot guarantee
-completed delivery to a callback that does not return. Execution results and
-cleanup do not wait indefinitely for that callback. Keep handlers short and
-send slow work to a process owned by the consumer.
+handlers can miss events, including terminal events. An abrupt tracker exit
+can also discard pending events. Jido does not repeat interrupted handler calls.
+Exec cannot guarantee completed delivery to a callback that does not return.
+Execution results and cleanup do not wait indefinitely for that callback.
+Keep handlers short and send slow work to a process owned by the consumer.
 
 Synchronous calls with `timeout: :infinity` and step-wise calls keep synchronous
 telemetry delivery. They do not have a finite complete-call deadline.

--- a/guides/execution.md
+++ b/guides/execution.md
@@ -223,6 +223,8 @@ work continues to use the same complete-call deadline.
 
 The delivery process uses the caller's Logger metadata and group leader.
 Tracker exit also stops delivery, including handlers that trap exit signals.
+Start and terminal measurements are captured at the lifecycle call, before
+queueing. Delivery delay does not change timestamps or span duration.
 
 Terminal cleanup allows up to 100 milliseconds for the full pending event queue,
 then stops the delivery process. Normal handlers retain start/terminal pairing.

--- a/guides/execution.md
+++ b/guides/execution.md
@@ -216,6 +216,22 @@ All nested events use one `execution_id`. Error events add `error` and
 Runic support nodes do not get artificial Jido node events. A complete-call
 timeout closes each active Jido span once with the timeout error.
 
+For a finite-timeout call or an async call, one owned process delivers events
+in order. The tracker keeps span records separately from handler execution.
+Timeout and cancellation stop execution work before telemetry cleanup. Nested
+work continues to use the same complete-call deadline.
+
+Terminal cleanup allows up to 100 milliseconds for pending event delivery,
+then stops the delivery process. Normal handlers retain start/terminal pairing.
+If a handler blocks, runs too slowly, or kills the delivery process, some
+handlers can miss events, including terminal events. Exec cannot guarantee
+completed delivery to a callback that does not return. Execution results and
+cleanup do not wait indefinitely for that callback. Keep handlers short and
+send slow work to a process owned by the consumer.
+
+Synchronous calls with `timeout: :infinity` and step-wise calls keep synchronous
+telemetry delivery. They do not have a finite complete-call deadline.
+
 ## Scope
 
 Exec provides one in-memory execution session. It provides validation, process

--- a/lib/jido_exec.ex
+++ b/lib/jido_exec.ex
@@ -41,6 +41,11 @@ defmodule Jido.Exec do
   Execution keeps Jido Action and Flow telemetry. Map, Reduce, and Iterate can
   also emit item or iteration telemetry. Native Runic support nodes do not get
   an artificial Jido component lifecycle.
+
+  Finite-timeout and async calls deliver telemetry in an owned process.
+  Terminal cleanup allows 100 milliseconds for pending delivery. A blocked
+  or slow handler can lose events, but cannot prevent timeout or cancellation.
+  Keep handlers short. See the execution guide for the delivery contract.
   """
 
   alias Jido.Action.Error
@@ -615,10 +620,10 @@ defmodule Jido.Exec do
   end
 
   defp terminate_managed_execution(worker, monitor, result_ref, telemetry_tracker, error) do
-    Tracker.fail_all(telemetry_tracker, error)
     Process.exit(worker, :kill)
     await_worker_down(monitor, worker)
     flush_execution_results(result_ref, worker)
+    Tracker.fail_all(telemetry_tracker, error)
     Tracker.stop(telemetry_tracker)
   end
 

--- a/lib/jido_exec/telemetry.ex
+++ b/lib/jido_exec/telemetry.ex
@@ -9,6 +9,7 @@ defmodule Jido.Exec.Telemetry do
           id: reference(),
           metadata: map(),
           started_at: integer(),
+          system_time: integer(),
           tracker: pid() | nil,
           tracked?: boolean()
         }
@@ -34,6 +35,7 @@ defmodule Jido.Exec.Telemetry do
       id: make_ref(),
       metadata: metadata,
       started_at: started_at,
+      system_time: System.system_time(),
       tracker: tracker,
       tracked?: false
     }
@@ -102,16 +104,15 @@ defmodule Jido.Exec.Telemetry do
   def emit_start(span) do
     :telemetry.execute(
       span.event ++ [:start],
-      %{system_time: System.system_time(), monotonic_time: span.started_at},
+      %{system_time: span.system_time, monotonic_time: span.started_at},
       span.metadata
     )
   end
 
   @doc false
   @spec emit_terminal(span(), :stop | :error, map()) :: :ok
-  def emit_terminal(span, suffix, extra_metadata) do
-    stopped_at = System.monotonic_time()
-
+  @spec emit_terminal(span(), :stop | :error, map(), integer()) :: :ok
+  def emit_terminal(span, suffix, extra_metadata, stopped_at \\ System.monotonic_time()) do
     :telemetry.execute(
       span.event ++ [suffix],
       %{duration: stopped_at - span.started_at, monotonic_time: stopped_at},

--- a/lib/jido_exec/telemetry/tracker.ex
+++ b/lib/jido_exec/telemetry/tracker.ex
@@ -26,7 +26,8 @@ defmodule Jido.Exec.Telemetry.Tracker do
   @spec close(pid(), Telemetry.span(), :stop | :error, map()) :: :ok
   def close(tracker, span, suffix, extra_metadata)
       when is_pid(tracker) and suffix in [:stop, :error] and is_map(extra_metadata) do
-    GenServer.call(tracker, {:close, span, suffix, extra_metadata}, @call_timeout)
+    stopped_at = System.monotonic_time()
+    GenServer.call(tracker, {:close, span, suffix, extra_metadata, stopped_at}, @call_timeout)
   catch
     :exit, _reason -> :ok
   end
@@ -34,7 +35,8 @@ defmodule Jido.Exec.Telemetry.Tracker do
   @doc false
   @spec fail_all(pid(), term()) :: :ok
   def fail_all(tracker, error) when is_pid(tracker) do
-    GenServer.call(tracker, {:fail_all, error}, @call_timeout)
+    stopped_at = System.monotonic_time()
+    GenServer.call(tracker, {:fail_all, error, stopped_at}, @call_timeout)
   catch
     :exit, _reason -> :ok
   end
@@ -97,25 +99,25 @@ defmodule Jido.Exec.Telemetry.Tracker do
      }}
   end
 
-  def handle_call({:close, span, suffix, extra_metadata}, _from, state) do
+  def handle_call({:close, span, suffix, extra_metadata, stopped_at}, _from, state) do
     case Map.pop(state.spans, span.id) do
       {nil, _spans} ->
         {:reply, :ok, state}
 
       {{_order, open_span}, spans} ->
-        enqueue(state.delivery, {:terminal, open_span, suffix, extra_metadata})
+        enqueue(state.delivery, {:terminal, open_span, suffix, extra_metadata, stopped_at})
         {:reply, :ok, %{state | spans: spans}}
     end
   end
 
-  def handle_call({:fail_all, error}, _from, state) do
+  def handle_call({:fail_all, error, stopped_at}, _from, state) do
     extra_metadata = Telemetry.error_metadata(error)
 
     state.spans
     |> Map.values()
     |> Enum.sort_by(&elem(&1, 0), :desc)
     |> Enum.each(fn {_order, span} ->
-      enqueue(state.delivery, {:terminal, span, :error, extra_metadata})
+      enqueue(state.delivery, {:terminal, span, :error, extra_metadata, stopped_at})
     end)
 
     {:reply, :ok, %{state | closed?: true, spans: %{}}}
@@ -179,8 +181,8 @@ defmodule Jido.Exec.Telemetry.Tracker do
         Telemetry.emit_start(span)
         deliver()
 
-      {:terminal, span, suffix, extra_metadata} ->
-        Telemetry.emit_terminal(span, suffix, extra_metadata)
+      {:terminal, span, suffix, extra_metadata, stopped_at} ->
+        Telemetry.emit_terminal(span, suffix, extra_metadata, stopped_at)
         deliver()
 
       :stop ->

--- a/lib/jido_exec/telemetry/tracker.ex
+++ b/lib/jido_exec/telemetry/tracker.ex
@@ -11,7 +11,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
   @doc false
   @spec start_link() :: GenServer.on_start()
   def start_link do
-    GenServer.start_link(__MODULE__, self())
+    GenServer.start_link(__MODULE__, {self(), Logger.metadata()})
   end
 
   @doc false
@@ -55,10 +55,19 @@ defmodule Jido.Exec.Telemetry.Tracker do
   end
 
   @impl true
-  def init(owner) do
+  def init({owner, logger_metadata}) do
     Process.flag(:trap_exit, true)
+    Logger.metadata(logger_metadata)
     owner_monitor = Process.monitor(owner)
-    delivery = spawn_link(fn -> deliver() end)
+    tracker = self()
+
+    delivery =
+      spawn_link(fn ->
+        Logger.metadata(logger_metadata)
+        deliver()
+      end)
+
+    delivery_guard = spawn(fn -> guard_delivery(tracker, delivery) end)
 
     {:ok,
      %{
@@ -66,6 +75,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
        next_order: 0,
        spans: %{},
        delivery: delivery,
+       delivery_guard: delivery_guard,
        owner_monitor: owner_monitor
      }}
   end
@@ -123,9 +133,14 @@ defmodule Jido.Exec.Telemetry.Tracker do
   end
 
   @impl true
-  def terminate(_reason, %{delivery: nil}), do: :ok
+  def terminate(_reason, %{delivery: delivery, delivery_guard: guard}) do
+    stop_delivery(delivery)
+    await_down(guard, Process.monitor(guard))
+  end
 
-  def terminate(_reason, %{delivery: delivery}) do
+  defp stop_delivery(nil), do: :ok
+
+  defp stop_delivery(delivery) do
     monitor = Process.monitor(delivery)
     send(delivery, :stop)
 
@@ -135,6 +150,21 @@ defmodule Jido.Exec.Telemetry.Tracker do
       @delivery_timeout ->
         Process.exit(delivery, :kill)
         await_down(delivery, monitor)
+    end
+  end
+
+  # A handler can trap exits. Keep its owner monitor outside handler code so
+  # an abrupt tracker exit still stops delivery, even without terminate/2.
+  defp guard_delivery(tracker, delivery) do
+    tracker_monitor = Process.monitor(tracker)
+    delivery_monitor = Process.monitor(delivery)
+
+    receive do
+      {:DOWN, ^tracker_monitor, :process, ^tracker, _reason} ->
+        Process.exit(delivery, :kill)
+
+      {:DOWN, ^delivery_monitor, :process, ^delivery, _reason} ->
+        :ok
     end
   end
 

--- a/lib/jido_exec/telemetry/tracker.ex
+++ b/lib/jido_exec/telemetry/tracker.ex
@@ -5,16 +5,19 @@ defmodule Jido.Exec.Telemetry.Tracker do
 
   alias Jido.Exec.Telemetry
 
+  @call_timeout 1_000
+  @delivery_timeout 100
+
   @doc false
   @spec start_link() :: GenServer.on_start()
   def start_link do
-    GenServer.start_link(__MODULE__, :ok)
+    GenServer.start_link(__MODULE__, self())
   end
 
   @doc false
   @spec open(pid(), Telemetry.span()) :: :ok | :suppressed
   def open(tracker, span) when is_pid(tracker) do
-    GenServer.call(tracker, {:open, span}, :infinity)
+    GenServer.call(tracker, {:open, span}, @call_timeout)
   catch
     :exit, _reason -> :suppressed
   end
@@ -23,7 +26,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
   @spec close(pid(), Telemetry.span(), :stop | :error, map()) :: :ok
   def close(tracker, span, suffix, extra_metadata)
       when is_pid(tracker) and suffix in [:stop, :error] and is_map(extra_metadata) do
-    GenServer.call(tracker, {:close, span, suffix, extra_metadata}, :infinity)
+    GenServer.call(tracker, {:close, span, suffix, extra_metadata}, @call_timeout)
   catch
     :exit, _reason -> :ok
   end
@@ -31,7 +34,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
   @doc false
   @spec fail_all(pid(), term()) :: :ok
   def fail_all(tracker, error) when is_pid(tracker) do
-    GenServer.call(tracker, {:fail_all, error}, :infinity)
+    GenServer.call(tracker, {:fail_all, error}, @call_timeout)
   catch
     :exit, _reason -> :ok
   end
@@ -39,13 +42,33 @@ defmodule Jido.Exec.Telemetry.Tracker do
   @doc false
   @spec stop(pid()) :: :ok
   def stop(tracker) when is_pid(tracker) do
-    GenServer.stop(tracker, :normal, :infinity)
-  catch
-    :exit, _reason -> :ok
+    monitor = Process.monitor(tracker)
+    Process.unlink(tracker)
+
+    try do
+      GenServer.stop(tracker, :normal, @call_timeout)
+    catch
+      :exit, _reason -> Process.exit(tracker, :kill)
+    end
+
+    await_down(tracker, monitor)
   end
 
   @impl true
-  def init(:ok), do: {:ok, %{closed?: false, next_order: 0, spans: %{}}}
+  def init(owner) do
+    Process.flag(:trap_exit, true)
+    owner_monitor = Process.monitor(owner)
+    delivery = spawn_link(fn -> deliver() end)
+
+    {:ok,
+     %{
+       closed?: false,
+       next_order: 0,
+       spans: %{},
+       delivery: delivery,
+       owner_monitor: owner_monitor
+     }}
+  end
 
   @impl true
   def handle_call({:open, _span}, _from, %{closed?: true} = state) do
@@ -53,7 +76,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
   end
 
   def handle_call({:open, span}, _from, state) do
-    Telemetry.emit_start(span)
+    enqueue(state.delivery, {:start, span})
     order = state.next_order + 1
 
     {:reply, :ok,
@@ -70,7 +93,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
         {:reply, :ok, state}
 
       {{_order, open_span}, spans} ->
-        Telemetry.emit_terminal(open_span, suffix, extra_metadata)
+        enqueue(state.delivery, {:terminal, open_span, suffix, extra_metadata})
         {:reply, :ok, %{state | spans: spans}}
     end
   end
@@ -82,9 +105,66 @@ defmodule Jido.Exec.Telemetry.Tracker do
     |> Map.values()
     |> Enum.sort_by(&elem(&1, 0), :desc)
     |> Enum.each(fn {_order, span} ->
-      Telemetry.emit_terminal(span, :error, extra_metadata)
+      enqueue(state.delivery, {:terminal, span, :error, extra_metadata})
     end)
 
     {:reply, :ok, %{state | closed?: true, spans: %{}}}
+  end
+
+  @impl true
+  def handle_info({:EXIT, delivery, _reason}, %{delivery: delivery} = state) do
+    {:noreply, %{state | delivery: nil}}
+  end
+
+  # stop/1 unlinks before forced shutdown. The monitor keeps ownership intact
+  # if the caller exits during that operation.
+  def handle_info({:DOWN, monitor, :process, _owner, _reason}, %{owner_monitor: monitor} = state) do
+    {:stop, :normal, state}
+  end
+
+  @impl true
+  def terminate(_reason, %{delivery: nil}), do: :ok
+
+  def terminate(_reason, %{delivery: delivery}) do
+    monitor = Process.monitor(delivery)
+    send(delivery, :stop)
+
+    receive do
+      {:DOWN, ^monitor, :process, ^delivery, _reason} -> :ok
+    after
+      @delivery_timeout ->
+        Process.exit(delivery, :kill)
+        await_down(delivery, monitor)
+    end
+  end
+
+  defp enqueue(nil, _event), do: :ok
+  defp enqueue(delivery, event), do: send(delivery, event)
+
+  # One sender and one delivery process keep event order. Handler code never
+  # runs in the process that owns span records or cancellation.
+  defp deliver do
+    receive do
+      {:start, span} ->
+        Telemetry.emit_start(span)
+        deliver()
+
+      {:terminal, span, suffix, extra_metadata} ->
+        Telemetry.emit_terminal(span, suffix, extra_metadata)
+        deliver()
+
+      :stop ->
+        :ok
+    end
+  end
+
+  defp await_down(pid, monitor) do
+    receive do
+      {:DOWN, ^monitor, :process, ^pid, _reason} -> :ok
+    after
+      @call_timeout ->
+        Process.demonitor(monitor, [:flush])
+        :ok
+    end
   end
 end

--- a/test/jido_exec/blocked_telemetry_test.exs
+++ b/test/jido_exec/blocked_telemetry_test.exs
@@ -77,7 +77,7 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
       operation: operation,
       supervisor: supervisor
     } do
-      token = attach_blocking([:jido, :action, :start])
+      token = attach_blocking([:jido, :action, :start], true)
       monitors_before = Process.info(self(), :monitors)
 
       handle =
@@ -86,7 +86,8 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
       on_exit(fn -> Process.exit(handle.pid, :kill) end)
       assert_receive {^token, :handler_blocked, handler}, 1_000
       assert_receive {^token, :action_started, action, tracker}, 1_000
-      owned = monitor_processes([handler, action, tracker])
+      guard = :sys.get_state(tracker).delivery_guard
+      owned = monitor_processes([handler, action, tracker, guard])
       caller_monitor = Process.monitor(handle.pid)
 
       case operation do
@@ -330,7 +331,99 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
     end
   end
 
-  def handle_blocked(_event, _measurements, _metadata, {owner, token}) do
+  test "tracker death stops a blocked handler that traps exits", %{supervisor: supervisor} do
+    token = attach_blocking([:jido, :action, :start], true)
+
+    handle =
+      Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+
+    on_exit(fn -> Process.exit(handle.pid, :kill) end)
+    assert_receive {^token, :handler_blocked, handler}, 1_000
+    on_exit(fn -> Process.exit(handler, :kill) end)
+    assert_receive {^token, :action_started, action, tracker}, 1_000
+    guard = :sys.get_state(tracker).delivery_guard
+    owned = monitor_processes([handler, action, tracker, guard])
+
+    Process.exit(tracker, :kill)
+
+    assert {:error, %Jido.Exec.Error.AsyncExecutionError{}} = Exec.await(handle, 1_000)
+    assert_stopped(owned)
+    assert Task.Supervisor.children(supervisor) == []
+    refute_received {^token, :handler_released}
+  end
+
+  for terminal <- [:cancel, :supervisor_shutdown] do
+    @tag terminal: terminal
+    test "nested #{terminal} stops delivery and its owner guard without handler release", %{
+      terminal: terminal,
+      supervisor: supervisor
+    } do
+      token = attach_blocking([:jido, :flow, :target, :start], true)
+
+      flow =
+        Flow.new!(
+          name: "blocked_telemetry_parent",
+          components: [Subflow.new!(name: "child", flow: ChildFlow)],
+          output: Ref.result("child")
+        )
+
+      handle = Exec.run_async(flow, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+      on_exit(fn -> Process.exit(handle.pid, :kill) end)
+      assert_receive {^token, :handler_blocked, handler}, 1_000
+      on_exit(fn -> Process.exit(handler, :kill) end)
+      assert_receive {^token, :action_started, action, tracker}, 1_000
+      guard = :sys.get_state(tracker).delivery_guard
+      owned = monitor_processes([handler, action, tracker, guard, handle.pid])
+
+      case terminal do
+        :cancel ->
+          assert :ok = Exec.cancel(handle)
+          assert Task.Supervisor.children(supervisor) == []
+
+        :supervisor_shutdown ->
+          stop_supervised!(supervisor)
+          assert {:error, %Jido.Exec.Error.AsyncExecutionError{}} = Exec.await(handle, 1_000)
+          assert Process.whereis(supervisor) == nil
+      end
+
+      assert_stopped(owned)
+      refute_received {^token, :handler_released}
+    end
+  end
+
+  test "event delivery keeps caller Logger metadata and group leader" do
+    token = make_ref()
+    handler_id = {__MODULE__, token}
+    events = [[:jido, :action, :start], [:jido, :action, :stop]]
+    group_leader = Process.group_leader()
+    Logger.metadata(ansi_color: :magenta)
+
+    :ok =
+      :telemetry.attach_many(handler_id, events, &__MODULE__.handle_context/4, {self(), token})
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    for mode <- [:sync, :async] do
+      target = JidoActionTest.Fixtures.Actions.Add
+      opts = [timeout: 1_000, jido: __MODULE__]
+
+      result =
+        case mode do
+          :sync -> Exec.run(target, %{value: 1}, %{}, opts)
+          :async -> target |> Exec.run_async(%{value: 1}, %{}, opts) |> Exec.await(1_000)
+        end
+
+      assert {:ok, %{value: 2}} = result
+
+      for event <- events do
+        assert_receive {^token, :context, ^event, metadata, ^group_leader}, 1_000
+        assert metadata[:ansi_color] == :magenta
+      end
+    end
+  end
+
+  def handle_blocked(_event, _measurements, _metadata, {owner, token, trap_exits?}) do
+    if trap_exits?, do: Process.flag(:trap_exit, true)
     send(owner, {token, :handler_blocked, self()})
 
     receive do
@@ -351,6 +444,10 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
     send(owner, {token, :event, event, measurements, metadata})
   end
 
+  def handle_context(event, _measurements, _metadata, {owner, token}) do
+    send(owner, {token, :context, event, Logger.metadata(), Process.group_leader()})
+  end
+
   defp monitor_processes(pids), do: Enum.map(pids, &{&1, Process.monitor(&1)})
 
   defp assert_stopped(processes) do
@@ -361,11 +458,18 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
     assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, 1_000
   end
 
-  defp attach_blocking(event) do
+  defp attach_blocking(event, trap_exits? \\ false) do
     token = make_ref()
     handler_id = {__MODULE__, token}
 
-    :ok = :telemetry.attach(handler_id, event, &__MODULE__.handle_blocked/4, {self(), token})
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        event,
+        &__MODULE__.handle_blocked/4,
+        {self(), token, trap_exits?}
+      )
+
     on_exit(fn -> :telemetry.detach(handler_id) end)
     token
   end

--- a/test/jido_exec/blocked_telemetry_test.exs
+++ b/test/jido_exec/blocked_telemetry_test.exs
@@ -1,0 +1,378 @@
+defmodule JidoActionTest.Exec.BlockedTelemetryTest do
+  use ExUnit.Case, async: false
+
+  @moduletag capture_log: true
+
+  alias Jido.Exec
+  alias Jido.Exec.Telemetry
+  alias Jido.Flow
+  alias Jido.Flow.{Ref, Step, Subflow}
+  alias JidoActionTest.Fixtures.Execution.BlockingAction
+
+  defmodule ControlledAction do
+    use Jido.Action, name: "blocked_telemetry_controlled"
+
+    def run(_params, %{test_pid: owner, token: token}) do
+      send(owner, {token, :action_started, self(), Telemetry.tracker()})
+
+      receive do
+        {^token, :finish, result} -> result
+      end
+    end
+  end
+
+  defmodule ChildFlow do
+    use Jido.Flow, name: "blocked_telemetry_child"
+
+    flow do
+      step "work", action: ControlledAction, params: %{}
+      output result("work")
+    end
+  end
+
+  setup do
+    supervisor = Exec.task_supervisor_name(__MODULE__)
+    start_supervised!({Task.Supervisor, name: supervisor})
+    %{supervisor: supervisor}
+  end
+
+  test "a complete-call timeout stops work before a blocked start handler is released", %{
+    supervisor: supervisor
+  } do
+    token = attach_blocking([:jido, :action, :start])
+    owner = self()
+
+    {caller, caller_monitor} =
+      spawn_caller(fn ->
+        result =
+          Exec.run(BlockingAction, %{value: 1}, %{test_pid: owner},
+            timeout: 1_000,
+            jido: __MODULE__
+          )
+
+        send(owner, {token, :result, result})
+      end)
+
+    assert_receive {^token, :handler_blocked, handler}, 1_000
+    handler_monitor = Process.monitor(handler)
+    assert {:monitors, [{:process, worker}]} = Process.info(caller, :monitors)
+    worker_monitor = Process.monitor(worker)
+    assert {:links, [tracker]} = Process.info(caller, :links)
+    tracker_monitor = Process.monitor(tracker)
+
+    assert_receive {^token, :result, {:error, %Jido.Action.Error.TimeoutError{}}}, 3_000
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
+    assert_receive {:DOWN, ^handler_monitor, :process, ^handler, _reason}, 1_000
+    assert_receive {:DOWN, ^tracker_monitor, :process, ^tracker, _reason}, 1_000
+    assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :normal}, 1_000
+    assert_receive {:blocking_flow_node_started, action}, 1_000
+    assert_down(Process.monitor(action), action)
+    assert Task.Supervisor.children(supervisor) == []
+    refute_received {^token, :handler_released}
+  end
+
+  for operation <- [:cancel, :await_timeout] do
+    @tag operation: operation
+    test "#{operation} stops active work while the start handler is blocked", %{
+      operation: operation,
+      supervisor: supervisor
+    } do
+      token = attach_blocking([:jido, :action, :start])
+      monitors_before = Process.info(self(), :monitors)
+
+      handle =
+        Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+
+      on_exit(fn -> Process.exit(handle.pid, :kill) end)
+      assert_receive {^token, :handler_blocked, handler}, 1_000
+      assert_receive {^token, :action_started, action, tracker}, 1_000
+      owned = monitor_processes([handler, action, tracker])
+      caller_monitor = Process.monitor(handle.pid)
+
+      case operation do
+        :cancel ->
+          assert :ok = Exec.cancel(handle)
+
+        :await_timeout ->
+          assert {:error, %Jido.Exec.Error.AsyncTimeoutError{}} = Exec.await(handle, 0)
+      end
+
+      assert_receive {:DOWN, ^caller_monitor, :process, _, :normal}, 1_000
+      assert_stopped(owned)
+      assert Task.Supervisor.children(supervisor) == []
+      assert Process.info(self(), :monitors) == monitors_before
+      refute_received {^token, :handler_released}
+      refute_received {:jido_exec_async_result, _, _, _}
+      refute_received {:DOWN, _, :process, _, _}
+    end
+  end
+
+  for {mode, reason} <- [sync: :shutdown, sync: :killed, async: :normal, async: :killed] do
+    @tag mode: mode, reason: reason
+    test "#{mode} owner exit (#{reason}) stops a blocked handler and active work", %{
+      mode: mode,
+      reason: reason,
+      supervisor: supervisor
+    } do
+      token = attach_blocking([:jido, :action, :start])
+      owner = self()
+
+      {caller, caller_monitor} =
+        spawn_caller(fn ->
+          context = %{test_pid: owner, token: token}
+
+          case mode do
+            :sync ->
+              Exec.run(ControlledAction, %{}, context, timeout: 10_000, jido: __MODULE__)
+
+            :async ->
+              handle = Exec.run_async(ControlledAction, %{}, context, jido: __MODULE__)
+              send(owner, {token, :handle, handle.pid})
+
+              receive do
+                {^token, :exit} -> :ok
+              end
+          end
+        end)
+
+      assert_receive {^token, :handler_blocked, handler}, 1_000
+      assert_receive {^token, :action_started, action, tracker}, 1_000
+      owned = monitor_processes([handler, action, tracker])
+
+      controller =
+        if mode == :async do
+          assert_receive {^token, :handle, pid}, 1_000
+          monitor_processes([pid])
+        else
+          []
+        end
+
+      case {mode, reason} do
+        {:async, :normal} -> send(caller, {token, :exit})
+        {_, :killed} -> Process.exit(caller, :kill)
+        {:sync, :shutdown} -> Process.exit(caller, :shutdown)
+      end
+
+      assert_receive {:DOWN, ^caller_monitor, :process, ^caller, ^reason}, 1_000
+      assert_stopped(owned ++ controller)
+      assert Task.Supervisor.children(supervisor) == []
+      refute_received {^token, :handler_released}
+    end
+  end
+
+  test "nested work keeps the complete-call deadline while a target handler is blocked", %{
+    supervisor: supervisor
+  } do
+    token = attach_blocking([:jido, :flow, :target, :start])
+    owner = self()
+
+    flow =
+      Flow.new!(
+        name: "blocked_telemetry_parent",
+        components: [Subflow.new!(name: "child", flow: ChildFlow)],
+        output: Ref.result("child")
+      )
+
+    {caller, caller_monitor} =
+      spawn_caller(fn ->
+        result =
+          Exec.run(flow, %{}, %{test_pid: owner, token: token},
+            timeout: 1_000,
+            jido: __MODULE__
+          )
+
+        send(owner, {token, :result, result})
+      end)
+
+    assert_receive {^token, :handler_blocked, handler}, 1_000
+    assert_receive {^token, :action_started, action, tracker}, 1_000
+    owned = monitor_processes([handler, action, tracker])
+
+    assert_receive {^token, :result, {:error, %Jido.Flow.Error.TimeoutError{timeout: 1_000}}},
+                   3_000
+
+    assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :normal}, 1_000
+    assert_stopped(owned)
+    assert Task.Supervisor.children(supervisor) == []
+    refute_received {^token, :handler_released}
+  end
+
+  for suffix <- [:stop, :error] do
+    @tag suffix: suffix
+    test "a blocked #{suffix} handler does not prevent a terminal result", %{
+      suffix: suffix,
+      supervisor: supervisor
+    } do
+      token = attach_blocking([:jido, :action, suffix])
+      owner = self()
+
+      {caller, caller_monitor} =
+        spawn_caller(fn ->
+          result =
+            Exec.run(ControlledAction, %{}, %{test_pid: owner, token: token},
+              timeout: 10_000,
+              jido: __MODULE__
+            )
+
+          send(owner, {token, :result, result})
+        end)
+
+      assert_receive {^token, :action_started, action, tracker}, 1_000
+      owned = monitor_processes([action, tracker])
+
+      result =
+        if suffix == :stop,
+          do: {:ok, %{value: 1}},
+          else: {:error, Jido.Action.Error.execution_error("test failure")}
+
+      send(action, {token, :finish, result})
+      assert_receive {^token, :handler_blocked, handler}, 1_000
+      handler_monitor = Process.monitor(handler)
+      assert_receive {^token, :result, ^result}, 1_000
+      assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :normal}, 1_000
+      assert_stopped([{handler, handler_monitor} | owned])
+      assert Task.Supervisor.children(supervisor) == []
+      refute_received {^token, :handler_released}
+    end
+  end
+
+  for failure <- [:raise, :kill] do
+    @tag failure: failure
+    test "a handler #{failure} does not fail execution or leave delivery work", %{
+      failure: failure,
+      supervisor: supervisor
+    } do
+      token = make_ref()
+      handler_id = {__MODULE__, token}
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:jido, :action, :start],
+          &__MODULE__.handle_failure/4,
+          {self(), token, failure}
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      handle =
+        Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+
+      on_exit(fn -> Process.exit(handle.pid, :kill) end)
+      assert_receive {^token, :handler_failed, handler}, 1_000
+      assert_receive {^token, :action_started, action, tracker}, 1_000
+      owned = monitor_processes([handler, action, tracker])
+      send(action, {token, :finish, {:ok, %{value: 1}}})
+      assert {:ok, %{value: 1}} = Exec.await(handle, 1_000)
+      assert_stopped(owned)
+      assert Task.Supervisor.children(supervisor) == []
+    end
+  end
+
+  test "managed success and failure preserve event order, nesting, and correlation" do
+    token = make_ref()
+    handler_id = {__MODULE__, token}
+    prefixes = [[:jido, :flow], [:jido, :flow, :node], [:jido, :flow, :target]]
+    events = for prefix <- prefixes, suffix <- [:start, :stop, :error], do: prefix ++ [suffix]
+    :ok = :telemetry.attach_many(handler_id, events, &__MODULE__.handle_event/4, {self(), token})
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    for suffix <- [:stop, :error] do
+      flow =
+        Flow.new!(
+          name: "managed_telemetry",
+          components: [Step.new!(name: "work", action: ControlledAction)],
+          output: Ref.result("work")
+        )
+
+      handle =
+        Exec.run_async(flow, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+
+      on_exit(fn -> Process.exit(handle.pid, :kill) end)
+      assert_receive {^token, :action_started, action, _tracker}, 1_000
+
+      result =
+        if suffix == :stop,
+          do: {:ok, %{value: 1}},
+          else: {:error, Jido.Action.Error.execution_error("test failure")}
+
+      send(action, {token, :finish, result})
+
+      case suffix do
+        :stop ->
+          assert ^result = Exec.await(handle, 1_000)
+
+        :error ->
+          assert {:error, %Jido.Action.Error.ExecutionFailureError{message: "test failure"}} =
+                   Exec.await(handle, 1_000)
+      end
+
+      recorded =
+        for _index <- 1..6 do
+          assert_receive {^token, :event, event, measurements, metadata}
+          {event, measurements, metadata}
+        end
+
+      expected =
+        Enum.map(prefixes, &(&1 ++ [:start])) ++
+          Enum.map(Enum.reverse(prefixes), &(&1 ++ [suffix]))
+
+      assert Enum.map(recorded, &elem(&1, 0)) == expected
+      assert [_id] = recorded |> Enum.map(&elem(&1, 2).execution_id) |> Enum.uniq()
+
+      for {start, terminal} <-
+            Enum.zip(Enum.take(recorded, 3), Enum.reverse(Enum.drop(recorded, 3))) do
+        assert elem(start, 2) == Map.drop(elem(terminal, 2), [:error, :error_type])
+        assert elem(terminal, 1).duration >= 0
+      end
+
+      refute_received {^token, :event, _, _, _}
+    end
+  end
+
+  def handle_blocked(_event, _measurements, _metadata, {owner, token}) do
+    send(owner, {token, :handler_blocked, self()})
+
+    receive do
+      {^token, :release} -> send(owner, {token, :handler_released})
+    end
+  end
+
+  def handle_failure(_event, _measurements, _metadata, {owner, token, failure}) do
+    send(owner, {token, :handler_failed, self()})
+
+    case failure do
+      :raise -> raise "handler failed"
+      :kill -> Process.exit(self(), :kill)
+    end
+  end
+
+  def handle_event(event, measurements, metadata, {owner, token}) do
+    send(owner, {token, :event, event, measurements, metadata})
+  end
+
+  defp monitor_processes(pids), do: Enum.map(pids, &{&1, Process.monitor(&1)})
+
+  defp assert_stopped(processes) do
+    for {pid, monitor} <- processes, do: assert_down(monitor, pid)
+  end
+
+  defp assert_down(monitor, pid) do
+    assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, 1_000
+  end
+
+  defp attach_blocking(event) do
+    token = make_ref()
+    handler_id = {__MODULE__, token}
+
+    :ok = :telemetry.attach(handler_id, event, &__MODULE__.handle_blocked/4, {self(), token})
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    token
+  end
+
+  defp spawn_caller(fun) do
+    {caller, monitor} = spawn_monitor(fun)
+    on_exit(fn -> Process.exit(caller, :kill) end)
+    {caller, monitor}
+  end
+end

--- a/test/jido_exec/telemetry_measurement_test.exs
+++ b/test/jido_exec/telemetry_measurement_test.exs
@@ -1,0 +1,113 @@
+defmodule JidoActionTest.Exec.TelemetryMeasurementTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Exec.Telemetry
+  alias Jido.Exec.Telemetry.Tracker
+
+  for terminal <- [:stop, :error, :fail_all] do
+    @tag terminal: terminal
+    test "delayed #{terminal} delivery retains lifecycle measurements", %{terminal: terminal} do
+      owner = self()
+      token = make_ref()
+      handler_id = {__MODULE__, token}
+      events = for suffix <- [:start, :stop, :error], do: [:jido, :action, suffix]
+      :ok = :telemetry.attach_many(handler_id, events, &__MODULE__.handle_event/4, {owner, token})
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      {:ok, tracker} = Tracker.start_link()
+      on_exit(fn -> Process.exit(tracker, :kill) end)
+
+      held =
+        Telemetry.with_tracker(tracker, fn ->
+          Telemetry.start([:jido, :action], %{name: :held, execution_id: "measurements"})
+        end)
+
+      assert_receive {^token, :event, [:jido, :action, :start], _, %{name: :held}}, 1_000
+      assert_receive {^token, :handler_blocked, handler}, 1_000
+      on_exit(fn -> Process.exit(handler, :kill) end)
+      handler_monitor = Process.monitor(handler)
+
+      queued =
+        Telemetry.with_tracker(tracker, fn ->
+          Telemetry.start([:jido, :action], %{name: :queued, execution_id: "measurements"})
+        end)
+
+      before_close = System.monotonic_time()
+
+      case terminal do
+        :stop ->
+          :ok = Telemetry.stop(held)
+          :ok = Telemetry.stop(queued)
+
+        :error ->
+          :ok = Telemetry.error(held, :failed)
+          :ok = Telemetry.error(queued, :failed)
+
+        :fail_all ->
+          :ok = Tracker.fail_all(tracker, :failed)
+      end
+
+      # Each close call is acknowledged while delivery is still blocked.
+      # These markers therefore precede delivery of the queued events.
+      closed_marker = System.monotonic_time()
+      system_marker = System.system_time()
+      send(handler, {token, :release})
+      assert :ok = Tracker.stop(tracker)
+      assert_receive {:DOWN, ^handler_monitor, :process, ^handler, :normal}, 1_000
+
+      assert_receive {^token, :event, [:jido, :action, :start], start_measurements,
+                      %{name: :queued}}
+
+      names = if terminal == :fail_all, do: [:queued, :held], else: [:held, :queued]
+      suffix = if terminal == :stop, do: :stop, else: :error
+      spans = %{held: held, queued: queued}
+
+      for name <- names do
+        assert_receive {^token, :event, [:jido, :action, ^suffix], measurements, %{name: ^name}}
+
+        assert measurements.monotonic_time >= before_close
+        assert measurements.monotonic_time <= closed_marker
+        assert measurements.duration == measurements.monotonic_time - spans[name].started_at
+      end
+
+      assert start_measurements.monotonic_time == queued.started_at
+      assert start_measurements.system_time <= system_marker
+      refute_received {^token, :event, _, _, _}
+    end
+  end
+
+  test "untracked delivery uses measurements from the lifecycle calls" do
+    token = make_ref()
+    handler_id = {__MODULE__, token}
+    events = [[:jido, :action, :start], [:jido, :action, :stop]]
+    :ok = :telemetry.attach_many(handler_id, events, &__MODULE__.handle_event/4, {self(), token})
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    before_start = System.system_time()
+    span = Telemetry.start([:jido, :action], %{name: :sync, execution_id: "measurements"})
+    after_start = System.system_time()
+    assert_receive {^token, :event, [:jido, :action, :start], start, _metadata}
+    assert start.system_time >= before_start
+    assert start.system_time <= after_start
+    assert start.monotonic_time == span.started_at
+
+    before_close = System.monotonic_time()
+    assert :ok = Telemetry.stop(span)
+    after_close = System.monotonic_time()
+    assert_receive {^token, :event, [:jido, :action, :stop], stop, _metadata}
+    assert stop.monotonic_time >= before_close
+    assert stop.monotonic_time <= after_close
+    assert stop.duration == stop.monotonic_time - start.monotonic_time
+  end
+
+  def handle_event(event, measurements, metadata, {owner, token}) do
+    send(owner, {token, :event, event, measurements, metadata})
+
+    if event == [:jido, :action, :start] and metadata.name == :held do
+      send(owner, {token, :handler_blocked, self()})
+
+      receive do
+        {^token, :release} -> :ok
+      end
+    end
+  end
+end


### PR DESCRIPTION
A blocked telemetry handler could stop a finite timeout from returning. The timeout path waited for the tracker before it stopped execution work. The tracker ran handlers in its callbacks and used unlimited calls and shutdown waits.

This change stops execution work first. The tracker keeps span records and sends events to one owned delivery process in order. Tracker calls have finite limits. Terminal cleanup gives the full pending event queue 100 milliseconds, then stops delivery. An owner monitor keeps cleanup active if the caller exits during shutdown. A separate guard stops delivery after abrupt tracker death, including when a handler traps exit signals. Normal shutdown also waits for that guard to stop. Delivery uses the caller's Logger metadata and group leader. Start and terminal timestamps are captured at the lifecycle call, before queueing, so delivery delay cannot inflate span duration or change event time.

The regression holds a start handler with an explicit receive. Before the fix, the caller did not return its timeout result while the handler was blocked. The tests confirm terminal results, worker, tracker, delivery and guard exit, empty task slots, and monitor cleanup without releasing the handler. They cover sync timeout, async cancellation, await timeout, sync and async owner exit, abrupt tracker death with trapped exits, nested cancellation and supervisor shutdown, blocked stop/error handlers, and handler exceptions or hard exits. Normal success and failure retain event order, nesting, metadata, and one execution ID. Separate tests check Logger metadata and group leader in sync and async delivery, and prove that delayed stop, error, and bulk-failure delivery retain the recorded lifecycle times. A marker after close and before handler release establishes those measurement assertions without sleeps.

Validation:

- Baseline: 36 nearest tests passed. The first new regression failed because no timeout result arrived before the failure guard.
- Focused tests: 57 passed, including 17 blocked-handler tests and four measurement tests.
- Full default suite: 756 passed. `mix test --cover --warnings-as-errors`: 756 passed; 94.57% coverage (93% required).
- `MIX_ENV=test mix compile --warnings-as-errors` and `mix quality` passed. Quality includes format, compile, Doctor, docs, Credo, and Dialyzer.

Local checks used Elixir 1.20.3 / OTP 29.0.5 with `ERL_FLAGS='+S 2:2 +SDcpu 1 +SDio 1'`. Dependencies, build files, and writable PLTs were copied into this worktree. The quality command used a command-local `core.hooksPath` under this worktree's `_build` to keep hook writes local.

Delivery limit: a blocked or slow handler, a handler that kills the delivery process, or abrupt tracker exit can cause missing events, including terminal events. Finite cancellation cannot guarantee delivery to a callback that does not return. Interrupted handler calls are not repeated. The execution guide states this limit. Synchronous calls with `timeout: :infinity` and step-wise calls retain synchronous telemetry delivery.

Closes #232
