### PR TITLE
feat(bench): add staged execution benchmark suite

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -37,7 +37,7 @@ locals_without_parens = [
 ]
 
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["{mix,.formatter}.exs", "{bench,config,lib,test}/**/*.{ex,exs}"],
   locals_without_parens: locals_without_parens,
   export: [locals_without_parens: locals_without_parens]
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,6 @@ jobs:
     with:
       credo_command: mix credo --min-priority high
       docs_command: mix docs --warnings-as-errors
-      test_command: mix test --cover --warnings-as-errors
+      test_command: |
+        mix test --cover --warnings-as-errors
+        ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile smoke

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ jido_action-*.tar
 
 # Local planning and review artifacts.
 /docs/
+
+# Machine-specific benchmark output.
+/bench/results/

--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ Livebook. ExDoc adds a **Run in Livebook** link to each `.livemd` guide.
 - [Runtime Configuration](guides/configuration.md)
 - [Security](guides/security.md)
 - [Testing](guides/testing.md)
+- [Execution Benchmarks](guides/benchmarks.md)
 
 ### Upgrade
 

--- a/bench/compare.exs
+++ b/bench/compare.exs
@@ -1,0 +1,12 @@
+Code.require_file("support/report.exs", __DIR__)
+
+case System.argv() do
+  [before_path, after_path, output_path] ->
+    before = before_path |> File.read!() |> JSON.decode!()
+    after_report = after_path |> File.read!() |> JSON.decode!()
+    File.write!(output_path, JidoActionBench.Report.compare!(before, after_report))
+    IO.puts("Wrote #{output_path}")
+
+  _ ->
+    raise ArgumentError, "usage: mix run bench/compare.exs BEFORE.json AFTER.json COMPARISON.md"
+end

--- a/bench/run.exs
+++ b/bench/run.exs
@@ -1,0 +1,17 @@
+Code.require_file("support/suite.exs", __DIR__)
+
+{opts, args, invalid} =
+  OptionParser.parse(System.argv(), strict: [profile: :string, output: :string])
+
+if args != [] or invalid != [],
+  do:
+    raise(
+      ArgumentError,
+      "usage: mix run bench/run.exs --profile short|scale|smoke --output DIRECTORY"
+    )
+
+profile = Keyword.get(opts, :profile, "short")
+output = Keyword.get(opts, :output, "bench/results/#{profile}")
+report = JidoActionBench.Suite.run(profile)
+JidoActionBench.Suite.write!(report, output)
+IO.puts("Wrote #{output}/report.json and report.md")

--- a/bench/support/fixtures.exs
+++ b/bench/support/fixtures.exs
@@ -1,0 +1,191 @@
+defmodule JidoActionBench.Echo do
+  @moduledoc false
+  use Jido.Action, name: "benchmark_echo"
+
+  @impl true
+  def run(params, context) do
+    JidoActionBench.Fixtures.barrier(context)
+    {:ok, params}
+  end
+end
+
+defmodule JidoActionBench.Child do
+  @moduledoc false
+  use Jido.Flow, name: "benchmark_child"
+
+  flow do
+    step "echo", action: JidoActionBench.Echo, params: %{value: input(:value)}
+    output result("echo")
+  end
+end
+
+defmodule JidoActionBench.Fixtures do
+  @moduledoc false
+  alias Jido.{Exec, Flow}
+  alias Jido.Flow.{Ref, Step, Subflow}
+  alias JidoActionBench.Echo
+
+  def barrier(context) do
+    if observer = context[:bench_observer] do
+      ref = make_ref()
+      send(observer, {:bench_barrier, self(), ref})
+
+      receive do
+        {:bench_release, ^ref} -> :ok
+      after
+        30_000 -> raise "benchmark barrier was not released"
+      end
+    end
+  end
+
+  def workloads(count, payload) when count in 1..32 do
+    input = %{value: payload(payload)}
+    action_workloads(input) ++ flow_workloads(count, input)
+  end
+
+  def workloads(_count, _payload), do: raise(ArgumentError, "graph size must be in 1..32")
+
+  def graph(shape, count) when count in 1..32 do
+    components =
+      for index <- 1..count do
+        name = "s#{index}"
+
+        value =
+          if shape == :serial and index > 1,
+            do: Ref.result("s#{index - 1}", :value),
+            else: Ref.input(:value)
+
+        if shape == :subflows do
+          Subflow.new!(name: name, flow: JidoActionBench.Child, params: %{value: value})
+        else
+          Step.new!(name: name, action: Echo, params: %{value: value})
+        end
+      end
+
+    output = Map.new(1..count, &{"s#{&1}", Ref.result("s#{&1}")})
+    Flow.new!(name: "benchmark_#{shape}", components: components, output: output)
+  end
+
+  defp payload(:small), do: 42
+  defp payload(:large_map), do: Map.new(1..1_000, &{&1, &1 * 2})
+  defp payload(:large_binary), do: :binary.copy(<<42>>, 1_048_576)
+
+  defp action_workloads(input) do
+    for mode <- [:direct, :run, :finite_timeout, :async_await] do
+      %{
+        name: "action/#{mode}",
+        setup: fn context -> context end,
+        run: fn context -> action(mode, input, context) end,
+        check: &expect!(&1, {:ok, input}),
+        retained: input
+      }
+    end
+  end
+
+  defp action(:direct, input, context), do: Echo.run(input, context)
+  defp action(:run, input, context), do: Exec.run(Echo, input, context, jido: JidoActionBench)
+
+  defp action(:finite_timeout, input, context),
+    do: Exec.run(Echo, input, context, jido: JidoActionBench, timeout: 30_000)
+
+  defp action(:async_await, input, context) do
+    Echo
+    |> Exec.run_async(input, context, jido: JidoActionBench)
+    |> Exec.await(30_000)
+  end
+
+  defp flow_workloads(count, input) do
+    for shape <- [:serial, :parallel, :subflows],
+        workload <- flow_cases(graph(shape, count), input, count, shape),
+        do: workload
+  end
+
+  defp flow_cases(flow, input, count, shape) do
+    {:ok, compiled} = Flow.compile(flow)
+    expected = {:ok, Map.new(1..count, &{"s#{&1}", input})}
+    opts = [jido: JidoActionBench, max_concurrency: if(shape == :serial, do: 1, else: 4)]
+    common = %{setup: fn context -> context end, retained: {flow, compiled, input}}
+
+    [
+      Map.merge(common, %{
+        name: "#{shape}/validate",
+        run: fn _ -> Flow.validate_executable(flow) end,
+        check: &expect!(&1, {:ok, flow})
+      }),
+      Map.merge(common, %{
+        name: "#{shape}/compile",
+        run: fn _ -> Flow.compile(flow) end,
+        check: fn {:ok, result} ->
+          expect!(result.compilation_digest, compiled.compilation_digest)
+        end
+      }),
+      Map.merge(common, %{
+        name: "#{shape}/run",
+        run: fn context -> Exec.run(flow, input, context, opts) end,
+        check: &expect!(&1, expected)
+      }),
+      Map.merge(common, %{
+        name: "#{shape}/prepared_reuse",
+        run: fn context -> run_prepared(flow, compiled, input, context, opts) end,
+        check: &expect!(&1, expected)
+      }),
+      %{
+        name: "#{shape}/paused_continue",
+        setup: fn context ->
+          {:ok, execution} = Exec.start(flow, input, context, opts)
+          [_ | _] = Exec.ready(execution)
+          barrier(context)
+          execution
+        end,
+        run: fn execution ->
+          {:ok, finished} = Exec.continue(execution)
+          Exec.result(finished)
+        end,
+        check: &expect!(&1, expected),
+        retained: {flow, compiled, input}
+      }
+    ]
+  end
+
+  # Internal measurement adapter for these empty-schema fixtures only. There is
+  # no public compiled-graph run API. Each call gets fresh execution state.
+  defp run_prepared(flow, compiled, input, context, opts) do
+    {:ok, options} = Jido.Exec.Options.validate_flow(opts, :start)
+    id = "bench_#{System.unique_integer([:positive])}"
+    name = flow.name
+    span = Jido.Exec.Telemetry.start([:jido, :flow], %{execution_id: id, flow: name})
+
+    runner = fn target, params, target_context, execution_id, owner ->
+      Jido.Exec.Flow.TargetRunner.run(
+        target,
+        params,
+        target_context,
+        execution_id,
+        options,
+        name,
+        owner
+      )
+    end
+
+    {:ok, execution} =
+      Jido.Exec.Flow.Engine.start(
+        flow,
+        compiled,
+        input,
+        context,
+        options,
+        &{:ok, &1},
+        runner,
+        id,
+        %{flow: span}
+      )
+
+    {:ok, finished} = Exec.continue(execution)
+    Exec.result(finished)
+  end
+
+  defp expect!(actual, expected) do
+    if actual != expected, do: raise("benchmark returned an incorrect result")
+    :ok
+  end
+end

--- a/bench/support/fixtures.exs
+++ b/bench/support/fixtures.exs
@@ -83,14 +83,20 @@ defmodule JidoActionBench.Fixtures do
   end
 
   defp action(:direct, input, context), do: Echo.run(input, context)
-  defp action(:run, input, context), do: Exec.run(Echo, input, context, jido: JidoActionBench)
+
+  defp action(:run, input, context),
+    do: Exec.run(Echo, input, context, task_supervisor: JidoActionBench.TaskSupervisor)
 
   defp action(:finite_timeout, input, context),
-    do: Exec.run(Echo, input, context, jido: JidoActionBench, timeout: 30_000)
+    do:
+      Exec.run(Echo, input, context,
+        task_supervisor: JidoActionBench.TaskSupervisor,
+        timeout: 30_000
+      )
 
   defp action(:async_await, input, context) do
     Echo
-    |> Exec.run_async(input, context, jido: JidoActionBench)
+    |> Exec.run_async(input, context, task_supervisor: JidoActionBench.TaskSupervisor)
     |> Exec.await(30_000)
   end
 
@@ -103,7 +109,12 @@ defmodule JidoActionBench.Fixtures do
   defp flow_cases(flow, input, count, shape) do
     {:ok, compiled} = Flow.compile(flow)
     expected = {:ok, Map.new(1..count, &{"s#{&1}", input})}
-    opts = [jido: JidoActionBench, max_concurrency: if(shape == :serial, do: 1, else: 4)]
+
+    opts = [
+      task_supervisor: JidoActionBench.TaskSupervisor,
+      max_concurrency: if(shape == :serial, do: 1, else: 4)
+    ]
+
     common = %{setup: fn context -> context end, retained: {flow, compiled, input}}
 
     [

--- a/bench/support/measure.exs
+++ b/bench/support/measure.exs
@@ -131,12 +131,13 @@ defmodule JidoActionBench.Measure do
       state = observe(state)
       send(caller, :bench_go)
       state = collect(state)
-      state = finish_owned(state)
 
       case state.result do
         :ok -> :ok
         other -> raise "resource caller failed: #{inspect(other)}"
       end
+
+      state = finish_owned(state)
 
       %{
         owned_process_starts: :ets.info(table, :size),
@@ -147,17 +148,40 @@ defmodule JidoActionBench.Measure do
         exact_peak_bytes: nil
       }
     after
-      :erlang.trace(supervisor, false, [:all])
-      Process.exit(caller, :kill)
-      Process.demonitor(caller_ref, [:flush])
-      # On a failed probe, also stop all observed descendants. Discard this
-      # probe's mailbox by ending its isolated observer process.
-      for {pid, ref} <- :ets.tab2list(table) do
-        Process.exit(pid, :kill)
-        Process.demonitor(ref, [:flush])
+      try do
+        stop_processes([caller])
+        stop_descendants(fence(state))
+      after
+        :erlang.trace(supervisor, false, [:all])
+        Process.demonitor(caller_ref, [:flush])
+        :ets.delete(table)
       end
+    end
+  end
 
-      :ets.delete(table)
+  # Stop the caller first, then drain traces before stopping its descendants.
+  # Repeat for any child starts delivered during termination. Return only after
+  # monitors confirm that every observed process has stopped.
+  defp stop_descendants(state) do
+    known = :ets.tab2list(state.table)
+    stop_processes(Enum.map(known, &elem(&1, 0)))
+    state = fence(state)
+
+    if :ets.info(state.table, :size) != length(known), do: stop_descendants(state)
+    :ok
+  end
+
+  defp stop_processes(pids) do
+    monitors = Enum.map(pids, &{&1, Process.monitor(&1)})
+    Enum.each(pids, &Process.exit(&1, :kill))
+    Enum.each(monitors, fn {pid, ref} -> await_down(pid, ref) end)
+  end
+
+  defp await_down(pid, ref) do
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      @timeout -> raise "owned process did not stop: #{inspect(pid)}"
     end
   end
 
@@ -195,7 +219,7 @@ defmodule JidoActionBench.Measure do
   end
 
   defp handle({:trace, _parent, :spawn, child, _mfa}, state) do
-    :ets.insert_new(state.table, {child, Process.monitor(child)})
+    :ets.insert_new(state.table, {child})
     state
   end
 
@@ -214,14 +238,8 @@ defmodule JidoActionBench.Measure do
   defp finish_owned(state) do
     previous = :ets.info(state.table, :size)
 
-    for {pid, _ref} <- :ets.tab2list(state.table) do
-      ref = Process.monitor(pid)
-
-      receive do
-        {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
-      after
-        @timeout -> raise "owned process did not stop: #{inspect(pid)}"
-      end
+    for {pid} <- :ets.tab2list(state.table) do
+      await_down(pid, Process.monitor(pid))
     end
 
     state = fence(state)

--- a/bench/support/measure.exs
+++ b/bench/support/measure.exs
@@ -1,0 +1,308 @@
+defmodule JidoActionBench.Measure do
+  @moduledoc false
+  @timeout 30_000
+
+  def timing(workload, warmup, samples) do
+    isolated(fn ->
+      for _ <- 1..warmup, do: invoke(workload)
+
+      measurements =
+        for _ <- 1..samples do
+          prepared = workload.setup.(%{})
+          {:reductions, before_reductions} = Process.info(self(), :reductions)
+          before_time = System.monotonic_time()
+          result = workload.run.(prepared)
+          elapsed = System.monotonic_time() - before_time
+          {:reductions, after_reductions} = Process.info(self(), :reductions)
+          :ok = workload.check.(result)
+
+          {System.convert_time_unit(elapsed, :native, :nanosecond),
+           after_reductions - before_reductions}
+        end
+
+      %{
+        wall_ns: distribution(Enum.map(measurements, &elem(&1, 0))),
+        caller_reductions: distribution(Enum.map(measurements, &elem(&1, 1)))
+      }
+    end)
+  end
+
+  def resources(workload) do
+    isolated(fn -> trace_resources(workload) end)
+  end
+
+  def term_size(term) do
+    word = :erlang.system_info(:wordsize)
+    local = :erts_debug.size(term) * word
+    flat = :erts_debug.flat_size(term) * word
+
+    # Bound the flattened heap before the transfer. Shared binary payloads do
+    # not form part of this heap estimate; the encoded size reports them too.
+    if flat > 64 * 1_048_576, do: raise("term transfer exceeds the 64 MiB heap bound")
+
+    transfer =
+      isolated(
+        fn ->
+          receive do
+            {:term, copied} ->
+              {:memory, memory} = Process.info(self(), :memory)
+
+              %{
+                copied_flat_heap_bytes: :erts_debug.flat_size(copied) * word,
+                receiver_memory_bytes: memory
+              }
+          end
+        end,
+        fn pid -> send(pid, {:term, term}) end
+      )
+
+    Map.merge(transfer, %{
+      local_heap_bytes: local,
+      flat_heap_bytes: flat,
+      external_bytes: :erlang.external_size(term)
+    })
+  end
+
+  def distribution(values) do
+    sorted = Enum.sort(values)
+    count = length(sorted)
+
+    %{
+      samples: values,
+      min: hd(sorted),
+      median: Enum.at(sorted, div(count, 2)),
+      p95: Enum.at(sorted, max(ceil(count * 0.95) - 1, 0)),
+      max: List.last(sorted),
+      mean: Enum.sum(sorted) / count
+    }
+  end
+
+  defp invoke(workload) do
+    result = workload.run.(workload.setup.(%{}))
+    :ok = workload.check.(result)
+  end
+
+  defp trace_resources(workload) do
+    observer = self()
+    table = :ets.new(:bench_owned, [:set, :private])
+
+    supervisor =
+      Process.whereis(JidoActionBench.TaskSupervisor) || raise "benchmark supervisor missing"
+
+    {caller, caller_ref} =
+      spawn_monitor(fn ->
+        receive do
+          :bench_go ->
+            try do
+              result = workload.run.(workload.setup.(%{bench_observer: observer}))
+              :ok = workload.check.(result)
+              send(observer, {:bench_result, :ok})
+            rescue
+              error -> send(observer, {:bench_result, {:error, Exception.message(error)}})
+            catch
+              kind, reason -> send(observer, {:bench_result, {:error, inspect({kind, reason})}})
+            end
+        end
+      end)
+
+    state = %{
+      caller: caller,
+      caller_ref: caller_ref,
+      table: table,
+      pending: [],
+      result: nil,
+      caller_down: false,
+      observations: 0,
+      observed_peak: %{
+        process_memory_bytes: 0,
+        process_heap_bytes: 0,
+        shared_binary_bytes: 0,
+        vm_total_bytes: 0,
+        vm_processes_bytes: 0,
+        vm_binary_bytes: 0,
+        live_owned: 0
+      }
+    }
+
+    try do
+      flags = [:procs, :set_on_spawn, {:tracer, self()}]
+      :erlang.trace(supervisor, true, flags)
+      :erlang.trace(caller, true, flags)
+      state = observe(state)
+      send(caller, :bench_go)
+      state = collect(state)
+      state = finish_owned(state)
+
+      case state.result do
+        :ok -> :ok
+        other -> raise "resource caller failed: #{inspect(other)}"
+      end
+
+      %{
+        owned_process_starts: :ets.info(table, :size),
+        owned_remaining: 0,
+        observations: state.observations,
+        observed_peak: state.observed_peak,
+        helper_reductions: nil,
+        exact_peak_bytes: nil
+      }
+    after
+      :erlang.trace(supervisor, false, [:all])
+      Process.exit(caller, :kill)
+      Process.demonitor(caller_ref, [:flush])
+      # On a failed probe, also stop all observed descendants. Discard this
+      # probe's mailbox by ending its isolated observer process.
+      for {pid, ref} <- :ets.tab2list(table) do
+        Process.exit(pid, :kill)
+        Process.demonitor(ref, [:flush])
+      end
+
+      :ets.delete(table)
+    end
+  end
+
+  defp collect(%{caller_down: true} = state), do: fence(state) |> observe()
+
+  defp collect(state) do
+    receive do
+      message ->
+        state = handle(message, state)
+        state = if state.pending == [], do: state, else: release_barriers(state)
+        collect(state)
+    after
+      @timeout -> raise "resource caller exceeded the safety limit"
+    end
+  end
+
+  defp release_barriers(state) do
+    state = state |> fence() |> observe()
+    for {pid, ref} <- state.pending, do: send(pid, {:bench_release, ref})
+    %{state | pending: []}
+  end
+
+  defp fence(state) do
+    marker = :erlang.trace_delivered(:all)
+    drain(marker, state)
+  end
+
+  defp drain(marker, state) do
+    receive do
+      {:trace_delivered, :all, ^marker} -> state
+      message -> drain(marker, handle(message, state))
+    after
+      @timeout -> raise "trace delivery barrier missing"
+    end
+  end
+
+  defp handle({:trace, _parent, :spawn, child, _mfa}, state) do
+    :ets.insert_new(state.table, {child, Process.monitor(child)})
+    state
+  end
+
+  defp handle({:bench_barrier, pid, ref}, state),
+    do: %{state | pending: [{pid, ref} | state.pending]}
+
+  defp handle({:bench_result, result}, state), do: %{state | result: result}
+
+  defp handle({:DOWN, ref, :process, _pid, reason}, %{caller_ref: ref} = state) do
+    result = if reason == :normal, do: state.result, else: {:error, inspect(reason)}
+    %{state | caller_down: true, result: result}
+  end
+
+  defp handle(_message, state), do: state
+
+  defp finish_owned(state) do
+    previous = :ets.info(state.table, :size)
+
+    for {pid, _ref} <- :ets.tab2list(state.table) do
+      ref = Process.monitor(pid)
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+      after
+        @timeout -> raise "owned process did not stop: #{inspect(pid)}"
+      end
+    end
+
+    state = fence(state)
+    if :ets.info(state.table, :size) == previous, do: state, else: finish_owned(state)
+  end
+
+  defp observe(state) do
+    owned = :ets.tab2list(state.table) |> Enum.map(&elem(&1, 0))
+    processes = [state.caller | owned]
+
+    infos =
+      Enum.flat_map(processes, fn pid ->
+        case Process.info(pid, [:memory, :total_heap_size, :binary]) do
+          nil -> []
+          info -> [info]
+        end
+      end)
+
+    binaries = infos |> Enum.flat_map(&Keyword.fetch!(&1, :binary))
+    binary_sizes = Map.new(binaries, fn {id, bytes, _refs} -> {id, bytes} end)
+    vm = :erlang.memory()
+
+    values = %{
+      process_memory_bytes: Enum.sum(Enum.map(infos, &Keyword.fetch!(&1, :memory))),
+      process_heap_bytes:
+        Enum.sum(Enum.map(infos, &Keyword.fetch!(&1, :total_heap_size))) *
+          :erlang.system_info(:wordsize),
+      shared_binary_bytes: binary_sizes |> Map.values() |> Enum.sum(),
+      vm_total_bytes: vm[:total],
+      vm_processes_bytes: vm[:processes],
+      vm_binary_bytes: vm[:binary],
+      live_owned: Enum.count(owned, &Process.alive?/1)
+    }
+
+    peaks = Map.merge(state.observed_peak, values, fn _key, old, new -> max(old, new) end)
+    %{state | observations: state.observations + 1, observed_peak: peaks}
+  end
+
+  defp isolated(fun, start \\ fn _pid -> :ok end) do
+    parent = self()
+    tag = make_ref()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        result =
+          try do
+            {:ok, fun.()}
+          rescue
+            error -> {:error, error, __STACKTRACE__}
+          end
+
+        send(parent, {tag, result})
+      end)
+
+    try do
+      start.(pid)
+
+      result =
+        receive do
+          {^tag, result} ->
+            result
+
+          {:DOWN, ^ref, :process, ^pid, reason} ->
+            raise "benchmark process failed: #{inspect(reason)}"
+        after
+          120_000 -> raise "benchmark exceeded the safety limit"
+        end
+
+      receive do
+        {:DOWN, ^ref, :process, ^pid, :normal} -> :ok
+      after
+        @timeout -> raise "benchmark process did not stop"
+      end
+
+      case result do
+        {:ok, value} -> value
+        {:error, error, stacktrace} -> reraise error, stacktrace
+      end
+    after
+      Process.exit(pid, :kill)
+      Process.demonitor(ref, [:flush])
+    end
+  end
+end

--- a/bench/support/report.exs
+++ b/bench/support/report.exs
@@ -1,0 +1,97 @@
+defmodule JidoActionBench.Report do
+  @moduledoc false
+
+  def limitations do
+    [
+      "Timing has no tracing or memory sampling. Setup and result checks are outside each timed interval.",
+      "Caller reductions exclude helpers. Helper reductions and exact memory peaks are unavailable (null).",
+      "Memory peaks are observed maxima at start, callback/pause barriers, and completion. Short-lived allocations can be missed.",
+      "Process heap and process memory include the measured caller and traced descendants. Shared binary bytes deduplicate observed off-heap binary references.",
+      "VM memory includes the observer, supervisor, loaded code, and unrelated activity. It does not establish ownership or leaks.",
+      "Owned starts follow spawn traces from the caller and dedicated Task.Supervisor. Both roots and the observer are excluded from helper counts.",
+      "Cleanup uses trace-delivery barriers and process monitors. Global process-count differences are not used.",
+      "Flat and copied heap sizes exclude off-heap binary payloads; external bytes include the external term representation. Receiver memory includes its process overhead.",
+      "Prepared reuse uses a benchmark-only internal adapter with empty schemas. It omits public target/input validation and graph compilation. It is not a public compiled-graph API.",
+      "Paused-continue timing excludes a fresh Exec.start per sample; its resource run includes start and the paused barrier.",
+      "Comparisons show raw ratios. No speedup claim is valid from these shared-host measurements. Repeat on an idle host with the same environment."
+    ]
+  end
+
+  def markdown(report) do
+    rows =
+      Enum.map(report.cases, fn row ->
+        "| #{row.id} | #{row.timing.wall_ns.median} | #{row.timing.wall_ns.p95} | #{row.resources.owned_process_starts} | #{row.resources.owned_remaining} |"
+      end)
+
+    """
+    # Execution benchmark
+
+    Commit: `#{report.source.commit}`. Runtime source dirty: `#{report.source.runtime_dirty}`.
+    Tool SHA-256: `#{report.source.tool_sha256}`.
+    Profile: `#{report.settings.profile}`. Elixir: `#{report.environment.elixir}`. OTP: `#{report.environment.otp}`.
+    Warm-up: #{report.settings.warmup}. Timing samples per case: #{report.settings.samples}.
+    See the JSON report for raw samples, reductions, term sizes, memory, and full machine data.
+
+    | Case | Median ns | p95 ns | Helper starts | Remaining |
+    | --- | ---: | ---: | ---: | ---: |
+    #{Enum.join(rows, "\n")}
+
+    ## Measurement limits
+
+    #{Enum.map_join(limitations(), "\n", &("- " <> &1))}
+    """
+  end
+
+  def compare!(before, after_report) do
+    for field <- ["schema_version", "environment", "settings"] do
+      if Map.fetch!(before, field) != Map.fetch!(after_report, field) do
+        raise ArgumentError, "reports have different #{field} values"
+      end
+    end
+
+    old = index!(before)
+    new = index!(after_report)
+
+    if Enum.sort(Map.keys(old)) != Enum.sort(Map.keys(new)),
+      do: raise(ArgumentError, "reports have different case sets")
+
+    rows =
+      for id <- Enum.sort(Map.keys(old)) do
+        a = old[id]
+        b = new[id]
+        median_a = a["timing"]["wall_ns"]["median"]
+        median_b = b["timing"]["wall_ns"]["median"]
+
+        ratio =
+          if median_a == 0,
+            do: "unavailable",
+            else: :erlang.float_to_binary(median_b / median_a, decimals: 3)
+
+        "| #{id} | #{median_a} | #{median_b} | #{ratio} | #{a["resources"]["owned_process_starts"]} → #{b["resources"]["owned_process_starts"]} | #{b["resources"]["owned_remaining"]} |"
+      end
+
+    """
+    # Execution benchmark comparison
+
+    Before: `#{get_in(before, ["source", "commit"])}`.
+    After: `#{get_in(after_report, ["source", "commit"])}`.
+    Ratio is after / before. No speedup claim is made. Environment and settings match.
+    Check tool hashes and runtime source state in both JSON files before using these ratios.
+
+    | Case | Before median ns | After median ns | Ratio | Helper starts | After remaining |
+    | --- | ---: | ---: | ---: | ---: | ---: |
+    #{Enum.join(rows, "\n")}
+
+    ## Measurement limits
+
+    #{Enum.map_join(limitations(), "\n", &("- " <> &1))}
+    """
+  end
+
+  defp index!(report) do
+    rows = Map.fetch!(report, "cases")
+    indexed = Map.new(rows, &{Map.fetch!(&1, "id"), &1})
+    if map_size(indexed) != length(rows), do: raise(ArgumentError, "duplicate case IDs")
+    indexed
+  end
+end

--- a/bench/support/report.exs
+++ b/bench/support/report.exs
@@ -9,7 +9,7 @@ defmodule JidoActionBench.Report do
       "Process heap and process memory include the measured caller and traced descendants. Shared binary bytes deduplicate observed off-heap binary references.",
       "VM memory includes the observer, supervisor, loaded code, and unrelated activity. It does not establish ownership or leaks.",
       "Owned starts follow spawn traces from the caller and dedicated Task.Supervisor. Both roots and the observer are excluded from helper counts.",
-      "Cleanup uses trace-delivery barriers and process monitors. Global process-count differences are not used.",
+      "Cleanup uses trace-delivery barriers and process monitors. Failed probes stop and confirm observed descendants before returning the failure. Global process-count differences are not used.",
       "Flat and copied heap sizes exclude off-heap binary payloads; external bytes include the external term representation. Receiver memory includes its process overhead.",
       "Prepared reuse uses a benchmark-only internal adapter with empty schemas. It omits public target/input validation and graph compilation. It is not a public compiled-graph API.",
       "Paused-continue timing excludes a fresh Exec.start per sample; its resource run includes start and the paused barrier.",
@@ -43,11 +43,16 @@ defmodule JidoActionBench.Report do
   end
 
   def compare!(before, after_report) do
-    for field <- ["schema_version", "environment", "settings"] do
+    for field <- ["schema_version", "environment", "settings", "method"] do
       if Map.fetch!(before, field) != Map.fetch!(after_report, field) do
         raise ArgumentError, "reports have different #{field} values"
       end
     end
+
+    tool_hash = get_in(before, ["source", "tool_sha256"])
+
+    if not is_binary(tool_hash) or tool_hash != get_in(after_report, ["source", "tool_sha256"]),
+      do: raise(ArgumentError, "reports have missing or different tool hashes")
 
     old = index!(before)
     new = index!(after_report)
@@ -75,8 +80,8 @@ defmodule JidoActionBench.Report do
 
     Before: `#{get_in(before, ["source", "commit"])}`.
     After: `#{get_in(after_report, ["source", "commit"])}`.
-    Ratio is after / before. No speedup claim is made. Environment and settings match.
-    Check tool hashes and runtime source state in both JSON files before using these ratios.
+    Ratio is after / before. No speedup claim is made. Environment, settings, method, and tool hash match.
+    Check runtime source state in both JSON files before using these ratios.
 
     | Case | Before median ns | After median ns | Ratio | Helper starts | After remaining |
     | --- | ---: | ---: | ---: | ---: | ---: |

--- a/bench/support/suite.exs
+++ b/bench/support/suite.exs
@@ -1,0 +1,185 @@
+Code.require_file("fixtures.exs", __DIR__)
+Code.require_file("measure.exs", __DIR__)
+Code.require_file("report.exs", __DIR__)
+
+defmodule JidoActionBench.Suite do
+  @moduledoc false
+  alias JidoActionBench.{Fixtures, Measure, Report}
+
+  def run(profile) do
+    settings = settings(profile)
+    {:ok, supervisor} = Task.Supervisor.start_link(name: JidoActionBench.TaskSupervisor)
+
+    try do
+      :ok = check_growth!()
+
+      workloads =
+        for count <- settings.sizes,
+            payload <- settings.payloads,
+            workload <- Fixtures.workloads(count, payload) do
+          Map.merge(workload, %{
+            id: "#{workload.name}/#{payload}/#{count}",
+            count: count,
+            payload: payload
+          })
+        end
+
+      # Warm and time every case before any process tracing or term transfer.
+      IO.puts("Timing #{length(workloads)} cases without tracing...")
+
+      timings =
+        Map.new(workloads, fn workload ->
+          {workload.id, Measure.timing(workload, settings.warmup, settings.samples)}
+        end)
+
+      IO.puts("Tracing ownership and sampling memory in separate calls...")
+
+      cases =
+        Enum.map(workloads, fn workload ->
+          %{
+            id: workload.id,
+            timing: Map.fetch!(timings, workload.id),
+            resources: Measure.resources(workload),
+            retained_term: Measure.term_size(workload.retained)
+          }
+        end)
+
+      %{
+        schema_version: 1,
+        source: source(),
+        environment: environment(),
+        settings: settings,
+        recorded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
+        method:
+          "untraced monotonic clock; caller reductions; separate traced barrier samples; monitored term transfer",
+        limitations: Report.limitations(),
+        growth_check: "passed: compiled serial, parallel, and Subflow graphs at sizes 2 and 6",
+        cases: cases
+      }
+    after
+      Supervisor.stop(supervisor)
+    end
+  end
+
+  def write!(report, directory) do
+    File.mkdir_p!(directory)
+    File.write!(Path.join(directory, "report.json"), JSON.encode!(report))
+    File.write!(Path.join(directory, "report.md"), Report.markdown(report))
+  end
+
+  def check_growth! do
+    for shape <- [:serial, :parallel, :subflows] do
+      [small, large] =
+        for count <- [2, 6] do
+          {:ok, compiled} = Jido.Flow.compile(Fixtures.graph(shape, count))
+          # This bound accompanies the broader merged capture regressions, which
+          # the documented smoke command runs without changing their fixtures.
+          bytes = :erts_debug.flat_size(compiled) * :erlang.system_info(:wordsize)
+          if bytes > 64 * 1_048_576, do: raise("compiled graph exceeds the safe transfer bound")
+          copied = Measure.term_size(compiled)
+          if copied.copied_flat_heap_bytes != bytes, do: raise("copied graph size differs")
+          bytes
+        end
+
+      if large >= small * 4, do: raise("#{shape} graph copy growth exceeds the bound")
+    end
+
+    :ok
+  end
+
+  defp settings("short"),
+    do: %{
+      profile: "short",
+      sizes: [4],
+      payloads: [:small, :large_map, :large_binary],
+      warmup: 3,
+      samples: 15,
+      resource_samples: 1
+    }
+
+  defp settings("scale"),
+    do: %{
+      profile: "scale",
+      sizes: [2, 8, 16],
+      payloads: [:small, :large_map, :large_binary],
+      warmup: 5,
+      samples: 30,
+      resource_samples: 1
+    }
+
+  defp settings("smoke"),
+    do: %{
+      profile: "smoke",
+      sizes: [2, 6],
+      payloads: [:small],
+      warmup: 1,
+      samples: 2,
+      resource_samples: 1
+    }
+
+  defp settings(_), do: raise(ArgumentError, "profile must be short, scale, or smoke")
+
+  defp source do
+    files = Path.wildcard(Path.expand("../**/*.exs", __DIR__)) |> Enum.sort()
+    tool_sha = files |> Enum.map(&File.read!/1) |> hash()
+
+    %{
+      commit: command("git", ["rev-parse", "HEAD"]),
+      runtime_dirty:
+        command("git", ["status", "--porcelain", "--", "lib", "config", "mix.exs", "mix.lock"]) !=
+          "",
+      checkout_dirty: command("git", ["status", "--porcelain"]) != "",
+      tool_sha256: tool_sha
+    }
+  end
+
+  defp environment do
+    %{
+      elixir: System.version(),
+      otp: :erlang.system_info(:otp_release) |> List.to_string(),
+      erts: :erlang.system_info(:system_version) |> List.to_string() |> String.trim(),
+      os: command("uname", ["-srv"]),
+      architecture: :erlang.system_info(:system_architecture) |> List.to_string(),
+      cpu: cpu(),
+      hostname: command("hostname", []),
+      word_size: :erlang.system_info(:wordsize),
+      schedulers: :erlang.system_info(:schedulers),
+      schedulers_online: :erlang.system_info(:schedulers_online),
+      logical_processors: :erlang.system_info(:logical_processors_available),
+      mix_env: to_string(Mix.env()),
+      dependency_lock_sha256: File.read!("mix.lock") |> hash()
+    }
+  end
+
+  defp cpu do
+    case :os.type() do
+      {:unix, :darwin} ->
+        command("sysctl", ["-n", "machdep.cpu.brand_string"])
+
+      {:unix, :linux} ->
+        case File.read("/proc/cpuinfo") do
+          {:ok, text} ->
+            text
+            |> String.split("\n")
+            |> Enum.find("unavailable", &String.starts_with?(&1, "model name"))
+
+          _ ->
+            "unavailable"
+        end
+
+      _ ->
+        "unavailable"
+    end
+  end
+
+  defp command(executable, args) do
+    case System.cmd(executable, args, stderr_to_stdout: true) do
+      {output, 0} -> String.trim(output)
+      _ -> "unavailable"
+    end
+  rescue
+    _ -> "unavailable"
+  end
+
+  defp hash(data), do: :crypto.hash(:sha256, data) |> Base.encode16(case: :lower)
+end

--- a/bench/support/suite.exs
+++ b/bench/support/suite.exs
@@ -24,7 +24,8 @@ defmodule JidoActionBench.Suite do
           })
         end
 
-      # Warm and time every case before any process tracing or term transfer.
+      # The untimed growth preflight is complete. Time every workload before
+      # its traced resource run and retained-term transfer probe.
       IO.puts("Timing #{length(workloads)} cases without tracing...")
 
       timings =

--- a/guides/benchmarks.md
+++ b/guides/benchmarks.md
@@ -1,131 +1,67 @@
 # Execution Benchmarks
 
-Use these development tools to compare execution cost before a runtime change.
-The tools do not change the package API. No downstream migration is required.
-They need Elixir 1.18 or later, a supported OTP release, Git, and the development
-dependencies in `mix.lock`. No profiler or extra dependency is required.
-
-Run commands from the package root. Keep the scheduler count, runtime, machine,
-Mix environment, and benchmark source the same for a comparison.
+Run from the package root with Elixir 1.18 or later and the development
+dependencies from `mix.lock`:
 
 ```bash
-mix deps.get
 ERL_FLAGS='+S 2:2' mix run bench/run.exs --output bench/results/before
 ```
 
-The default `short` profile runs 57 cases: 4 nodes, 3 warm-up calls, and 15 timing
-samples per case. It takes one separate resource sample per case. To run the
-larger, bounded profile:
+Each run writes `report.json` and `report.md`. Reports under `bench/results/`
+are ignored by Git.
 
-```bash
-ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile scale --output bench/results/scale
-```
+| Profile | Cases | Graph sizes | Warm-up calls | Timing samples |
+| --- | ---: | --- | ---: | ---: |
+| `short` (default) | 57 | 4 | 3 | 15 |
+| `scale` | 171 | 2, 8, 16 | 5 | 30 |
+| `smoke` | 38 | 2, 6 | 1 | 2 |
 
-The `scale` profile uses 2, 8, and 16 nodes, 5 warm-up calls, and 30 timing samples.
-Fixtures reject graph sizes outside 1 through 32. Term transfer stops if the
-estimated flat heap exceeds 64 MiB. Run larger workloads only after you review
-the smaller results. A safety timeout fails a stuck probe; it is not a speed
-threshold.
+Select a profile with `--profile scale` or `--profile smoke`. Short and scale
+use small data, a 1,000-entry map, and a 1 MiB binary. Smoke uses small data.
+Each case also takes one separate resource sample. Fixtures allow 1–32 nodes;
+a transfer probe rejects a flat heap above 64 MiB.
 
-## Workloads And Boundaries
+## What Is Measured
 
-All workloads use the same deterministic echo Action and have no network work.
-Each accepted warm-up, timing sample, and resource sample must return the
-expected result. Each Flow output contains every authored node result.
+The Action cases cover a direct callback, Exec, a finite complete-call timeout,
+and async start/await. Serial, parallel, and repeated Subflow graphs each
+measure validation, compilation, complete execution, compiled-graph reuse,
+and continuation of a paused execution. Every sample must return the expected
+result. The Actions perform no network work.
 
-| Workload | Measured operation |
+Compilation includes validation. The internal compiled-graph adapter omits
+public target/input validation and creates a fresh execution each time. It is
+not a public cache API. Paused-continue setup is outside the timing boundary;
+resource measurements include setup.
+
+Timing samples run without tracing. The clock covers the operation only;
+setup and result checks are outside it. Reports include raw samples and
+summary statistics. Caller reductions exclude work in helper processes.
+
+Resource samples use a separate caller and Task.Supervisor. Spawn tracing
+follows their descendants. Callback and trace-delivery barriers establish
+sampling points; process monitors confirm cleanup, including after a failed
+probe. Reports separate these quantities:
+
+| Metric | Meaning |
 | --- | --- |
-| `action/direct` | Direct `run/2` callback; no Exec validation or lifecycle. |
-| `action/run` | `Jido.Exec.run/4` with the default infinite timeout. |
-| `action/finite_timeout` | `Jido.Exec.run/4` with a 30-second complete-call limit. |
-| `action/async_await` | Start an async call and await it in its owner process. |
-| `serial/*` | A chain of result dependencies, concurrency 1. |
-| `parallel/*` | Independent Steps, concurrency 4. |
-| `subflows/*` | Repeated instances of the same one-Step child Flow, concurrency 4. |
+| Process memory and heap | Sum across the observed caller and helpers. |
+| Shared binary bytes | Unique observed off-heap references; ownership can be shared. |
+| VM memory | Whole-VM use, including unrelated work and measurement tools. |
+| Observed peak | Largest barrier sample; short allocations can be missed. |
+| Local and flat term heap | Heap with and without local sharing; excludes binary payloads. |
+| Copied term heap and receiver memory | Measured after an actual process transfer. |
+| External bytes | External term encoding size, not message-copy cost. |
 
-Every Flow shape has five separate measurements:
+Exact memory peaks and total helper reductions are unavailable. Reports mark
+these fields as null and record runtime, machine, commit, tool hash, lockfile
+hash, sample settings, and measurement limits.
 
-- `validate`: `Jido.Flow.validate_executable/1`.
-- `compile`: `Jido.Flow.compile/1`, which also validates. It is not a pure compiler-only measurement.
-- `run`: the complete public `Jido.Exec.run/4` call, including preparation.
-- `prepared_reuse`: reuse one compiled graph with fresh execution state per call.
-- `paused_continue`: call `continue/1` on a fresh paused execution created outside the timer.
+## Compare Runs
 
-There is no public API that runs a compiled graph. The `prepared_reuse` case
-uses an internal adapter for these empty-schema fixtures. It uses the normal
-engine and target runner, but omits public target/input validation and graph
-compilation. It is a lower-level comparison, not a promised API or cache. The
-adapter must be checked when internal interfaces change. It never reuses an
-Execution revision or replaces the revision guard.
-
-The input value is either an integer, a map with 1,000 integer entries, or a
-1 MiB binary. The same values pass through all call paths. A Flow holds all
-node results until completion. Retained-term measurements include the input,
-Flow, and compiled graph for Flow cases; Action cases include their input.
-
-## Measurement Method
-
-The runner warms every case and completes all timing runs before resource
-tracing starts. Loaded fixture modules and warm calls preload execution paths.
-Each timing case runs in its own monitored caller process. Samples for that case
-share the caller and its natural garbage collection. The monotonic clock covers
-only the measured operation. Setup and result assertions are outside the timer.
-Raw samples, minimum, upper median, mean, p95, and maximum are in the JSON file.
-Caller reduction counts exclude work in other processes.
-
-Resource runs use a separate caller and a dedicated Task.Supervisor. Fixtures
-pass `task_supervisor: JidoActionBench.TaskSupervisor` to Exec. Spawn
-tracing follows both roots and their descendants. The roots and observer do not
-count as helper starts. Workers stop at explicit callback barriers. The observer
-uses a trace-delivery barrier, samples memory, then releases each worker. A paused
-case also has a barrier after `start/4`. Completion uses process monitors and
-another trace barrier, including helpers that start during cleanup. If a probe
-fails, it stops the caller and observed descendants, confirms their termination,
-and then returns the failure. It does not first wait for normal helper completion.
-No sleep or
-global process-count difference establishes cleanup.
-
-Resource runs include setup. Their memory data does not have the same boundary
-as paused-continue timing. The following metrics have different meanings:
-
-| Metric | Meaning and limit |
-| --- | --- |
-| Process memory | Sum of observed caller and helper `Process.info(:memory)` values. Includes process overhead. |
-| Process heap | Sum of observed `total_heap_size` values, in bytes. |
-| Shared binary memory | Bytes in unique observed off-heap binary references. Binaries shared outside the execution are not exclusively owned. |
-| VM memory | Whole-VM total, process, and binary memory. Includes tools and unrelated work. |
-| Observed peak | Largest sampled value at start, callback/pause barriers, and completion. Short allocations can be missed. Different metric maxima can occur at different samples. |
-| Local term heap | `:erts_debug.size(term)` times word size, with local sharing. |
-| Flat term heap | `:erts_debug.flat_size(term)` times word size, without sharing. Excludes off-heap binary payloads. |
-| Copied term heap | Flat heap size in a monitored receiver after an actual message transfer. |
-| External bytes | `:erlang.external_size/1`; includes the external term representation, not actual message-copy cost. |
-| Receiver memory | Receiver process memory after transfer, including overhead. |
-
-Exact memory peaks and complete helper reduction totals are unavailable and
-have explicit `null` fields. Results include the commit, source state, tool
-hash, dependency lock hash, Elixir, OTP/ERTS, OS, CPU, architecture, word size,
-schedulers, warm-up count, sample count, method, and measurement limits.
-
-## Save And Compare Results
-
-Each command writes `report.json` and `report.md`. Generated reports are ignored
-under `bench/results/`. Keep machine-specific results with review evidence,
-outside ordinary source commits.
-
-Record the initial runtime baseline at commit
-`99cebd3f2ebc1137ae8fefb84c8292b1064de8e1`. To measure an older revision, use a
-separate checkout of that revision with its own build and dependencies. Run the
-same benchmark scripts by absolute path from that checkout. The scripts report
-the current working checkout as the measured source and hash their own source.
-Do not change the runtime and benchmark tools in the same comparison.
-
-The historical baseline uses the scripts at
-`2f42eef1fd547bcddfc33a0a3068e4150c6a1331`, which pass the former `jido:` option.
-Current scripts require the explicit supervisor API from #237. Keep the original
-baseline reports and scripts. Their tool hash differs from the current tools,
-so the comparison command rejects ratios between those report sets.
-
-After the candidate change, repeat the same profile and output to another path:
+Repeat the same profile on the same idle host and runtime. Use separate
+checkouts with separate builds when comparing revisions. Keep the benchmark
+scripts unchanged; they can be run by absolute path from another checkout.
 
 ```bash
 ERL_FLAGS='+S 2:2' mix run bench/run.exs --output bench/results/after
@@ -134,28 +70,11 @@ ERL_FLAGS='+S 2:2' mix run bench/compare.exs \
   bench/results/comparison.md
 ```
 
-The comparison joins case IDs and rejects different environments, settings,
-methods, tool hashes, or case sets. Inspect the runtime source state too. A ratio is candidate
-median divided by baseline median. A smaller number alone does not prove a
-speedup. Shared-host load, CPU frequency, scheduling, and garbage collection
-can change timing. Repeat reports on an idle host before making a performance
-claim. CI has no fixed wall-time pass threshold.
+Comparison requires matching environments, settings, methods, tool hashes,
+and case IDs. A ratio is the candidate median divided by the baseline median.
+Host load and garbage collection can change results; repeat measurements
+before making a performance claim. CI has no fixed timing threshold.
 
-## Smoke Check And Deferred Work
-
-```bash
-ERL_FLAGS='+S 2:2' mix test test/bench/execution_bench_test.exs \
-  test/jido_exec/runnable_capture_test.exs test/jido_flow/compiler/capture_test.exs
-ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile smoke
-```
-
-The `smoke` profile uses small input, sizes 2 and 6, one warm-up call, and two
-timing samples. It checks results, monitored cleanup, actual graph transfer,
-and bounded graph-copy growth. CI runs it after the full coverage suite on the
-supported runtime matrix. The merged compiler-capture and runnable-capture
-regressions remain unchanged in that suite.
-
-Map, Reduce, Iterate, continuations, concurrent callers, and detailed failures
-are deferred. This first stage does not measure durable execution, saturation,
-production capacity, or exact allocation totals. It does not redesign execution
-ownership, cancellation, or revision guards.
+The smoke profile runs in CI and checks results, cleanup, graph transfer, and
+bounded copy growth. The suite does not yet cover Map, Reduce, Iterate,
+continuations, concurrent callers, or a complete failure matrix.

--- a/guides/benchmarks.md
+++ b/guides/benchmarks.md
@@ -1,0 +1,151 @@
+# Execution Benchmarks
+
+Use these development tools to compare execution cost before a runtime change.
+The tools do not change the package API. No downstream migration is required.
+They need Elixir 1.18 or later, a supported OTP release, Git, and the development
+dependencies in `mix.lock`. No profiler or extra dependency is required.
+
+Run commands from the package root. Keep the scheduler count, runtime, machine,
+Mix environment, and benchmark source the same for a comparison.
+
+```bash
+mix deps.get
+ERL_FLAGS='+S 2:2' mix run bench/run.exs --output bench/results/before
+```
+
+The default `short` profile runs 57 cases: 4 nodes, 3 warm-up calls, and 15 timing
+samples per case. It takes one separate resource sample per case. To run the
+larger, bounded profile:
+
+```bash
+ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile scale --output bench/results/scale
+```
+
+The `scale` profile uses 2, 8, and 16 nodes, 5 warm-up calls, and 30 timing samples.
+Fixtures reject graph sizes outside 1 through 32. Term transfer stops if the
+estimated flat heap exceeds 64 MiB. Run larger workloads only after you review
+the smaller results. A safety timeout fails a stuck probe; it is not a speed
+threshold.
+
+## Workloads And Boundaries
+
+All workloads use the same deterministic echo Action and have no network work.
+Each accepted warm-up, timing sample, and resource sample must return the
+expected result. Each Flow output contains every authored node result.
+
+| Workload | Measured operation |
+| --- | --- |
+| `action/direct` | Direct `run/2` callback; no Exec validation or lifecycle. |
+| `action/run` | `Jido.Exec.run/4` with the default infinite timeout. |
+| `action/finite_timeout` | `Jido.Exec.run/4` with a 30-second complete-call limit. |
+| `action/async_await` | Start an async call and await it in its owner process. |
+| `serial/*` | A chain of result dependencies, concurrency 1. |
+| `parallel/*` | Independent Steps, concurrency 4. |
+| `subflows/*` | Repeated instances of the same one-Step child Flow, concurrency 4. |
+
+Every Flow shape has five separate measurements:
+
+- `validate`: `Jido.Flow.validate_executable/1`.
+- `compile`: `Jido.Flow.compile/1`, which also validates. It is not a pure compiler-only measurement.
+- `run`: the complete public `Jido.Exec.run/4` call, including preparation.
+- `prepared_reuse`: reuse one compiled graph with fresh execution state per call.
+- `paused_continue`: call `continue/1` on a fresh paused execution created outside the timer.
+
+There is no public API that runs a compiled graph. The `prepared_reuse` case
+uses an internal adapter for these empty-schema fixtures. It uses the normal
+engine and target runner, but omits public target/input validation and graph
+compilation. It is a lower-level comparison, not a promised API or cache. The
+adapter must be checked when internal interfaces change. It never reuses an
+Execution revision or replaces the revision guard.
+
+The input value is either an integer, a map with 1,000 integer entries, or a
+1 MiB binary. The same values pass through all call paths. A Flow holds all
+node results until completion. Retained-term measurements include the input,
+Flow, and compiled graph for Flow cases; Action cases include their input.
+
+## Measurement Method
+
+The runner warms every case and completes all timing runs before resource
+tracing starts. Loaded fixture modules and warm calls preload execution paths.
+Each timing case runs in its own monitored caller process. Samples for that case
+share the caller and its natural garbage collection. The monotonic clock covers
+only the measured operation. Setup and result assertions are outside the timer.
+Raw samples, minimum, upper median, mean, p95, and maximum are in the JSON file.
+Caller reduction counts exclude work in other processes.
+
+Resource runs use a separate caller and a dedicated Task.Supervisor. Spawn
+tracing follows both roots and their descendants. The roots and observer do not
+count as helper starts. Workers stop at explicit callback barriers. The observer
+uses a trace-delivery barrier, samples memory, then releases each worker. A paused
+case also has a barrier after `start/4`. Completion uses process monitors and
+another trace barrier, including helpers that start during cleanup. No sleep or
+global process-count difference establishes cleanup.
+
+Resource runs include setup. Their memory data does not have the same boundary
+as paused-continue timing. The following metrics have different meanings:
+
+| Metric | Meaning and limit |
+| --- | --- |
+| Process memory | Sum of observed caller and helper `Process.info(:memory)` values. Includes process overhead. |
+| Process heap | Sum of observed `total_heap_size` values, in bytes. |
+| Shared binary memory | Bytes in unique observed off-heap binary references. Binaries shared outside the execution are not exclusively owned. |
+| VM memory | Whole-VM total, process, and binary memory. Includes tools and unrelated work. |
+| Observed peak | Largest sampled value at start, callback/pause barriers, and completion. Short allocations can be missed. Different metric maxima can occur at different samples. |
+| Local term heap | `:erts_debug.size(term)` times word size, with local sharing. |
+| Flat term heap | `:erts_debug.flat_size(term)` times word size, without sharing. Excludes off-heap binary payloads. |
+| Copied term heap | Flat heap size in a monitored receiver after an actual message transfer. |
+| External bytes | `:erlang.external_size/1`; includes the external term representation, not actual message-copy cost. |
+| Receiver memory | Receiver process memory after transfer, including overhead. |
+
+Exact memory peaks and complete helper reduction totals are unavailable and
+have explicit `null` fields. Results include the commit, source state, tool
+hash, dependency lock hash, Elixir, OTP/ERTS, OS, CPU, architecture, word size,
+schedulers, warm-up count, sample count, method, and measurement limits.
+
+## Save And Compare Results
+
+Each command writes `report.json` and `report.md`. Generated reports are ignored
+under `bench/results/`. Keep machine-specific results with review evidence,
+outside ordinary source commits.
+
+Record the initial runtime baseline at commit
+`99cebd3f2ebc1137ae8fefb84c8292b1064de8e1`. To measure an older revision, use a
+separate checkout of that revision with its own build and dependencies. Run the
+same benchmark scripts by absolute path from that checkout. The scripts report
+the current working checkout as the measured source and hash their own source.
+Do not change the runtime and benchmark tools in the same comparison.
+
+After the candidate change, repeat the same profile and output to another path:
+
+```bash
+ERL_FLAGS='+S 2:2' mix run bench/run.exs --output bench/results/after
+ERL_FLAGS='+S 2:2' mix run bench/compare.exs \
+  bench/results/before/report.json bench/results/after/report.json \
+  bench/results/comparison.md
+```
+
+The comparison joins case IDs and rejects different environments, settings, or
+case sets. Inspect the source state and tool hashes too. A ratio is candidate
+median divided by baseline median. A smaller number alone does not prove a
+speedup. Shared-host load, CPU frequency, scheduling, and garbage collection
+can change timing. Repeat reports on an idle host before making a performance
+claim. CI has no fixed wall-time pass threshold.
+
+## Smoke Check And Deferred Work
+
+```bash
+ERL_FLAGS='+S 2:2' mix test test/bench/execution_bench_test.exs \
+  test/jido_exec/runnable_capture_test.exs test/jido_flow/compiler/capture_test.exs
+ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile smoke
+```
+
+The `smoke` profile uses small input, sizes 2 and 6, one warm-up call, and two
+timing samples. It checks results, monitored cleanup, actual graph transfer,
+and bounded graph-copy growth. CI runs it after the full coverage suite on the
+supported runtime matrix. The merged compiler-capture and runnable-capture
+regressions remain unchanged in that suite.
+
+Map, Reduce, Iterate, continuations, concurrent callers, and detailed failures
+are deferred. This first stage does not measure durable execution, saturation,
+production capacity, or exact allocation totals. It does not redesign execution
+ownership, cancellation, or revision guards.

--- a/guides/benchmarks.md
+++ b/guides/benchmarks.md
@@ -73,12 +73,16 @@ only the measured operation. Setup and result assertions are outside the timer.
 Raw samples, minimum, upper median, mean, p95, and maximum are in the JSON file.
 Caller reduction counts exclude work in other processes.
 
-Resource runs use a separate caller and a dedicated Task.Supervisor. Spawn
+Resource runs use a separate caller and a dedicated Task.Supervisor. Fixtures
+pass `task_supervisor: JidoActionBench.TaskSupervisor` to Exec. Spawn
 tracing follows both roots and their descendants. The roots and observer do not
 count as helper starts. Workers stop at explicit callback barriers. The observer
 uses a trace-delivery barrier, samples memory, then releases each worker. A paused
 case also has a barrier after `start/4`. Completion uses process monitors and
-another trace barrier, including helpers that start during cleanup. No sleep or
+another trace barrier, including helpers that start during cleanup. If a probe
+fails, it stops the caller and observed descendants, confirms their termination,
+and then returns the failure. It does not first wait for normal helper completion.
+No sleep or
 global process-count difference establishes cleanup.
 
 Resource runs include setup. Their memory data does not have the same boundary
@@ -115,6 +119,12 @@ same benchmark scripts by absolute path from that checkout. The scripts report
 the current working checkout as the measured source and hash their own source.
 Do not change the runtime and benchmark tools in the same comparison.
 
+The historical baseline uses the scripts at
+`2f42eef1fd547bcddfc33a0a3068e4150c6a1331`, which pass the former `jido:` option.
+Current scripts require the explicit supervisor API from #237. Keep the original
+baseline reports and scripts. Their tool hash differs from the current tools,
+so the comparison command rejects ratios between those report sets.
+
 After the candidate change, repeat the same profile and output to another path:
 
 ```bash
@@ -124,8 +134,8 @@ ERL_FLAGS='+S 2:2' mix run bench/compare.exs \
   bench/results/comparison.md
 ```
 
-The comparison joins case IDs and rejects different environments, settings, or
-case sets. Inspect the source state and tool hashes too. A ratio is candidate
+The comparison joins case IDs and rejects different environments, settings,
+methods, tool hashes, or case sets. Inspect the runtime source state too. A ratio is candidate
 median divided by baseline median. A smaller number alone does not prove a
 speedup. Shared-host load, CPU frequency, scheduling, and garbage collection
 can change timing. Repeat reports on an idle host before making a performance

--- a/mix.exs
+++ b/mix.exs
@@ -113,7 +113,8 @@ defmodule JidoAction.MixProject do
           "guides/debugging-flows.md",
           "guides/configuration.md",
           "guides/security.md",
-          "guides/testing.md"
+          "guides/testing.md",
+          "guides/benchmarks.md"
         ],
         Upgrade: [
           "guides/v2-to-v3-migration.md",
@@ -156,6 +157,7 @@ defmodule JidoAction.MixProject do
         {"guides/configuration.md", title: "Runtime Configuration"},
         {"guides/security.md", title: "Security"},
         {"guides/testing.md", title: "Testing"},
+        {"guides/benchmarks.md", title: "Execution Benchmarks"},
         # Upgrade
         {"guides/v2-to-v3-migration.md", title: "Version 2 To Version 3 Migration"},
         {"guides/v2-to-v3-upgrade-skill.md", title: "Upgrade From v2 To v3 Skill"}

--- a/test/bench/execution_bench_test.exs
+++ b/test/bench/execution_bench_test.exs
@@ -29,6 +29,60 @@ defmodule JidoActionTest.ExecutionBenchTest do
     assert_raise RuntimeError, ~r/resource caller failed/, fn -> Measure.resources(workload) end
   end
 
+  test "a failed probe stops and confirms its waiting child and grandchild" do
+    owner = self()
+    tag = make_ref()
+
+    workload = %{
+      setup: fn _ -> nil end,
+      run: fn _ ->
+        caller = self()
+
+        {:ok, child} =
+          Task.Supervisor.start_child(JidoActionBench.TaskSupervisor, fn ->
+            Process.flag(:trap_exit, true)
+            child = self()
+
+            grandchild =
+              spawn(fn ->
+                Process.flag(:trap_exit, true)
+                send(child, {tag, :ready, self()})
+                receive do: (:release -> :ok)
+              end)
+
+            receive do
+              {^tag, :ready, ^grandchild} -> send(caller, {tag, :ready, child, grandchild})
+            end
+
+            receive do: (:release -> :ok)
+          end)
+
+        receive do
+          {^tag, :ready, ^child, grandchild} -> send(owner, {tag, child, grandchild})
+        end
+
+        :incorrect
+      end,
+      check: fn _ -> raise "probe rejected" end
+    }
+
+    assert_raise RuntimeError, ~r/resource caller failed:.*probe rejected/, fn ->
+      Measure.resources(workload)
+    end
+
+    assert_received {^tag, child, grandchild}
+
+    for pid <- [child, grandchild] do
+      refute Process.alive?(pid)
+      ref = Process.monitor(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :noproc}
+    end
+
+    assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
+    direct = Enum.find(Fixtures.workloads(2, :small), &(&1.name == "action/direct"))
+    assert Measure.resources(direct).owned_process_starts == 0
+  end
+
   test "traced Action helpers belong to the caller and dedicated supervisor" do
     workloads = Fixtures.workloads(2, :small)
     direct = Enum.find(workloads, &(&1.name == "action/direct"))
@@ -36,6 +90,15 @@ defmodule JidoActionTest.ExecutionBenchTest do
     assert Measure.resources(direct).owned_process_starts == 0
     assert Measure.resources(run).owned_process_starts > 0
     assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
+  end
+
+  test "a small shared term cannot bypass the flat copy bound" do
+    shared = Enum.reduce(1..22, :leaf, fn _, child -> {child, child} end)
+    assert :erts_debug.size(shared) < 1_000
+
+    assert_raise RuntimeError, ~r/term transfer exceeds the 64 MiB heap bound/, fn ->
+      Measure.term_size(shared)
+    end
   end
 
   test "copy growth stays bounded for the first-stage graphs" do
@@ -53,6 +116,8 @@ defmodule JidoActionTest.ExecutionBenchTest do
 
     before = %{
       "schema_version" => 1,
+      "source" => %{"tool_sha256" => "same-tool"},
+      "method" => "test-method",
       "environment" => %{"otp" => "29"},
       "settings" => %{"samples" => 2},
       "cases" => [row]
@@ -64,6 +129,14 @@ defmodule JidoActionTest.ExecutionBenchTest do
 
     assert_raise ArgumentError, ~r/environment/, fn ->
       Report.compare!(before, put_in(after_report, ["environment", "otp"], "28"))
+    end
+
+    assert_raise ArgumentError, ~r/tool/, fn ->
+      Report.compare!(before, put_in(after_report, ["source", "tool_sha256"], "changed-tool"))
+    end
+
+    assert_raise ArgumentError, ~r/method/, fn ->
+      Report.compare!(before, put_in(after_report, ["method"], "changed-method"))
     end
 
     assert_raise ArgumentError, ~r/case/, fn ->

--- a/test/bench/execution_bench_test.exs
+++ b/test/bench/execution_bench_test.exs
@@ -1,0 +1,73 @@
+Code.require_file("../../bench/support/suite.exs", __DIR__)
+
+defmodule JidoActionTest.ExecutionBenchTest do
+  use ExUnit.Case, async: false
+
+  alias JidoActionBench.{Fixtures, Measure, Report, Suite}
+
+  setup do
+    start_supervised!({Task.Supervisor, name: JidoActionBench.TaskSupervisor})
+    :ok
+  end
+
+  test "every first-stage workload checks its result in timing and resource runs" do
+    for payload <- [:small, :large_map, :large_binary],
+        workload <- Fixtures.workloads(2, payload) do
+      timing = Measure.timing(workload, 1, 2)
+      assert length(timing.wall_ns.samples) == 2
+      assert timing.caller_reductions.min >= 0
+      resources = Measure.resources(workload)
+      assert resources.owned_remaining == 0
+      assert resources.observations > 0
+      assert resources.observed_peak.process_memory_bytes > 0
+    end
+  end
+
+  test "incorrect results cannot be accepted as measurements" do
+    workload = %{setup: fn _ -> nil end, run: fn _ -> :wrong end, check: fn :right -> :ok end}
+    assert_raise FunctionClauseError, fn -> Measure.timing(workload, 1, 1) end
+    assert_raise RuntimeError, ~r/resource caller failed/, fn -> Measure.resources(workload) end
+  end
+
+  test "traced Action helpers belong to the caller and dedicated supervisor" do
+    workloads = Fixtures.workloads(2, :small)
+    direct = Enum.find(workloads, &(&1.name == "action/direct"))
+    run = Enum.find(workloads, &(&1.name == "action/run"))
+    assert Measure.resources(direct).owned_process_starts == 0
+    assert Measure.resources(run).owned_process_starts > 0
+    assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
+  end
+
+  test "copy growth stays bounded for the first-stage graphs" do
+    assert :ok == Suite.check_growth!()
+    assert_raise ArgumentError, fn -> Fixtures.workloads(33, :small) end
+    assert_raise ArgumentError, fn -> Fixtures.workloads(0, :small) end
+  end
+
+  test "comparison joins case identities and rejects incompatible measurements" do
+    row = %{
+      "id" => "action/run/small/2",
+      "timing" => %{"wall_ns" => %{"median" => 100}},
+      "resources" => %{"owned_process_starts" => 2, "owned_remaining" => 0}
+    }
+
+    before = %{
+      "schema_version" => 1,
+      "environment" => %{"otp" => "29"},
+      "settings" => %{"samples" => 2},
+      "cases" => [row]
+    }
+
+    after_report = put_in(before, ["cases"], [put_in(row, ["timing", "wall_ns", "median"], 120)])
+    assert Report.compare!(before, after_report) =~ "1.200"
+    assert Report.compare!(before, after_report) =~ "No speedup claim"
+
+    assert_raise ArgumentError, ~r/environment/, fn ->
+      Report.compare!(before, put_in(after_report, ["environment", "otp"], "28"))
+    end
+
+    assert_raise ArgumentError, ~r/case/, fn ->
+      Report.compare!(before, %{after_report | "cases" => []})
+    end
+  end
+end


### PR DESCRIPTION
Add repeatable execution benchmarks for Action calls and serial, parallel, and nested Flow graphs. Separate timing from resource probes. Record process counts, memory samples, term transfer cost, runtime details, and cleanup results.

The suite provides smoke, short, and scale profiles, JSON/Markdown reports, and a comparison command. It checks expected results and bounds copy growth. Measurements state their limits; CI has no fixed timing threshold. The guide contains the commands and measurement rules in one place.

Validation: the combined suite passed with 94.89% coverage and `mix quality`. All 38 smoke cases passed, and the dependency audit found no vulnerabilities. PR CI checks each supported runtime pair.

Closes #235.
