### PR TITLE
feat(exec)!: accept explicit Task.Supervisor references

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ representation, compilation, and Flow semantics. Jido Exec owns one in-memory
 execution session: step-wise execution, bounded concurrency, Action invocation,
 errors, telemetry, and final results.
 
-Use `task_supervisor: reference` to select a local Task.Supervisor PID, name,
-or via route. The default is `Jido.Exec.TaskSupervisor`. See the
-[supervision examples and beta migration](guides/configuration.md#task-supervisor-references).
-
 Durable orchestration is not provided. An outer system must own persistence,
 queues, scheduling, recovery, retries, durable cancellation policy,
 distributed coordination, supervision, and deployment-safe continuation.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ representation, compilation, and Flow semantics. Jido Exec owns one in-memory
 execution session: step-wise execution, bounded concurrency, Action invocation,
 errors, telemetry, and final results.
 
+Use `task_supervisor: reference` to select a local Task.Supervisor PID, name,
+or via route. The default is `Jido.Exec.TaskSupervisor`. See the
+[supervision examples and beta migration](guides/configuration.md#task-supervisor-references).
+
 Durable orchestration is not provided. An outer system must own persistence,
 queues, scheduling, recovery, retries, durable cancellation policy,
 distributed coordination, supervision, and deployment-safe continuation.

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -51,121 +51,47 @@ rules of its target. The removed Flow `async:` option is an unknown option.
 
 ## Task Supervisor References
 
-Pass the supervisor reference directly. The host owns its name, capacity, and
-shutdown policy. Exec does not derive a name or create routing atoms.
+The host owns the Task.Supervisor, its capacity, and its shutdown policy.
+Pass a local PID, registered name, or `{:via, module, name}` reference. Omit
+`task_supervisor` to use `Jido.Exec.TaskSupervisor`.
 
 ```elixir
-children = [
-  {Task.Supervisor, name: MyApp.ReportTasks, max_children: 1_000}
-]
-
-# Add these children to the host application supervision tree.
-Supervisor.start_link(children, strategy: :one_for_one)
+# Add this child to the application supervision tree.
+{Task.Supervisor, name: MyApp.ReportTasks, max_children: 1_000}
 
 Jido.Exec.run(MyApp.Flows.BuildReport, input, context,
-  task_supervisor: MyApp.ReportTasks,
-  max_concurrency: 4
+  task_supervisor: MyApp.ReportTasks
 )
 ```
 
-An unnamed supervisor is also valid:
+For partitioned supervision, start a PartitionSupervisor with Task.Supervisor
+children and pass a route selected by the caller:
 
 ```elixir
-{:ok, supervisor} = Task.Supervisor.start_link()
-Jido.Exec.run(MyApp.Flows.BuildReport, input, context, task_supervisor: supervisor)
-```
+{PartitionSupervisor, child_spec: Task.Supervisor, name: MyApp.ReportPartitions}
 
-A Registry route selects a supervisor registered with that key:
-
-```elixir
-children = [
-  {Registry, keys: :unique, name: MyApp.TaskRegistry},
-  {Task.Supervisor, name: {:via, Registry, {MyApp.TaskRegistry, "reports"}}}
-]
-
-Supervisor.start_link(children, strategy: :one_for_one)
-route = {:via, Registry, {MyApp.TaskRegistry, "reports"}}
+route = {:via, PartitionSupervisor, {MyApp.ReportPartitions, self()}}
 Jido.Exec.run(MyApp.Flows.BuildReport, input, context, task_supervisor: route)
 ```
 
-PartitionSupervisor can distribute task starts across local supervisors. Build
-one route in the calling process and pass it to Exec:
+Exec keeps the same reference and partition key through nested work and
+continuations. Names and via routes resolve at each task start, so later work
+can use a replacement supervisor. A PID selects only that process.
 
-```elixir
-children = [
-  {PartitionSupervisor, child_spec: Task.Supervisor, name: MyApp.ReportPartitions}
-]
+The supervisor must be local; `nil`, remote references, and `:global` routes
+are invalid. Missing supervisors and task-start failures produce structured
+errors. Exec does not fall back to another supervisor or restart interrupted
+work. Failure details include the supplied `task_supervisor` and `reason`.
 
-Supervisor.start_link(children, strategy: :one_for_one)
-route = {:via, PartitionSupervisor, {MyApp.ReportPartitions, self()}}
-handle = Jido.Exec.run_async(MyApp.Flows.BuildReport, input, context,
-  task_supervisor: route)
-```
+The supervisor owns Action workers and async control tasks. An async call
+needs a control slot in addition to its Action worker slots. `run_async/4`
+raises `InvalidInputError` for invalid routing or `AsyncExecutionError` if its
+control task cannot start. After it returns a handle, failures use the normal
+async result contract.
 
-Exec keeps this exact route, including its partition key, through async,
-finite-timeout, step-wise, nested, collection, and continuation work. It does
-not select a new partition from an internal worker PID. See the official
-[Task.Supervisor routing contract](https://elixir.hexdocs.pm/1.18.4/Task.Supervisor.html#module-scalability-and-partitioning).
-
-### Lifetime And Failures
-
-The reference must select a local Task.Supervisor. Remote PIDs, remote name
-tuples, and `:global` references are not supported. A via resolver must return
-a local PID or report that no process is registered. Omit `task_supervisor`
-to use the package default. An explicit `nil` is invalid. Duplicate
-`task_supervisor` options and the removed `jido` option are errors.
-
-Exec checks the selected route before work. Each task start resolves names
-and via references again. If the supervisor stops, active tasks stop and the
-call returns a structured error. Tasks are temporary and are not restarted.
-If the same name is registered again, later work can use the replacement.
-This includes a later step of a paused Flow or a later task in the same call.
-Use a PID when all work must use one specific supervisor process; a dead PID
-never selects its replacement. Neither route provides rollback or retry.
-
-There is no fallback to the package supervisor. Absence and invalid routes
-produce Action or Flow validation errors. Capacity refusal and task-start
-races produce execution errors with `task_supervisor` and `reason` details.
-The route in those details is the supplied reference. Local lookup exceptions,
-throws, and exits are contained at the same boundary.
-
-`run_async/4` must start its control task before it can return a handle. Invalid
-routing raises `Jido.Action.Error.InvalidInputError`. Failure to start that
-task raises `Jido.Exec.Error.AsyncExecutionError`. After the handle exists,
-use its result or completion message to receive failures. The control task
-uses one supervisor slot in addition to active Action workers. For example,
-`max_children: 1` cannot run an async Action under that same supervisor.
-
-The selected supervisor owns isolated Action workers, including Flow target
-Actions, and the async control task. The finite-timeout coordinator, caller
-watchers, telemetry processes, and Runic stream helpers keep their existing
-ownership rules. They are not all direct children of the Task.Supervisor.
-Caller death and cancellation still stop owned work. The
-`max_concurrency` option bounds Flow work; it is not a limit on all helper
-processes or all children shared by several executions.
-
-### Beta Migration
-
-Replace `jido: MyApp.Jido` with
-`task_supervisor: MyApp.Jido.TaskSupervisor` if the host keeps that name.
-Remove `jido: nil` to use the default. This also applies to deprecated
-`Instruction.opts`; Exec rejects `jido` there even when a new route is supplied
-at the call. `Jido.Exec.task_supervisor_name(instance)` has been removed. Declare the
-supervisor name in the host supervision tree, as shown above.
-
-This rejection applies only to execution options. `context.jido` remains
-ordinary host data and is preserved through nested Flows and continuations.
-
-A host with several statically named instances can keep its own naming helper:
-
-```elixir
-def task_supervisor_name(nil), do: Jido.Exec.TaskSupervisor
-def task_supervisor_name(instance), do: Module.concat(instance, TaskSupervisor)
-```
-
-Use that helper only with host-controlled instance atoms. For runtime tenant
-keys, register supervisors through Registry or use PartitionSupervisor. Exec
-needs only the resulting reference.
+`max_concurrency` limits Flow work, not every helper process or all callers
+that share a supervisor. Context values, including `context.jido`, remain
+caller data and do not select the supervisor.
 
 ## Policy Boundary
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -10,7 +10,7 @@ All resolved targets accept these options in `run/4`:
 | Option | Default | Rule |
 | --- | --- | --- |
 | `timeout` | `:infinity` | `:infinity` or a non-negative millisecond integer. |
-| `jido` | `nil` | A Jido instance module or `nil`. |
+| `task_supervisor` | `Jido.Exec.TaskSupervisor` | A local Task.Supervisor PID, registered name, or via reference. |
 | `max_continuations` | `256` | An integer from `0` through `10_000`. |
 | `max_concurrency` | `8` | A positive integer used if the chain runs a Flow. |
 
@@ -21,7 +21,7 @@ and active child work. It does not retry the target.
 rejects the first continuation. The fixed upper bound prevents a caller from
 removing this safety limit. The complete-call timeout is a second guard.
 
-`start/4` accepts `jido` and `max_concurrency`, but not `timeout` or
+`start/4` accepts `task_supervisor` and `max_concurrency`, but not `timeout` or
 `max_continuations`. A paused step-wise execution does not have one
 complete-call clock and cannot run a continuation. Use `continue/1` to run it
 to completion.
@@ -49,48 +49,120 @@ Unknown options are errors. An Action does not use `max_concurrency` itself,
 but its continuation can select a Flow. An Instruction follows the option
 rules of its target. The removed Flow `async:` option is an unknown option.
 
-## Jido Instance Routing
+## Task Supervisor References
 
-`jido: MyApp.Jido` routes Action workers through
-`MyApp.Jido.TaskSupervisor`.
+Pass the supervisor reference directly. The host owns its name, capacity, and
+shutdown policy. Exec does not derive a name or create routing atoms.
 
 ```elixir
-Jido.Exec.run(
-  MyApp.Flows.BuildReport,
-  input,
-  context,
-  jido: MyApp.Jido,
+children = [
+  {Task.Supervisor, name: MyApp.ReportTasks, max_children: 1_000}
+]
+
+# Add these children to the host application supervision tree.
+Supervisor.start_link(children, strategy: :one_for_one)
+
+Jido.Exec.run(MyApp.Flows.BuildReport, input, context,
+  task_supervisor: MyApp.ReportTasks,
   max_concurrency: 4
 )
 ```
 
-The Jido instance must be running. Exec returns a structured error if the
-named Task Supervisor does not exist. It does not fall back to the global
-supervisor.
+An unnamed supervisor is also valid:
 
-When `jido` is absent or `nil`, Exec uses `Jido.Exec.TaskSupervisor`.
+```elixir
+{:ok, supervisor} = Task.Supervisor.start_link()
+Jido.Exec.run(MyApp.Flows.BuildReport, input, context, task_supervisor: supervisor)
+```
 
-### Instance Runtime Setup
-
-A higher-level runtime that owns a Jido instance must start one Task Supervisor
-under that instance. Use `Jido.Exec.task_supervisor_name/1` instead of copying
-the registered-name rule.
+A Registry route selects a supervisor registered with that key:
 
 ```elixir
 children = [
-  {Task.Supervisor,
-   name: Jido.Exec.task_supervisor_name(MyApp.Jido),
-   max_children: 1_000}
+  {Registry, keys: :unique, name: MyApp.TaskRegistry},
+  {Task.Supervisor, name: {:via, Registry, {MyApp.TaskRegistry, "reports"}}}
 ]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+route = {:via, Registry, {MyApp.TaskRegistry, "reports"}}
+Jido.Exec.run(MyApp.Flows.BuildReport, input, context, task_supervisor: route)
 ```
 
-The supervisor name in this child specification is the same name selected by
-`jido: MyApp.Jido`. The runtime owns its capacity and shutdown policy. A runtime
-that includes this child should start it automatically when the instance
-starts. Its users must not start a second supervisor with the same name.
+PartitionSupervisor can distribute task starts across local supervisors. Build
+one route in the calling process and pass it to Exec:
 
-Nested Flows inherit the routing and scheduling options. Options do not change
-Flow dependencies.
+```elixir
+children = [
+  {PartitionSupervisor, child_spec: Task.Supervisor, name: MyApp.ReportPartitions}
+]
+
+Supervisor.start_link(children, strategy: :one_for_one)
+route = {:via, PartitionSupervisor, {MyApp.ReportPartitions, self()}}
+handle = Jido.Exec.run_async(MyApp.Flows.BuildReport, input, context,
+  task_supervisor: route)
+```
+
+Exec keeps this exact route, including its partition key, through async,
+finite-timeout, step-wise, nested, collection, and continuation work. It does
+not select a new partition from an internal worker PID. See the official
+[Task.Supervisor routing contract](https://elixir.hexdocs.pm/1.18.4/Task.Supervisor.html#module-scalability-and-partitioning).
+
+### Lifetime And Failures
+
+The reference must select a local Task.Supervisor. Remote PIDs, remote name
+tuples, and `:global` references are not supported. A via resolver must return
+a local PID or report that no process is registered. Omit `task_supervisor`
+to use the package default. An explicit `nil` is invalid. Duplicate
+`task_supervisor` options and the removed `jido` option are errors.
+
+Exec checks the selected route before work. Each task start resolves names
+and via references again. If the supervisor stops, active tasks stop and the
+call returns a structured error. Tasks are temporary and are not restarted.
+If the same name is registered again, later work can use the replacement.
+This includes a later step of a paused Flow or a later task in the same call.
+Use a PID when all work must use one specific supervisor process; a dead PID
+never selects its replacement. Neither route provides rollback or retry.
+
+There is no fallback to the package supervisor. Absence and invalid routes
+produce Action or Flow validation errors. Capacity refusal and task-start
+races produce execution errors with `task_supervisor` and `reason` details.
+The route in those details is the supplied reference. Local lookup exceptions,
+throws, and exits are contained at the same boundary.
+
+`run_async/4` must start its control task before it can return a handle. Invalid
+routing raises `Jido.Action.Error.InvalidInputError`. Failure to start that
+task raises `Jido.Exec.Error.AsyncExecutionError`. After the handle exists,
+use its result or completion message to receive failures. The control task
+uses one supervisor slot in addition to active Action workers. For example,
+`max_children: 1` cannot run an async Action under that same supervisor.
+
+The selected supervisor owns isolated Action workers, including Flow target
+Actions, and the async control task. The finite-timeout coordinator, caller
+watchers, telemetry processes, and Runic stream helpers keep their existing
+ownership rules. They are not all direct children of the Task.Supervisor.
+Caller death and cancellation still stop owned work. The
+`max_concurrency` option bounds Flow work; it is not a limit on all helper
+processes or all children shared by several executions.
+
+### Beta Migration
+
+Replace `jido: MyApp.Jido` with
+`task_supervisor: MyApp.Jido.TaskSupervisor` if the host keeps that name.
+Remove `jido: nil` to use the default. This also applies to deprecated
+`Instruction.opts`; Exec rejects `jido` there even when a new route is supplied
+at the call. `Jido.Exec.task_supervisor_name(instance)` has been removed. Declare the
+supervisor name in the host supervision tree, as shown above.
+
+A host with several statically named instances can keep its own naming helper:
+
+```elixir
+def task_supervisor_name(nil), do: Jido.Exec.TaskSupervisor
+def task_supervisor_name(instance), do: Module.concat(instance, TaskSupervisor)
+```
+
+Use that helper only with host-controlled instance atoms. For runtime tenant
+keys, register supervisors through Registry or use PartitionSupervisor. Exec
+needs only the resulting reference.
 
 ## Policy Boundary
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -153,6 +153,9 @@ Remove `jido: nil` to use the default. This also applies to deprecated
 at the call. `Jido.Exec.task_supervisor_name(instance)` has been removed. Declare the
 supervisor name in the host supervision tree, as shown above.
 
+This rejection applies only to execution options. `context.jido` remains
+ordinary host data and is preserved through nested Flows and continuations.
+
 A host with several statically named instances can keep its own naming helper:
 
 ```elixir

--- a/guides/execution.md
+++ b/guides/execution.md
@@ -104,7 +104,8 @@ returns a handle with `ref`, `pid`, `owner`, `monitor_ref`, and shared `state`
 fields. Treat these fields as one handle. The process that calls `run_async/4`
 owns the handle. Only that process can await, handle, or cancel it.
 
-Call `handle_message/2` from `handle_info/2` or an equivalent OTP callback. It
+Start the call in the process that handles its completion. Use
+`handle_message/2` in `handle_info/2` to keep a GenServer responsive. It
 returns `{:done, result}` for the exact completion message and `:ignore` for an
 unrelated message. A matching process exit returns the execution error inside
 `{:done, {:error, error}}`. An invalid handle or owner returns the outer
@@ -127,65 +128,6 @@ side effects that already completed.
 Invalid handles and owner violations return
 `Jido.Exec.Error.InvalidHandleError`. An unexpected failure of the managed
 process returns `Jido.Exec.Error.AsyncExecutionError`.
-
-### Responsive GenServer Completion
-
-Start the async call in the GenServer that will consume its completion. Keep
-the handle in state and use `handle_message/2` in `handle_info/2`. Do not call
-`await/2` inside a callback that must remain responsive.
-
-```elixir
-defmodule MyApp.ReportServer do
-  use GenServer
-
-  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
-
-  @impl true
-  def init(opts) do
-    {:ok, %{target: Keyword.fetch!(opts, :target),
-            supervisor: Keyword.fetch!(opts, :task_supervisor),
-            handle: nil, result: nil}}
-  end
-
-  @impl true
-  def handle_call({:run, input, context}, _from, %{handle: nil} = state) do
-    handle = Jido.Exec.run_async(state.target, input, context,
-      task_supervisor: state.supervisor)
-    {:reply, :ok, %{state | handle: handle, result: nil}}
-  rescue
-    error in [Jido.Action.Error.InvalidInputError, Jido.Exec.Error.AsyncExecutionError] ->
-      {:reply, {:error, error}, state}
-  end
-
-  def handle_call({:run, _input, _context}, _from, state),
-    do: {:reply, {:error, :busy}, state}
-
-  def handle_call(:status, _from, state),
-    do: {:reply, %{running?: state.handle != nil, result: state.result}, state}
-
-  @impl true
-  def handle_info(_message, %{handle: nil} = state), do: {:noreply, state}
-
-  def handle_info(message, state) do
-    case Jido.Exec.handle_message(state.handle, message) do
-      {:done, result} -> {:noreply, %{state | handle: nil, result: result}}
-      :ignore -> {:noreply, state}
-      {:error, error} -> {:noreply, %{state | handle: nil, result: {:error, error}}}
-    end
-  end
-end
-
-# The host starts MyApp.ReportTasks before this server.
-{:ok, server} = MyApp.ReportServer.start_link(
-  target: MyApp.Flows.BuildReport, task_supervisor: MyApp.ReportTasks)
-:ok = GenServer.call(server, {:run, input, context})
-status = GenServer.call(server, :status)
-```
-
-The server can process status calls while Action work is blocked. Completion
-stores the normal Exec result. Startup errors leave the server ready for a
-later request. See [Runtime Configuration](configuration.md) for capacity,
-shutdown, replacement, and route examples.
 
 ## Runtime Options
 

--- a/guides/execution.md
+++ b/guides/execution.md
@@ -128,6 +128,65 @@ Invalid handles and owner violations return
 `Jido.Exec.Error.InvalidHandleError`. An unexpected failure of the managed
 process returns `Jido.Exec.Error.AsyncExecutionError`.
 
+### Responsive GenServer Completion
+
+Start the async call in the GenServer that will consume its completion. Keep
+the handle in state and use `handle_message/2` in `handle_info/2`. Do not call
+`await/2` inside a callback that must remain responsive.
+
+```elixir
+defmodule MyApp.ReportServer do
+  use GenServer
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @impl true
+  def init(opts) do
+    {:ok, %{target: Keyword.fetch!(opts, :target),
+            supervisor: Keyword.fetch!(opts, :task_supervisor),
+            handle: nil, result: nil}}
+  end
+
+  @impl true
+  def handle_call({:run, input, context}, _from, %{handle: nil} = state) do
+    handle = Jido.Exec.run_async(state.target, input, context,
+      task_supervisor: state.supervisor)
+    {:reply, :ok, %{state | handle: handle, result: nil}}
+  rescue
+    error in [Jido.Action.Error.InvalidInputError, Jido.Exec.Error.AsyncExecutionError] ->
+      {:reply, {:error, error}, state}
+  end
+
+  def handle_call({:run, _input, _context}, _from, state),
+    do: {:reply, {:error, :busy}, state}
+
+  def handle_call(:status, _from, state),
+    do: {:reply, %{running?: state.handle != nil, result: state.result}, state}
+
+  @impl true
+  def handle_info(_message, %{handle: nil} = state), do: {:noreply, state}
+
+  def handle_info(message, state) do
+    case Jido.Exec.handle_message(state.handle, message) do
+      {:done, result} -> {:noreply, %{state | handle: nil, result: result}}
+      :ignore -> {:noreply, state}
+      {:error, error} -> {:noreply, %{state | handle: nil, result: {:error, error}}}
+    end
+  end
+end
+
+# The host starts MyApp.ReportTasks before this server.
+{:ok, server} = MyApp.ReportServer.start_link(
+  target: MyApp.Flows.BuildReport, task_supervisor: MyApp.ReportTasks)
+:ok = GenServer.call(server, {:run, input, context})
+status = GenServer.call(server, :status)
+```
+
+The server can process status calls while Action work is blocked. Completion
+stores the normal Exec result. Startup errors leave the server ready for a
+later request. See [Runtime Configuration](configuration.md) for capacity,
+shutdown, replacement, and route examples.
+
 ## Runtime Options
 
 All targets accept:
@@ -135,7 +194,7 @@ All targets accept:
 | Option | Default | Meaning |
 | --- | --- | --- |
 | `timeout` | `:infinity` | Complete-call limit for `run/4`. |
-| `jido` | `nil` | Jido instance used for Action worker routing. |
+| `task_supervisor` | `Jido.Exec.TaskSupervisor` | Local Task.Supervisor reference for Action workers and async control. |
 | `max_continuations` | `256` | Maximum continuations in one complete call. |
 | `max_concurrency` | `8` | Bounds ready Flow work if the chain runs a Flow. |
 
@@ -153,7 +212,7 @@ executable and starts the target in the same complete call. The timeout and
 continuation limit cover the full chain. See
 [Continue to Another Executable](continuations.md).
 
-`start/4` accepts `jido` and `max_concurrency`. It does not accept a timeout or
+`start/4` accepts `task_supervisor` and `max_concurrency`. It does not accept a timeout or
 Dispatch because a paused execution cannot run a continuation as part of one
 complete call.
 
@@ -261,6 +320,6 @@ telemetry delivery. They do not have a finite complete-call deadline.
 
 Exec provides one in-memory execution session. It provides validation, process
 ownership, whole-call timeout, owner-bound async handles, optional
-concurrency, and Jido instance routing. It does not provide automatic retry,
+concurrency, and explicit supervisor routing. It does not provide automatic retry,
 per-node deadlines, durable cancellation, persistence, rewind, queues,
 recovery, or distributed coordination.

--- a/guides/instructions.md
+++ b/guides/instructions.md
@@ -55,7 +55,7 @@ Use `target:` in new code. The compatibility path does not restore the removed
 
 Version 3 also accepts the deprecated `opts` field so old struct literals
 compile. Exec warns when it consumes a non-empty value. It forwards `timeout`
-and `jido`, leaves out known settings that version 3 removed, and rejects
+and `task_supervisor`, leaves out known settings that version 3 removed, and rejects
 unknown settings. Move all execution options to `Jido.Exec.run/4`. See
 [Migration Shims](migration-shims.md) for the package policy and exact option
 rules.
@@ -77,7 +77,7 @@ Jido.Exec.run(
 ```
 
 An Instruction uses the rules of its resolved target. All run-to-completion
-targets accept `timeout:`, `jido:`, `max_continuations:`, and
+targets accept `timeout:`, `task_supervisor:`, `max_continuations:`, and
 `max_concurrency:`. An Action does not use `max_concurrency` itself, but it can
 continue to a Flow. An Instruction can be a target for `Jido.Exec.run_async/4`.
 

--- a/guides/migration-shims.md
+++ b/guides/migration-shims.md
@@ -128,10 +128,11 @@ Jido.Exec.run(legacy_instruction, %{}, %{}, timeout: 10_000)
 
 ### Option Results
 
-| Version 2 option | Version 3 result | Migration |
+| Instruction option | Version 3 result | Migration |
 | --- | --- | --- |
 | `timeout` | Forwarded by `run/4` | Pass it directly to `Jido.Exec.run/4`. |
-| `jido` | Forwarded | Pass it directly to `Jido.Exec.run/4` or `start/4`. |
+| `task_supervisor` | Forwarded | Pass it directly to `Jido.Exec.run/4` or `start/4`. |
+| `jido` | Rejected | Use an explicit `task_supervisor:` reference. |
 | `max_retries` | Warned and not applied | Put retry count in the caller or Jido runtime. |
 | `backoff` | Warned and not applied | Put retry delay in the caller or Jido runtime. |
 | `log_level` | Warned and not applied | Configure logging at the application boundary. |
@@ -162,7 +163,7 @@ migration warnings:
 - `Jido.Exec.run/4` as the complete-call execution boundary;
 - `Jido.Exec.run_async/4`, `await/1`, `await/2`, and `cancel/1` as the
   owner-bound asynchronous execution boundary; and
-- `jido:` instance routing.
+- `task_supervisor:` local supervisor routing.
 
 `timeout` also remains an Exec option. Its location and default changed. Pass
 it to `Jido.Exec.run/4`; the version 3 default is `:infinity`.

--- a/guides/nested-flows.livemd
+++ b/guides/nested-flows.livemd
@@ -72,7 +72,7 @@ A Subflow lowers to a nested native Runic Workflow. Step-wise execution can
 show child validators, child Steps, InputBinding, and connection work. Jido
 does not hide these native runnables.
 
-The child inherits the parent context, `max_concurrency`, `jido` routing, and
+The child inherits the parent context, `max_concurrency`, `task_supervisor` routing, and
 execution ID. Its Action calls share the parent execution budget.
 
 Child output uses the same caller context as root Flow output. This includes

--- a/guides/v2-to-v3-migration.md
+++ b/guides/v2-to-v3-migration.md
@@ -487,17 +487,9 @@ Version 3 uses `Jido.Exec.TaskSupervisor`.
 
 Replace direct references to the old global supervisor name.
 
-Replace `jido: MyApp.Jido` with
-`task_supervisor: MyApp.Jido.TaskSupervisor`. Remove `jido: nil` to use the
-default. The old option now returns a migration error, including in deprecated
-`Instruction.opts`. Do not supply both options.
-
-`Jido.Exec.task_supervisor_name(instance)` has been removed. The host must name and
-start its Task.Supervisor. Exec accepts the resulting local PID, registered
-name, or via reference. A missing supervisor is an error; Exec does not fall
-back to the default. Names resolve at each task start, so later work can use
-a replacement under the same name. A PID remains tied to the original process.
-See [supervision and partition examples](configuration.md#task-supervisor-references).
+Pass a custom supervisor directly with `task_supervisor: reference`.
+The host must start it before execution. See
+[Task Supervisor References](configuration.md#task-supervisor-references).
 
 ## Version 2 To Version 3 Migration Checklist
 

--- a/guides/v2-to-v3-migration.md
+++ b/guides/v2-to-v3-migration.md
@@ -268,7 +268,7 @@ Apply these field changes:
 
 Version 3 temporarily accepts `action:` and `opts` as migration shims. These
 paths emit warnings. Replace them before the upgrade is complete. The shim
-for `opts` forwards `timeout` and `jido`; it does not restore removed version
+for `opts` forwards `timeout` and `task_supervisor`; it does not restore removed version
 2 execution policy.
 
 See [Migration Shims](migration-shims.md) for the exact warning and error
@@ -377,7 +377,7 @@ timeout = Application.fetch_env!(:my_app, :action_timeout)
 
 Jido.Exec.run(action, params, context,
   timeout: timeout,
-  jido: MyApp.Jido
+  task_supervisor: MyApp.Jido.TaskSupervisor
 )
 ```
 
@@ -487,10 +487,17 @@ Version 3 uses `Jido.Exec.TaskSupervisor`.
 
 Replace direct references to the old global supervisor name.
 
-Instance routing keeps `MyApp.Jido.TaskSupervisor` for
-`jido: MyApp.Jido`. The selected instance must start that supervisor. Version
-3 returns an error when the instance supervisor is not running; it does not
-fall back to the global supervisor.
+Replace `jido: MyApp.Jido` with
+`task_supervisor: MyApp.Jido.TaskSupervisor`. Remove `jido: nil` to use the
+default. The old option now returns a migration error, including in deprecated
+`Instruction.opts`. Do not supply both options.
+
+`Jido.Exec.task_supervisor_name(instance)` has been removed. The host must name and
+start its Task.Supervisor. Exec accepts the resulting local PID, registered
+name, or via reference. A missing supervisor is an error; Exec does not fall
+back to the default. Names resolve at each task start, so later work can use
+a replacement under the same name. A PID remains tied to the original process.
+See [supervision and partition examples](configuration.md#task-supervisor-references).
 
 ## Version 2 To Version 3 Migration Checklist
 

--- a/guides/v2-to-v3-upgrade-skill.md
+++ b/guides/v2-to-v3-upgrade-skill.md
@@ -147,7 +147,7 @@ change application behavior.
   continuation loop.
 - Move retry count, backoff, durable cancellation policy, deadline, and
   compensation to the caller. Preserve idempotency rules.
-- Keep jido: instance routing. Confirm that the selected instance Task
+- Replace jido: with task_supervisor:. Confirm that the selected Task
   Supervisor is running.
 - Remove the Flow async option. Use max_concurrency alone for Flow scheduling.
   Its default is 8. Use 1 for serial scheduling.
@@ -192,9 +192,8 @@ change application behavior.
   global execution supervisor.
 - Do not depend on the package root supervisor name. Use
   Jido.Exec.TaskSupervisor when direct Task Supervisor access is required.
-- Use Jido.Exec.task_supervisor_name/1 when a higher-level runtime builds an
-  instance supervision tree.
-- Keep MyApp.Jido.TaskSupervisor for jido: MyApp.Jido instance routing.
+- Remove calls to Jido.Exec.task_supervisor_name/1. The host names its Task.Supervisor.
+- Pass task_supervisor: MyApp.Jido.TaskSupervisor when the host keeps that name.
 - Treat the v3 stored Flow document as a new format. Do not decode v2 Plan,
   Instruction, Action JSON, or development-spike data with Jido.Flow.Codec.
 - Use Jido.Flow.Codec with a trusted Jido.Flow.Registry for stored Flows.

--- a/guides/v2-to-v3-upgrade-skill.md
+++ b/guides/v2-to-v3-upgrade-skill.md
@@ -147,8 +147,7 @@ change application behavior.
   continuation loop.
 - Move retry count, backoff, durable cancellation policy, deadline, and
   compensation to the caller. Preserve idempotency rules.
-- Replace jido: with task_supervisor:. Confirm that the selected Task
-  Supervisor is running.
+- Pass task_supervisor: to select a running Task.Supervisor.
 - Remove the Flow async option. Use max_concurrency alone for Flow scheduling.
   Its default is 8. Use 1 for serial scheduling.
 

--- a/lib/jido_exec.ex
+++ b/lib/jido_exec.ex
@@ -104,18 +104,10 @@ defmodule Jido.Exec do
   @doc """
   Runs an executable Jido artifact.
 
-  All targets accept `task_supervisor: reference`. Use a local Task.Supervisor
-  PID, registered name, or `{:via, module, name}` reference, including
-  PartitionSupervisor routes. The default is `Jido.Exec.TaskSupervisor`.
-  The same reference is kept through nested work and continuations. Exec does
-  not derive names or partition keys from its workers and does not fall back
-  when the selected supervisor is absent or refuses work.
-
-  Names and via references are resolved at each task start. A later task can
-  use a replacement registered under the same name. A PID always selects the
-  original process. Tasks are temporary; shutdown stops active tasks and does
-  not restart completed or interrupted work. See the configuration guide for
-  supervision and migration examples. The former `jido:` option is an error.
+  The `task_supervisor:` option accepts a local Task.Supervisor PID, name, or
+  via route. It defaults to `Jido.Exec.TaskSupervisor`. Exec preserves the route
+  through nested work and continuations. Names resolve at each task start;
+  a PID selects one process. An unavailable supervisor is an error.
 
   All targets accept `timeout: milliseconds | :infinity`. The default is
   `:infinity`. A finite timeout covers the complete call and terminates its

--- a/lib/jido_exec.ex
+++ b/lib/jido_exec.ex
@@ -151,7 +151,6 @@ defmodule Jido.Exec do
     timeout_owner = initial_timeout_owner(executable)
 
     with {:ok, opts} <- prepare_run_options(executable, opts),
-         :ok <- Options.reject_jido(opts, timeout_owner),
          {:ok, timeout, run_opts} <- Options.take_timeout(opts, timeout_owner),
          {:ok, continuation_limit} <- Options.continuation_limit(run_opts, timeout_owner) do
       execute_with_timeout(

--- a/lib/jido_exec.ex
+++ b/lib/jido_exec.ex
@@ -87,38 +87,35 @@ defmodule Jido.Exec do
 
   @type async_control :: %{required(:ref) => reference(), required(:owner) => pid()}
 
-  @doc """
-  Returns the registered Task Supervisor name for an Exec route.
+  @typedoc "A local Task.Supervisor PID, registered name, or via reference."
+  @type task_supervisor :: pid() | atom() | {:via, module(), term()}
 
-  Pass `nil` for the global Exec supervisor. Pass a Jido instance name for an
-  instance-owned supervisor. This function only returns the required name. It
-  does not start the supervisor.
+  @typedoc "Options for run-to-completion execution."
+  @type run_option ::
+          {:task_supervisor, task_supervisor()}
+          | {:timeout, timeout()}
+          | {:max_concurrency, pos_integer()}
+          | {:max_continuations, non_neg_integer()}
 
-      Jido.Exec.task_supervisor_name(nil)
-      #=> Jido.Exec.TaskSupervisor
-
-      Jido.Exec.task_supervisor_name(MyApp.Jido)
-      #=> MyApp.Jido.TaskSupervisor
-
-  A higher-level runtime can use this function when it builds its supervision
-  tree. Calls that use `jido: MyApp.Jido` route Action work through the same
-  name.
-  """
-  @spec task_supervisor_name(atom() | nil) :: atom()
-  def task_supervisor_name(nil), do: Jido.Exec.TaskSupervisor
-  def task_supervisor_name(jido) when is_atom(jido), do: Module.concat(jido, TaskSupervisor)
-
-  def task_supervisor_name(jido) do
-    raise ArgumentError, "Jido instance must be an atom or nil, got: #{inspect(jido)}"
-  end
+  @typedoc "Options for a paused Flow execution."
+  @type start_option ::
+          {:task_supervisor, task_supervisor()} | {:max_concurrency, pos_integer()}
 
   @doc """
   Runs an executable Jido artifact.
 
-  All targets accept `jido: MyApp.Jido` for Jido instance routing. This option
-  runs Action work under `MyApp.Jido.TaskSupervisor`. The instance must be
-  running. Exec does not fall back to its global Task Supervisor when a caller
-  requests an instance.
+  All targets accept `task_supervisor: reference`. Use a local Task.Supervisor
+  PID, registered name, or `{:via, module, name}` reference, including
+  PartitionSupervisor routes. The default is `Jido.Exec.TaskSupervisor`.
+  The same reference is kept through nested work and continuations. Exec does
+  not derive names or partition keys from its workers and does not fall back
+  when the selected supervisor is absent or refuses work.
+
+  Names and via references are resolved at each task start. A later task can
+  use a replacement registered under the same name. A PID always selects the
+  original process. Tasks are temporary; shutdown stops active tasks and does
+  not restart completed or interrupted work. See the configuration guide for
+  supervision and migration examples. The former `jido:` option is an error.
 
   All targets accept `timeout: milliseconds | :infinity`. The default is
   `:infinity`. A finite timeout covers the complete call and terminates its
@@ -137,7 +134,8 @@ defmodule Jido.Exec do
   through 10,000. This limit and the complete-call timeout stop infinite
   continuation chains.
   """
-  @spec run(term(), map() | keyword() | nil, map() | keyword() | nil, keyword()) :: exec_result()
+  @spec run(term(), map() | keyword() | nil, map() | keyword() | nil, [run_option()]) ::
+          exec_result()
   def run(executable, input \\ %{}, context \\ %{}, opts \\ []) do
     do_run(executable, input, context, opts, nil)
   end
@@ -161,6 +159,7 @@ defmodule Jido.Exec do
     timeout_owner = initial_timeout_owner(executable)
 
     with {:ok, opts} <- prepare_run_options(executable, opts),
+         :ok <- Options.reject_jido(opts, timeout_owner),
          {:ok, timeout, run_opts} <- Options.take_timeout(opts, timeout_owner),
          {:ok, continuation_limit} <- Options.continuation_limit(run_opts, timeout_owner) do
       execute_with_timeout(
@@ -304,8 +303,13 @@ defmodule Jido.Exec do
   The handle is tied to the mailbox of the process that starts the execution.
   Only that process can wait for, handle, or cancel it. These operations are
   alternative one-shot terminal consumers.
+
+  Invalid routing raises `Jido.Action.Error.InvalidInputError` before a handle
+  exists. Failure to start the async control task raises
+  `Jido.Exec.Error.AsyncExecutionError`. Once a handle exists, failures use its
+  normal result and message contract.
   """
-  @spec run_async(term(), map() | keyword() | nil, map() | keyword() | nil, keyword()) ::
+  @spec run_async(term(), map() | keyword() | nil, map() | keyword() | nil, [run_option()]) ::
           async_ref()
   def run_async(executable, input \\ %{}, context \\ %{}, opts \\ []) do
     Async.start(executable, input, context, opts)
@@ -358,7 +362,7 @@ defmodule Jido.Exec do
   and run options before it returns. The returned execution is paused before
   the first native Runic runnable.
 
-  `:max_concurrency` and common `:jido` routing are stored on the execution.
+  `:max_concurrency` and the `:task_supervisor` reference are stored on the execution.
   `wave/1` and `continue/1` use the scheduling options. `step/1` and `step/2`
   always execute one runnable.
 
@@ -366,7 +370,7 @@ defmodule Jido.Exec do
   `:timeout` option. The step-wise API also does not accept retry, deadline,
   asynchronous execution, cancellation, persistence, or rewind options.
   """
-  @spec start(term(), map() | keyword() | nil, map() | keyword() | nil, keyword()) ::
+  @spec start(term(), map() | keyword() | nil, map() | keyword() | nil, [start_option()]) ::
           {:ok, Execution.t()} | {:error, Exception.t()}
   def start(executable, input \\ %{}, context \\ %{}, opts \\ []) do
     execution_id = Telemetry.execution_id()

--- a/lib/jido_exec/action/runner.ex
+++ b/lib/jido_exec/action/runner.ex
@@ -3,6 +3,7 @@ defmodule Jido.Exec.Action.Runner do
 
   alias Jido.Action.Error
   alias Jido.Action.Output
+  alias Jido.Exec.Runtime
   alias Jido.Exec.Transition
   alias Jido.Instruction
   alias Jido.Exec.Telemetry
@@ -288,7 +289,7 @@ defmodule Jido.Exec.Action.Runner do
     telemetry_tracker = Telemetry.tracker()
     ref = make_ref()
 
-    case start_worker(task_supervisor, fn ->
+    case Runtime.start_child(task_supervisor, fn ->
            worker = self()
            spawn(fn -> terminate_with_caller(caller, worker) end)
            Telemetry.put_tracker(telemetry_tracker)
@@ -303,12 +304,6 @@ defmodule Jido.Exec.Action.Runner do
       {:ok, worker} -> await_worker(worker, ref)
       {:error, reason} -> {:start_error, reason}
     end
-  end
-
-  defp start_worker(task_supervisor, work) do
-    Task.Supervisor.start_child(task_supervisor, work)
-  catch
-    :exit, reason -> {:error, {:exit, reason}}
   end
 
   defp await_worker(worker, ref) do

--- a/lib/jido_exec/async.ex
+++ b/lib/jido_exec/async.ex
@@ -4,6 +4,7 @@ defmodule Jido.Exec.Async do
   alias Jido.Exec
   alias Jido.Exec.Error
   alias Jido.Exec.Runtime
+  alias Jido.Instruction
 
   @default_await_timeout 5_000
   @stop_wait_ms 1_000
@@ -33,6 +34,7 @@ defmodule Jido.Exec.Async do
     owner = self()
     ref = make_ref()
     state = new_state()
+    {executable, opts} = prepare_options!(executable, opts)
     task_supervisor = task_supervisor!(opts)
     group_leader = Process.group_leader()
     logger_metadata = Logger.metadata()
@@ -49,7 +51,7 @@ defmodule Jido.Exec.Async do
       result
     end
 
-    case start_child(task_supervisor, work) do
+    case Runtime.start_child(task_supervisor, work) do
       {:ok, pid} ->
         handle = %{
           ref: ref,
@@ -517,6 +519,15 @@ defmodule Jido.Exec.Async do
     end
   end
 
+  defp prepare_options!(%Instruction{} = instruction, opts) do
+    case Instruction.prepare_run_options(instruction, opts) do
+      {:ok, opts} -> {%{instruction | opts: []}, opts}
+      {:error, error} -> raise error
+    end
+  end
+
+  defp prepare_options!(executable, opts), do: {executable, opts}
+
   defp task_supervisor!(opts) when is_list(opts) do
     case Runtime.task_supervisor(opts) do
       {:ok, supervisor} -> supervisor
@@ -529,11 +540,5 @@ defmodule Jido.Exec.Async do
             options: opts,
             retry: false
           })
-  end
-
-  defp start_child(task_supervisor, work) do
-    Task.Supervisor.start_child(task_supervisor, work)
-  catch
-    :exit, reason -> {:error, {:exit, reason}}
   end
 end

--- a/lib/jido_exec/options.ex
+++ b/lib/jido_exec/options.ex
@@ -84,7 +84,6 @@ defmodule Jido.Exec.Options do
           {:ok, keyword()} | {:error, Exception.t()}
   def validate_action(opts, executable_type) do
     with :ok <- validate_action_keyword(opts),
-         :ok <- reject_jido(opts, ActionError),
          {:ok, task_supervisor} <- validate_task_supervisor(opts, ActionError),
          :ok <- validate_known_action_options(opts, executable_type),
          max_concurrency = Keyword.get(opts, :max_concurrency, @default_max_concurrency),

--- a/lib/jido_exec/options.ex
+++ b/lib/jido_exec/options.ex
@@ -5,7 +5,7 @@ defmodule Jido.Exec.Options do
   alias Jido.Exec.Runtime
   alias Jido.Flow.Error, as: FlowError
 
-  @routing_option_keys [:jido]
+  @routing_option_keys [:task_supervisor]
   @common_run_option_keys [:max_concurrency, :max_continuations | @routing_option_keys]
   @flow_run_option_keys @common_run_option_keys
   @flow_start_option_keys [:max_concurrency | @routing_option_keys]
@@ -67,15 +67,15 @@ defmodule Jido.Exec.Options do
           {:ok, keyword()} | {:error, Exception.t()}
   def validate_flow(opts, mode \\ :run) when mode in [:run, :start] do
     with :ok <- validate_keyword(opts),
+         :ok <- reject_jido(opts, FlowError),
          :ok <- validate_known_flow_options(opts, mode),
-         :ok <- validate_jido(opts, FlowError),
          {:ok, task_supervisor} <- validate_task_supervisor(opts, FlowError),
          max_concurrency = Keyword.get(opts, :max_concurrency, @default_max_concurrency),
          :ok <- validate_max_concurrency(max_concurrency, FlowError),
          {:ok, continuation_options} <- continuation_options(opts, mode) do
       {:ok,
        [max_concurrency: max_concurrency, task_supervisor: task_supervisor] ++
-         continuation_options ++ routing_options(opts)}
+         continuation_options}
     end
   end
 
@@ -84,9 +84,9 @@ defmodule Jido.Exec.Options do
           {:ok, keyword()} | {:error, Exception.t()}
   def validate_action(opts, executable_type) do
     with :ok <- validate_action_keyword(opts),
-         :ok <- validate_known_action_options(opts, executable_type),
-         :ok <- validate_jido(opts, ActionError),
+         :ok <- reject_jido(opts, ActionError),
          {:ok, task_supervisor} <- validate_task_supervisor(opts, ActionError),
+         :ok <- validate_known_action_options(opts, executable_type),
          max_concurrency = Keyword.get(opts, :max_concurrency, @default_max_concurrency),
          :ok <- validate_max_concurrency(max_concurrency, ActionError),
          {:ok, max_continuations} <- continuation_limit(opts, ActionError) do
@@ -95,14 +95,7 @@ defmodule Jido.Exec.Options do
          max_concurrency: max_concurrency,
          max_continuations: max_continuations,
          task_supervisor: task_supervisor
-       ] ++ routing_options(opts)}
-    end
-  end
-
-  defp routing_options(opts) do
-    case Keyword.fetch(opts, :jido) do
-      {:ok, jido} -> [jido: jido]
-      :error -> []
+       ]}
     end
   end
 
@@ -120,25 +113,23 @@ defmodule Jido.Exec.Options do
     end
   end
 
-  defp validate_jido(opts, error_module) do
-    case Keyword.fetch(opts, :jido) do
-      :error ->
-        :ok
+  @doc false
+  @spec reject_jido(term(), ActionError | FlowError) :: :ok | {:error, Exception.t()}
+  def reject_jido(opts, error_module) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      case Runtime.reject_jido(opts) do
+        :ok ->
+          :ok
 
-      {:ok, nil} ->
-        :ok
-
-      {:ok, jido} when is_atom(jido) ->
-        :ok
-
-      {:ok, jido} ->
-        {:error,
-         execution_option_error(error_module, "jido option must be an atom or nil", %{
-           option: :jido,
-           value: jido
-         })}
+        {:error, error} ->
+          {:error, execution_option_error(error_module, error.message, error.details)}
+      end
+    else
+      :ok
     end
   end
+
+  def reject_jido(_opts, _error_module), do: :ok
 
   defp validate_task_supervisor(opts, error_module) do
     case Runtime.task_supervisor(opts) do
@@ -146,12 +137,7 @@ defmodule Jido.Exec.Options do
         {:ok, supervisor}
 
       {:error, error} ->
-        {:error,
-         execution_option_error(error_module, Exception.message(error), %{
-           option: :jido,
-           jido: Keyword.get(opts, :jido),
-           task_supervisor: Runtime.task_supervisor_name(opts)
-         })}
+        {:error, execution_option_error(error_module, Exception.message(error), error.details)}
     end
   end
 

--- a/lib/jido_exec/options.ex
+++ b/lib/jido_exec/options.ex
@@ -67,7 +67,6 @@ defmodule Jido.Exec.Options do
           {:ok, keyword()} | {:error, Exception.t()}
   def validate_flow(opts, mode \\ :run) when mode in [:run, :start] do
     with :ok <- validate_keyword(opts),
-         :ok <- reject_jido(opts, FlowError),
          :ok <- validate_known_flow_options(opts, mode),
          {:ok, task_supervisor} <- validate_task_supervisor(opts, FlowError),
          max_concurrency = Keyword.get(opts, :max_concurrency, @default_max_concurrency),
@@ -111,24 +110,6 @@ defmodule Jido.Exec.Options do
        })}
     end
   end
-
-  @doc false
-  @spec reject_jido(term(), ActionError | FlowError) :: :ok | {:error, Exception.t()}
-  def reject_jido(opts, error_module) when is_list(opts) do
-    if Keyword.keyword?(opts) do
-      case Runtime.reject_jido(opts) do
-        :ok ->
-          :ok
-
-        {:error, error} ->
-          {:error, execution_option_error(error_module, error.message, error.details)}
-      end
-    else
-      :ok
-    end
-  end
-
-  def reject_jido(_opts, _error_module), do: :ok
 
   defp validate_task_supervisor(opts, error_module) do
     case Runtime.task_supervisor(opts) do

--- a/lib/jido_exec/runtime.ex
+++ b/lib/jido_exec/runtime.ex
@@ -3,31 +3,126 @@ defmodule Jido.Exec.Runtime do
 
   alias Jido.Action.Error
 
-  @type routing_option :: {:jido, atom() | nil}
+  @type supervisor_reference :: pid() | atom() | {:via, module(), term()}
 
   @doc false
-  @spec task_supervisor_name([routing_option()]) :: atom()
-  def task_supervisor_name(opts) when is_list(opts) do
-    Jido.Exec.task_supervisor_name(Keyword.get(opts, :jido))
-  rescue
-    ArgumentError ->
-      jido = Keyword.get(opts, :jido)
-      raise ArgumentError, ":jido must be an atom or nil, got: #{inspect(jido)}"
+  @spec task_supervisor(keyword()) :: {:ok, supervisor_reference()} | {:error, Exception.t()}
+  def task_supervisor(opts) do
+    with :ok <- validate_options(opts),
+         :ok <- reject_jido(opts),
+         :ok <- reject_duplicate_route(opts) do
+      supervisor = Keyword.get(opts, :task_supervisor, Jido.Exec.TaskSupervisor)
+
+      if local_reference?(supervisor) do
+        lookup(supervisor)
+      else
+        invalid_reference(supervisor)
+      end
+    end
   end
 
   @doc false
-  @spec task_supervisor([routing_option()]) :: {:ok, atom()} | {:error, Exception.t()}
-  def task_supervisor(opts) when is_list(opts) do
-    supervisor = task_supervisor_name(opts)
+  @spec start_child(supervisor_reference(), (-> term())) :: {:ok, pid()} | {:error, term()}
+  def start_child(supervisor, work) do
+    case GenServer.whereis(supervisor) do
+      pid when is_pid(pid) and node(pid) == node() ->
+        Task.Supervisor.start_child(pid, work, restart: :temporary)
 
-    if Process.whereis(supervisor) do
-      {:ok, supervisor}
-    else
-      {:error,
-       Error.validation_error("Task Supervisor is not running", %{
-         jido: Keyword.get(opts, :jido),
-         task_supervisor: supervisor
-       })}
+      nil ->
+        {:error, :noproc}
+
+      _other ->
+        {:error, :non_local_supervisor}
     end
+  rescue
+    error -> {:error, {:error, error}}
+  catch
+    kind, reason -> {:error, {kind, reason}}
+  end
+
+  @doc false
+  @spec reject_jido(keyword()) :: :ok | {:error, Exception.t()}
+  def reject_jido(opts) do
+    if Keyword.has_key?(opts, :jido) do
+      {:error,
+       Error.validation_error(
+         "jido option was removed; pass task_supervisor: MyApp.TaskSupervisor instead",
+         %{option: :jido, replacement: :task_supervisor}
+       )}
+    else
+      :ok
+    end
+  end
+
+  defp validate_options(opts) when is_list(opts) do
+    if Keyword.keyword?(opts), do: :ok, else: invalid_options()
+  end
+
+  defp validate_options(_opts), do: invalid_options()
+
+  defp invalid_options do
+    {:error, Error.validation_error("run options must be a keyword list")}
+  end
+
+  defp reject_duplicate_route(opts) do
+    if length(Keyword.get_values(opts, :task_supervisor)) > 1 do
+      {:error,
+       Error.validation_error("pass only one task_supervisor: reference", %{
+         option: :task_supervisor,
+         reason: :duplicate_option
+       })}
+    else
+      :ok
+    end
+  end
+
+  defp local_reference?(pid) when is_pid(pid), do: node(pid) == node()
+  defp local_reference?(name) when is_atom(name), do: name not in [nil, true, false]
+
+  defp local_reference?({:via, module, _name}) when is_atom(module),
+    do: module not in [nil, true, false]
+
+  defp local_reference?(_reference), do: false
+
+  defp lookup(supervisor) do
+    case GenServer.whereis(supervisor) do
+      nil ->
+        not_running(supervisor)
+
+      pid when is_pid(pid) and node(pid) == node() ->
+        if Process.alive?(pid), do: {:ok, supervisor}, else: not_running(supervisor)
+
+      _other ->
+        invalid_reference(supervisor)
+    end
+  rescue
+    error -> lookup_error(supervisor, error)
+  catch
+    kind, reason -> lookup_error(supervisor, {kind, reason})
+  end
+
+  defp not_running(supervisor) do
+    {:error,
+     Error.validation_error("Task Supervisor is not running", %{
+       option: :task_supervisor,
+       task_supervisor: supervisor
+     })}
+  end
+
+  defp lookup_error(supervisor, reason) do
+    {:error,
+     Error.validation_error("Task Supervisor lookup failed", %{
+       option: :task_supervisor,
+       task_supervisor: supervisor,
+       reason: reason
+     })}
+  end
+
+  defp invalid_reference(supervisor) do
+    {:error,
+     Error.validation_error(
+       "task_supervisor must be a local PID, registered name, or {:via, module, name} reference",
+       %{option: :task_supervisor, value: supervisor}
+     )}
   end
 end

--- a/lib/jido_exec/runtime.ex
+++ b/lib/jido_exec/runtime.ex
@@ -9,7 +9,6 @@ defmodule Jido.Exec.Runtime do
   @spec task_supervisor(keyword()) :: {:ok, supervisor_reference()} | {:error, Exception.t()}
   def task_supervisor(opts) do
     with :ok <- validate_options(opts),
-         :ok <- reject_jido(opts),
          :ok <- reject_duplicate_route(opts) do
       supervisor = Keyword.get(opts, :task_supervisor, Jido.Exec.TaskSupervisor)
 
@@ -38,20 +37,6 @@ defmodule Jido.Exec.Runtime do
     error -> {:error, {:error, error}}
   catch
     kind, reason -> {:error, {kind, reason}}
-  end
-
-  @doc false
-  @spec reject_jido(keyword()) :: :ok | {:error, Exception.t()}
-  def reject_jido(opts) do
-    if Keyword.has_key?(opts, :jido) do
-      {:error,
-       Error.validation_error(
-         "jido option was removed; pass task_supervisor: MyApp.TaskSupervisor instead",
-         %{option: :jido, replacement: :task_supervisor}
-       )}
-    else
-      :ok
-    end
   end
 
   defp validate_options(opts) when is_list(opts) do

--- a/lib/jido_instruction.ex
+++ b/lib/jido_instruction.ex
@@ -381,9 +381,7 @@ defmodule Jido.Instruction do
         {:ok, call_opts}
 
       {:ok, legacy_opts} ->
-        with :ok <- Jido.Exec.Runtime.reject_jido(legacy_opts) do
-          migrate_normalized_legacy_opts(legacy_opts, call_opts, target, mode)
-        end
+        migrate_normalized_legacy_opts(legacy_opts, call_opts, target, mode)
 
       {:error, error} ->
         warn_invalid_legacy_opts(target, mode)

--- a/lib/jido_instruction.ex
+++ b/lib/jido_instruction.ex
@@ -39,8 +39,8 @@ defmodule Jido.Instruction do
 
   @target_fields [:target, :action, :flow]
   @removed_legacy_fields [:id]
-  @forwarded_legacy_run_option_keys [:timeout, :jido]
-  @forwarded_legacy_start_option_keys [:jido]
+  @forwarded_legacy_run_option_keys [:timeout, :task_supervisor]
+  @forwarded_legacy_start_option_keys [:task_supervisor]
   @start_rejected_legacy_option_keys [:timeout]
   @removed_legacy_option_keys [
     :max_retries,
@@ -381,7 +381,9 @@ defmodule Jido.Instruction do
         {:ok, call_opts}
 
       {:ok, legacy_opts} ->
-        migrate_normalized_legacy_opts(legacy_opts, call_opts, target, mode)
+        with :ok <- Jido.Exec.Runtime.reject_jido(legacy_opts) do
+          migrate_normalized_legacy_opts(legacy_opts, call_opts, target, mode)
+        end
 
       {:error, error} ->
         warn_invalid_legacy_opts(target, mode)

--- a/test/jido_exec/action_process_test.exs
+++ b/test/jido_exec/action_process_test.exs
@@ -51,9 +51,13 @@ defmodule JidoActionTest.Exec.ActionProcessTest do
           Exec.run(target, input, context)
         end)
 
+      on_exit(fn -> Process.exit(caller, :kill) end)
       assert_receive {:blocking_flow_node_started, worker}, 2_000, to_string(form)
       refute worker == caller
       worker_monitor = Process.monitor(worker)
+      # Confirm the monitor before caller cleanup can terminate this worker.
+      assert {:monitored_by, monitors} = Process.info(worker, :monitored_by)
+      assert self() in monitors
 
       Process.exit(caller, :kill)
 
@@ -70,9 +74,12 @@ defmodule JidoActionTest.Exec.ActionProcessTest do
         Exec.run(BlockingAction, %{value: 1}, %{test_pid: owner}, timeout: 10_000)
       end)
 
+    on_exit(fn -> Process.exit(caller, :kill) end)
     assert_receive {:blocking_flow_node_started, worker}, 1_000
     refute worker == caller
     worker_monitor = Process.monitor(worker)
+    assert {:monitored_by, monitors} = Process.info(worker, :monitored_by)
+    assert self() in monitors
 
     Process.exit(caller, :kill)
 

--- a/test/jido_exec/action_process_test.exs
+++ b/test/jido_exec/action_process_test.exs
@@ -115,7 +115,7 @@ defmodule JidoActionTest.Exec.ActionProcessTest do
     assert_receive {:action_result, :second, {:ok, %{value: 2}}}, 1_000
   end
 
-  test "routes every executable form through one Jido instance" do
+  test "routes every executable form through one named supervisor" do
     instance = unique_module("JidoInstance")
     task_supervisor = Module.concat(instance, TaskSupervisor)
     start_supervised!({Task.Supervisor, name: task_supervisor})
@@ -129,7 +129,9 @@ defmodule JidoActionTest.Exec.ActionProcessTest do
                                                                          } ->
       caller =
         Task.async(fn ->
-          result = Exec.run(target, input, context, jido: instance, timeout: 10_000)
+          result =
+            Exec.run(target, input, context, task_supervisor: task_supervisor, timeout: 10_000)
+
           send(owner, {:instance_routed_result, form, result})
         end)
 

--- a/test/jido_exec/async_execution_test.exs
+++ b/test/jido_exec/async_execution_test.exs
@@ -199,7 +199,7 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
   end
 
-  test "routes the handle and target work through a requested Jido instance" do
+  test "routes the handle and target work through a named supervisor" do
     instance = unique_module("AsyncJido")
     task_supervisor = Module.concat(instance, TaskSupervisor)
     start_supervised!({Task.Supervisor, name: task_supervisor})
@@ -209,7 +209,7 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
         BlockingAction,
         %{value: 1},
         %{test_pid: self()},
-        jido: instance
+        task_supervisor: task_supervisor
       )
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
@@ -247,10 +247,10 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
   end
 
   test "reports routing and option failures before an async process starts" do
-    missing_instance = unique_module("MissingAsyncJido")
+    missing_supervisor = unique_module("MissingAsyncSupervisor")
 
     assert_raise Jido.Action.Error.InvalidInputError, fn ->
-      Exec.run_async(Add, %{value: 1}, %{}, jido: missing_instance)
+      Exec.run_async(Add, %{value: 1}, %{}, task_supervisor: missing_supervisor)
     end
 
     assert_raise Error.AsyncExecutionError, fn ->

--- a/test/jido_exec/async_mailbox_hygiene_test.exs
+++ b/test/jido_exec/async_mailbox_hygiene_test.exs
@@ -82,7 +82,7 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
   test "an abnormal DOWN returns one terminal execution error" do
     handle = Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
     assert_receive {:blocking_flow_node_started, worker}, 1_000
-    worker_monitor = Process.monitor(worker)
+    worker_monitor = monitor_worker(worker)
 
     Process.exit(handle.pid, :kill)
 
@@ -138,7 +138,7 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
   test "cancel by PID claims the shared handle and leaves no mailbox residue" do
     handle = Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
     assert_receive {:blocking_flow_node_started, worker}, 1_000
-    worker_monitor = Process.monitor(worker)
+    worker_monitor = monitor_worker(worker)
 
     assert :ok = Exec.cancel(handle.pid)
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
@@ -168,11 +168,20 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
       Exec.run_async(ContinueToBlocking, %{value: 1}, %{test_pid: self()}, max_continuations: 1)
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
-    worker_monitor = Process.monitor(worker)
+    worker_monitor = monitor_worker(worker)
 
     assert :ok = Exec.cancel(handle)
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
     refute_handle_messages(handle)
+  end
+
+  defp monitor_worker(worker) do
+    monitor = Process.monitor(worker)
+    # Monitor requests are asynchronous. Confirm installation before another
+    # process kills the worker so the DOWN reason must be :killed, not :noproc.
+    assert {:monitored_by, monitors} = Process.info(worker, :monitored_by)
+    assert self() in monitors
+    monitor
   end
 
   defp with_released_action(value, fun) do

--- a/test/jido_exec/blocked_telemetry_test.exs
+++ b/test/jido_exec/blocked_telemetry_test.exs
@@ -31,7 +31,7 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
   end
 
   setup do
-    supervisor = Exec.task_supervisor_name(__MODULE__)
+    supervisor = __MODULE__.TaskSupervisor
     start_supervised!({Task.Supervisor, name: supervisor})
     %{supervisor: supervisor}
   end
@@ -47,7 +47,7 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
         result =
           Exec.run(BlockingAction, %{value: 1}, %{test_pid: owner},
             timeout: 1_000,
-            jido: __MODULE__
+            task_supervisor: __MODULE__.TaskSupervisor
           )
 
         send(owner, {token, :result, result})
@@ -81,7 +81,9 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
       monitors_before = Process.info(self(), :monitors)
 
       handle =
-        Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+        Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token},
+          task_supervisor: __MODULE__.TaskSupervisor
+        )
 
       on_exit(fn -> Process.exit(handle.pid, :kill) end)
       assert_receive {^token, :handler_blocked, handler}, 1_000
@@ -124,10 +126,17 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
 
           case mode do
             :sync ->
-              Exec.run(ControlledAction, %{}, context, timeout: 10_000, jido: __MODULE__)
+              Exec.run(ControlledAction, %{}, context,
+                timeout: 10_000,
+                task_supervisor: __MODULE__.TaskSupervisor
+              )
 
             :async ->
-              handle = Exec.run_async(ControlledAction, %{}, context, jido: __MODULE__)
+              handle =
+                Exec.run_async(ControlledAction, %{}, context,
+                  task_supervisor: __MODULE__.TaskSupervisor
+                )
+
               send(owner, {token, :handle, handle.pid})
 
               receive do
@@ -179,7 +188,7 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
         result =
           Exec.run(flow, %{}, %{test_pid: owner, token: token},
             timeout: 1_000,
-            jido: __MODULE__
+            task_supervisor: __MODULE__.TaskSupervisor
           )
 
         send(owner, {token, :result, result})
@@ -212,7 +221,7 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
           result =
             Exec.run(ControlledAction, %{}, %{test_pid: owner, token: token},
               timeout: 10_000,
-              jido: __MODULE__
+              task_supervisor: __MODULE__.TaskSupervisor
             )
 
           send(owner, {token, :result, result})
@@ -257,7 +266,9 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
       on_exit(fn -> :telemetry.detach(handler_id) end)
 
       handle =
-        Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+        Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token},
+          task_supervisor: __MODULE__.TaskSupervisor
+        )
 
       on_exit(fn -> Process.exit(handle.pid, :kill) end)
       assert_receive {^token, :handler_failed, handler}, 1_000
@@ -287,7 +298,9 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
         )
 
       handle =
-        Exec.run_async(flow, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+        Exec.run_async(flow, %{}, %{test_pid: self(), token: token},
+          task_supervisor: __MODULE__.TaskSupervisor
+        )
 
       on_exit(fn -> Process.exit(handle.pid, :kill) end)
       assert_receive {^token, :action_started, action, _tracker}, 1_000
@@ -335,7 +348,9 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
     token = attach_blocking([:jido, :action, :start], true)
 
     handle =
-      Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+      Exec.run_async(ControlledAction, %{}, %{test_pid: self(), token: token},
+        task_supervisor: __MODULE__.TaskSupervisor
+      )
 
     on_exit(fn -> Process.exit(handle.pid, :kill) end)
     assert_receive {^token, :handler_blocked, handler}, 1_000
@@ -367,7 +382,11 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
           output: Ref.result("child")
         )
 
-      handle = Exec.run_async(flow, %{}, %{test_pid: self(), token: token}, jido: __MODULE__)
+      handle =
+        Exec.run_async(flow, %{}, %{test_pid: self(), token: token},
+          task_supervisor: __MODULE__.TaskSupervisor
+        )
+
       on_exit(fn -> Process.exit(handle.pid, :kill) end)
       assert_receive {^token, :handler_blocked, handler}, 1_000
       on_exit(fn -> Process.exit(handler, :kill) end)
@@ -405,7 +424,7 @@ defmodule JidoActionTest.Exec.BlockedTelemetryTest do
 
     for mode <- [:sync, :async] do
       target = JidoActionTest.Fixtures.Actions.Add
-      opts = [timeout: 1_000, jido: __MODULE__]
+      opts = [timeout: 1_000, task_supervisor: __MODULE__.TaskSupervisor]
 
       result =
         case mode do

--- a/test/jido_exec/execution_guard_interruption_test.exs
+++ b/test/jido_exec/execution_guard_interruption_test.exs
@@ -9,6 +9,7 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
   alias JidoActionTest.Fixtures.Execution, as: ExecFixtures
   alias JidoActionTest.Fixtures.Actions.RecorderAction
 
+  @node_start [:jido, :flow, :node, :start]
   @node_stop [:jido, :flow, :node, :stop]
 
   test "marks a mutation indeterminate when its owner exits during Action work" do
@@ -20,15 +21,16 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
       )
 
     assert {:ok, execution} = Exec.start(flow, %{}, %{test_pid: self()})
-    {caller, caller_monitor} = spawn_monitor(fn -> Exec.step(execution) end)
+    {caller, caller_monitor, helper, helper_monitor} = start_step(execution)
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
-    worker_monitor = Process.monitor(worker)
+    worker_monitor = monitor_process(worker)
     Process.exit(caller, :kill)
 
     assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :killed}, 1_000
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
-    assert_guard_indeterminate(execution)
+    assert_receive {:DOWN, ^helper_monitor, :process, ^helper, :normal}, 1_000
+    assert :atomics.get(execution.guard, 2) == 1
 
     assert {:error, %InvalidExecutionError{details: %{reason: :indeterminate}}} =
              Exec.step(execution)
@@ -43,12 +45,13 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
       :telemetry.attach(handler, @node_stop, &__MODULE__.kill_owner_after_node_stop/4, self())
 
     on_exit(fn -> :telemetry.detach(handler) end)
-    {caller, caller_monitor} = spawn_monitor(fn -> Exec.step(execution) end)
+    {caller, caller_monitor, helper, helper_monitor} = start_step(execution)
 
     assert_receive {RecorderAction, %{value: :once}}, 1_000
     assert_receive {:node_stopped_before_guard_advance, ^caller}, 1_000
     assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :killed}, 1_000
-    assert_guard_indeterminate(execution)
+    assert_receive {:DOWN, ^helper_monitor, :process, ^helper, :normal}, 1_000
+    assert :atomics.get(execution.guard, 2) == 1
 
     assert {:error, %InvalidExecutionError{details: %{reason: :indeterminate}}} =
              Exec.step(execution)
@@ -88,7 +91,7 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
       end)
 
     assert_receive {:guard_claimed, ^owner, helper}, 1_000
-    helper_monitor = Process.monitor(helper)
+    helper_monitor = monitor_process(helper)
 
     {claimant, claimant_monitor} =
       spawn_monitor(fn -> send(test_pid, {:failed_claim, ExecutionGuard.claim(execution)}) end)
@@ -147,17 +150,50 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
     Process.exit(self(), :kill)
   end
 
-  defp assert_guard_indeterminate(%{guard: guard}) do
-    assert await_guard_state(guard, 10_000) == :indeterminate
+  def capture_guard_before_node_start(
+        @node_start,
+        _measurements,
+        %{execution_id: execution_id},
+        {test_pid, execution_id, token}
+      ) do
+    send(test_pid, {token, :guard_ready, self()})
+    receive do: ({^token, :resume} -> :ok)
   end
 
-  defp await_guard_state(_guard, 0), do: :not_indeterminate
+  def capture_guard_before_node_start(_event, _measurements, _metadata, _config), do: :ok
 
-  defp await_guard_state(guard, attempts) do
-    case :atomics.get(guard, 2) do
-      1 -> :indeterminate
-      _state -> await_guard_state(guard, attempts - 1)
-    end
+  defp start_step(execution) do
+    token = make_ref()
+    handler = {__MODULE__, token}
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        @node_start,
+        &__MODULE__.capture_guard_before_node_start/4,
+        {self(), execution.id, token}
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    {caller, caller_monitor} = spawn_monitor(fn -> Exec.step(execution) end)
+    on_exit(fn -> Process.exit(caller, :kill) end)
+    assert_receive {^token, :guard_ready, ^caller}, 1_000
+
+    # At node start the mutation is claimed, but no Action worker exists yet.
+    # Caller death alone does not confirm that this helper handled its DOWN.
+    assert {:monitors, [{:process, helper}]} = Process.info(caller, :monitors)
+    helper_monitor = monitor_process(helper)
+    :ok = :telemetry.detach(handler)
+    send(caller, {token, :resume})
+    {caller, caller_monitor, helper, helper_monitor}
+  end
+
+  defp monitor_process(pid) do
+    monitor = Process.monitor(pid)
+    # Confirm registration before another process can stop the monitored PID.
+    assert {:monitored_by, monitors} = Process.info(pid, :monitored_by)
+    assert self() in monitors
+    monitor
   end
 
   defp recorder_flow(name) do

--- a/test/jido_exec/genserver_completion_test.exs
+++ b/test/jido_exec/genserver_completion_test.exs
@@ -1,50 +1,77 @@
 defmodule JidoActionTest.Exec.GenServerCompletionTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Jido.Exec.Error.AsyncExecutionError
   alias JidoActionTest.Fixtures.Execution.BlockingAction
 
-  # Compile the exact guide example so the public callback pattern stays usable.
-  @guide Path.expand("../../guides/execution.md", __DIR__)
-  @external_resource @guide
-  [_, source] =
-    Regex.run(~r/```elixir\n(defmodule MyApp.ReportServer.*?\nend)\n/s, File.read!(@guide))
+  defmodule ReportServer do
+    use GenServer
 
-  Code.compile_string(source, @guide)
+    def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
 
-  test "the documented server handles calls while work runs and consumes completion" do
+    @impl true
+    def init(opts) do
+      {:ok, %{supervisor: opts[:supervisor], owner: opts[:owner], handle: nil, result: nil}}
+    end
+
+    @impl true
+    def handle_call({:run, value}, _from, %{handle: nil} = state) do
+      handle =
+        Jido.Exec.run_async(BlockingAction, %{value: value}, %{test_pid: state.owner},
+          task_supervisor: state.supervisor
+        )
+
+      {:reply, :ok, %{state | handle: handle}}
+    rescue
+      error in AsyncExecutionError -> {:reply, {:error, error}, state}
+    end
+
+    def handle_call({:run, _value}, _from, state), do: {:reply, {:error, :busy}, state}
+
+    def handle_call(:status, _from, state),
+      do: {:reply, %{running?: state.handle != nil, result: state.result}, state}
+
+    @impl true
+    def handle_info(_message, %{handle: nil} = state), do: {:noreply, state}
+
+    def handle_info(message, state) do
+      case Jido.Exec.handle_message(state.handle, message) do
+        :ignore ->
+          {:noreply, state}
+
+        {:done, result} ->
+          send(state.owner, {:completed, self(), result})
+          {:noreply, %{state | handle: nil, result: result}}
+      end
+    end
+  end
+
+  test "a GenServer remains responsive and consumes completion in its owner" do
     supervisor = start_supervised!(Task.Supervisor)
 
-    server =
-      start_supervised!({MyApp.ReportServer, target: BlockingAction, task_supervisor: supervisor})
+    server = start_supervised!({ReportServer, supervisor: supervisor, owner: self()})
 
-    :erlang.trace(server, true, [:receive])
-
-    assert :ok = GenServer.call(server, {:run, %{value: :report}, %{test_pid: self()}})
+    assert :ok = GenServer.call(server, {:run, :report})
     assert_receive {:blocking_flow_node_started, worker}, 1_000
     assert GenServer.call(server, :status) == %{running?: true, result: nil}
-    assert GenServer.call(server, {:run, %{}, %{}}) == {:error, :busy}
+    assert GenServer.call(server, {:run, :other}) == {:error, :busy}
     send(server, :unrelated)
     assert GenServer.call(server, :status) == %{running?: true, result: nil}
 
     send(worker, :finish)
-    # The receive trace is a barrier: the server has selected its completion
-    # before the next status call. No timing or polling is needed.
-    assert_receive {:trace, ^server, :receive, {:jido_exec_async_result, _, _, _}}, 1_000
+    assert_receive {:completed, ^server, {:ok, %{value: :report}}}, 1_000
     assert GenServer.call(server, :status) == %{running?: false, result: {:ok, %{value: :report}}}
     send(server, :stale)
     assert GenServer.call(server, :status).running? == false
-    :erlang.trace(server, false, [:receive])
   end
 
-  test "the documented server contains a control-task capacity failure" do
+  test "a GenServer contains a control-task capacity failure" do
     supervisor = start_supervised!({Task.Supervisor, max_children: 0})
 
-    server =
-      start_supervised!({MyApp.ReportServer, target: BlockingAction, task_supervisor: supervisor})
+    server = start_supervised!({ReportServer, supervisor: supervisor, owner: self()})
 
     assert {:error, %AsyncExecutionError{details: %{reason: :max_children}}} =
-             GenServer.call(server, {:run, %{}, %{}})
+             GenServer.call(server, {:run, :report})
 
     assert GenServer.call(server, :status) == %{running?: false, result: nil}
   end

--- a/test/jido_exec/genserver_completion_test.exs
+++ b/test/jido_exec/genserver_completion_test.exs
@@ -1,0 +1,51 @@
+defmodule JidoActionTest.Exec.GenServerCompletionTest do
+  use ExUnit.Case, async: false
+
+  alias Jido.Exec.Error.AsyncExecutionError
+  alias JidoActionTest.Fixtures.Execution.BlockingAction
+
+  # Compile the exact guide example so the public callback pattern stays usable.
+  @guide Path.expand("../../guides/execution.md", __DIR__)
+  @external_resource @guide
+  [_, source] =
+    Regex.run(~r/```elixir\n(defmodule MyApp.ReportServer.*?\nend)\n/s, File.read!(@guide))
+
+  Code.compile_string(source, @guide)
+
+  test "the documented server handles calls while work runs and consumes completion" do
+    supervisor = start_supervised!(Task.Supervisor)
+
+    server =
+      start_supervised!({MyApp.ReportServer, target: BlockingAction, task_supervisor: supervisor})
+
+    :erlang.trace(server, true, [:receive])
+
+    assert :ok = GenServer.call(server, {:run, %{value: :report}, %{test_pid: self()}})
+    assert_receive {:blocking_flow_node_started, worker}, 1_000
+    assert GenServer.call(server, :status) == %{running?: true, result: nil}
+    assert GenServer.call(server, {:run, %{}, %{}}) == {:error, :busy}
+    send(server, :unrelated)
+    assert GenServer.call(server, :status) == %{running?: true, result: nil}
+
+    send(worker, :finish)
+    # The receive trace is a barrier: the server has selected its completion
+    # before the next status call. No timing or polling is needed.
+    assert_receive {:trace, ^server, :receive, {:jido_exec_async_result, _, _, _}}, 1_000
+    assert GenServer.call(server, :status) == %{running?: false, result: {:ok, %{value: :report}}}
+    send(server, :stale)
+    assert GenServer.call(server, :status).running? == false
+    :erlang.trace(server, false, [:receive])
+  end
+
+  test "the documented server contains a control-task capacity failure" do
+    supervisor = start_supervised!({Task.Supervisor, max_children: 0})
+
+    server =
+      start_supervised!({MyApp.ReportServer, target: BlockingAction, task_supervisor: supervisor})
+
+    assert {:error, %AsyncExecutionError{details: %{reason: :max_children}}} =
+             GenServer.call(server, {:run, %{}, %{}})
+
+    assert GenServer.call(server, :status) == %{running?: false, result: nil}
+  end
+end

--- a/test/jido_exec/inline_action_contract_test.exs
+++ b/test/jido_exec/inline_action_contract_test.exs
@@ -270,7 +270,7 @@ defmodule JidoActionTest.Exec.InlineActionContractTest do
 
   test "cancelling inline Map work stops all workers and releases the routed supervisor" do
     instance = JidoActionTest.InlineMapCancellation
-    supervisor = Exec.task_supervisor_name(instance)
+    supervisor = Module.concat(instance, TaskSupervisor)
     start_supervised!({Task.Supervisor, name: supervisor})
     probe = start_supervised!({Agent, fn -> %{running: 0, max: 0, started: []} end})
     ref = make_ref()
@@ -279,7 +279,7 @@ defmodule JidoActionTest.Exec.InlineActionContractTest do
     handle =
       Exec.run_async(ControlledMap, %{items: [1, 2, 3, 4]}, context,
         max_concurrency: 2,
-        jido: instance
+        task_supervisor: supervisor
       )
 
     try do

--- a/test/jido_exec/instruction_execution_test.exs
+++ b/test/jido_exec/instruction_execution_test.exs
@@ -81,22 +81,6 @@ defmodule JidoActionTest.Exec.InstructionExecutionTest do
     refute log =~ "Not applied because"
   end
 
-  test "rejects legacy jido routing with migration guidance" do
-    instruction = %Instruction{
-      target: Add,
-      params: %{value: 5},
-      opts: [jido: "do-not-log"]
-    }
-
-    {result, log} = with_log(fn -> Exec.run(instruction) end)
-
-    assert {:error, %InvalidInputError{message: message, details: %{option: :jido}}} = result
-    assert message =~ "jido option was removed"
-    assert message =~ "task_supervisor:"
-    refute log =~ "Forwarded"
-    refute log =~ "do-not-log"
-  end
-
   test "gives direct Exec options precedence over legacy Instruction options" do
     instruction = %Instruction{
       target: Add,

--- a/test/jido_exec/instruction_execution_test.exs
+++ b/test/jido_exec/instruction_execution_test.exs
@@ -64,24 +64,24 @@ defmodule JidoActionTest.Exec.InstructionExecutionTest do
     assert log =~ "Use :target instead"
   end
 
-  test "forwards legacy timeout and jido options with one grouped warning" do
+  test "forwards legacy timeout and supervisor options with one grouped warning" do
     instruction = %Instruction{
       target: Add,
       params: %{value: 5},
-      opts: [timeout: 0, jido: nil]
+      opts: [timeout: 0, task_supervisor: Jido.Exec.TaskSupervisor]
     }
 
     {result, log} = with_log(fn -> Exec.run(instruction) end)
 
     assert {:error, %TimeoutError{timeout: 0}} = result
     assert log =~ "Jido.Instruction received the deprecated :opts field"
-    assert log =~ "Forwarded to Jido.Exec.run/4: [:timeout, :jido]"
+    assert log =~ "Forwarded to Jido.Exec.run/4: [:timeout, :task_supervisor]"
     assert log =~ "Move execution options to Jido.Exec.run/4"
     assert length(Regex.scan(~r/received the deprecated :opts field/, log)) == 1
     refute log =~ "Not applied because"
   end
 
-  test "forwards legacy jido routing to normal Exec validation" do
+  test "rejects legacy jido routing with migration guidance" do
     instruction = %Instruction{
       target: Add,
       params: %{value: 5},
@@ -90,8 +90,10 @@ defmodule JidoActionTest.Exec.InstructionExecutionTest do
 
     {result, log} = with_log(fn -> Exec.run(instruction) end)
 
-    assert {:error, %InvalidInputError{details: %{option: :jido, value: "do-not-log"}}} = result
-    assert log =~ "Forwarded to Jido.Exec.run/4: [:jido]"
+    assert {:error, %InvalidInputError{message: message, details: %{option: :jido}}} = result
+    assert message =~ "jido option was removed"
+    assert message =~ "task_supervisor:"
+    refute log =~ "Forwarded"
     refute log =~ "do-not-log"
   end
 

--- a/test/jido_exec/native_runtime_policy_test.exs
+++ b/test/jido_exec/native_runtime_policy_test.exs
@@ -397,7 +397,10 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
       )
     )
 
-    for opts <- [[jido: instance], [jido: instance, timeout: 1_000]] do
+    for opts <- [
+          [task_supervisor: task_supervisor],
+          [task_supervisor: task_supervisor, timeout: 1_000]
+        ] do
       assert {:error,
               %Jido.Action.Error.ExecutionFailureError{
                 message: "action execution process could not start",
@@ -458,25 +461,25 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
     Enum.each(workers, &assert_process_stops/1)
   end
 
-  test "validates the Jido instance routing option for Actions and Flows" do
+  test "validates the supervisor reference for Actions and Flows" do
     flow = FlowFixtures.math_flow!()
 
-    assert {:error, %InvalidInputError{details: %{option: :jido, value: "bad"}}} =
-             Exec.run(Add, %{value: 1}, %{}, jido: "bad")
+    assert {:error, %InvalidInputError{details: %{option: :task_supervisor, value: "bad"}}} =
+             Exec.run(Add, %{value: 1}, %{}, task_supervisor: "bad")
 
-    assert {:error, %InvalidExecutionError{details: %{option: :jido, value: "bad"}}} =
-             Exec.run(flow, %{value: 1}, %{}, jido: "bad")
+    assert {:error, %InvalidExecutionError{details: %{option: :task_supervisor, value: "bad"}}} =
+             Exec.run(flow, %{value: 1}, %{}, task_supervisor: "bad")
 
     missing_instance = Module.concat(__MODULE__, MissingJidoInstance)
     missing_supervisor = Module.concat(missing_instance, TaskSupervisor)
 
     for {form, {target, input, context}} <-
           ExecFixtures.blocking_execution_forms(BlockingFlow, self()) do
-      case Exec.run(target, input, context, jido: missing_instance) do
+      case Exec.run(target, input, context, task_supervisor: missing_supervisor) do
         {:error,
          %InvalidInputError{
            message: "Task Supervisor is not running",
-           details: %{jido: ^missing_instance, task_supervisor: ^missing_supervisor}
+           details: %{task_supervisor: ^missing_supervisor}
          }}
         when form in [:action, :action_instruction] ->
           :ok
@@ -484,7 +487,7 @@ defmodule JidoActionTest.Exec.NativeRuntimePolicyTest do
         {:error,
          %InvalidExecutionError{
            message: "Task Supervisor is not running",
-           details: %{jido: ^missing_instance, task_supervisor: ^missing_supervisor}
+           details: %{task_supervisor: ^missing_supervisor}
          }}
         when form in [:flow_value, :flow_module, :flow_instruction, :subflow] ->
           :ok

--- a/test/jido_exec/supervisor_reference_test.exs
+++ b/test/jido_exec/supervisor_reference_test.exs
@@ -5,7 +5,7 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
   alias Jido.Exec
   alias Jido.Exec.Error.AsyncExecutionError
   alias Jido.Flow
-  alias Jido.Flow.{Condition, Dispatch, Iterate, Reduce, Ref}
+  alias Jido.Flow.{Condition, Dispatch, Iterate, Reduce, Ref, Subflow}
   alias Jido.Flow.Map, as: FlowMap
   alias Jido.Instruction
   alias JidoActionTest.Fixtures.BlockingFlow
@@ -32,8 +32,27 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
 
       receive do
         {^ref, :raise} -> raise ArgumentError, "via registry stopped"
+        {^ref, :throw} -> throw(:via_unavailable)
+        {^ref, :exit} -> exit(:via_unavailable)
+        {^ref, :missing} -> :undefined
         {^ref, pid} -> pid
       end
+    end
+  end
+
+  defmodule ContextData do
+    use Jido.Action, name: "supervisor_host_context"
+
+    @impl true
+    def run(_params, context), do: {:ok, context}
+  end
+
+  defmodule ContextFlow do
+    use Jido.Flow, name: "supervisor_host_context_flow"
+
+    flow do
+      step("echo", action: ContextData, params: %{})
+      output(result("echo"))
     end
   end
 
@@ -73,7 +92,7 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
         assert_receive {:blocking_flow_node_started, worker}, 1_000, inspect({form, mode})
         assert worker in Task.Supervisor.children(expected_supervisor)
         refute worker in Task.Supervisor.children(Jido.Exec.TaskSupervisor)
-        monitor = Process.monitor(worker)
+        monitor = monitor_worker(worker)
         send(worker, :finish)
         assert {:ok, %{value: _}} = caller_result(caller)
         assert_receive {:DOWN, ^monitor, :process, ^worker, :normal}
@@ -275,7 +294,7 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
       Exec.run_async(BlockingAction, %{}, %{test_pid: self()}, task_supervisor: first)
 
     assert_receive {:blocking_flow_node_started, first_worker}
-    first_monitor = Process.monitor(first_worker)
+    first_monitor = monitor_worker(first_worker)
 
     second_handle =
       Exec.run_async(BlockingAction, %{}, %{test_pid: self()}, task_supervisor: second)
@@ -292,29 +311,34 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
     assert {:ok, %{}} = Exec.await(second_handle)
   end
 
-  test "named paused work uses a replacement while a PID route stays with its original process" do
-    name = __MODULE__.Replacement
-    original = start_supervised!({Task.Supervisor, name: name})
-    context = %{test_pid: self()}
-    {:ok, named} = Exec.start(BlockingFlow, %{value: :new}, context, task_supervisor: name)
-    {:ok, pinned} = Exec.start(BlockingFlow, %{value: :old}, context, task_supervisor: original)
-    stop_supervised!(name)
-    replacement = start_supervised!({Task.Supervisor, name: name})
-    refute original == replacement
+  for route_kind <- [:name, :registry] do
+    @route_kind route_kind
+    test "paused #{@route_kind} work uses a replacement while a PID keeps its original lifetime" do
+      route = start_route(@route_kind)
+      original = GenServer.whereis(route)
+      context = %{test_pid: self()}
+      {:ok, named} = Exec.start(BlockingFlow, %{value: :new}, context, task_supervisor: route)
+      {:ok, pinned} = Exec.start(BlockingFlow, %{value: :old}, context, task_supervisor: original)
+      stop_supervised!(Task.Supervisor.child_spec(name: route).id)
+      replacement = start_supervised!({Task.Supervisor, name: route})
+      refute original == replacement
 
-    assert {:ok, failed} = Exec.continue(pinned)
+      assert {:ok, failed} = Exec.continue(pinned)
 
-    assert {:error, %ExecutionFailureError{details: %{task_supervisor: ^original}}} =
-             Exec.result(failed)
+      assert {:error, %ExecutionFailureError{details: %{task_supervisor: ^original}}} =
+               Exec.result(failed)
 
-    refute_received {:blocking_flow_node_started, _}
+      refute_received {:blocking_flow_node_started, _}
 
-    caller = start_caller(fn -> finish_execution(named, :continue) end)
-    assert_receive {:blocking_flow_node_started, worker}
-    assert worker in Task.Supervisor.children(replacement)
-    send(worker, :finish)
-    assert {:ok, %{value: :new}} = caller_result(caller)
-    assert Task.Supervisor.children(replacement) == []
+      caller = start_caller(fn -> finish_execution(named, :continue) end)
+      assert_receive {:blocking_flow_node_started, worker}, 1_000
+      monitor = monitor_worker(worker)
+      assert worker in Task.Supervisor.children(replacement)
+      send(worker, :finish)
+      assert {:ok, %{value: :new}} = caller_result(caller)
+      assert_receive {:DOWN, ^monitor, :process, ^worker, :normal}, 1_000
+      assert Task.Supervisor.children(replacement) == []
+    end
   end
 
   test "contains supervisor shutdown during a synchronous Action or Flow call" do
@@ -332,7 +356,7 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
         end)
 
       assert_receive {:blocking_flow_node_started, worker}
-      monitor = Process.monitor(worker)
+      monitor = monitor_worker(worker)
       Supervisor.stop(supervisor)
       assert_receive {:DOWN, ^monitor, :process, ^worker, :shutdown}
 
@@ -344,7 +368,8 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
   test "contains a task-start race after successful via lookup without fallback" do
     owner = self()
 
-    for mode <- [:run, :async], failure <- [:dead_pid, :raise] do
+    for mode <- [:run, :finite, :flow, :async],
+        failure <- [:dead_pid, :raise, :missing, :throw, :exit] do
       supervisor = start_route(:pid)
       token = make_ref()
       route = {:via, BarrierVia, {owner, token}}
@@ -355,6 +380,15 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
             case mode do
               :run ->
                 Exec.run(BlockingAction, %{}, %{test_pid: owner}, task_supervisor: route)
+
+              :finite ->
+                Exec.run(BlockingAction, %{}, %{test_pid: owner},
+                  task_supervisor: route,
+                  timeout: 10_000
+                )
+
+              :flow ->
+                Exec.run(BlockingFlow, %{value: 1}, %{test_pid: owner}, task_supervisor: route)
 
               :async ->
                 Exec.run_async(BlockingAction, %{}, %{test_pid: owner}, task_supervisor: route)
@@ -368,23 +402,121 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
       send(lookup_caller, {ref, supervisor})
       assert_receive {:lookup, ^token, lookup_caller, ref}
       Supervisor.stop(supervisor)
-      send(lookup_caller, {ref, if(failure == :raise, do: :raise, else: supervisor)})
+      send(lookup_caller, {ref, if(failure == :dead_pid, do: supervisor, else: failure)})
       assert {:error, error} = caller_result(caller)
 
       assert error.__struct__ ==
-               if(mode == :run, do: ExecutionFailureError, else: AsyncExecutionError)
+               if(mode == :async, do: AsyncExecutionError, else: ExecutionFailureError)
 
       assert error.details.task_supervisor == route
 
-      if failure == :raise do
-        assert {:error, %ArgumentError{}} = error.details.reason
-      else
-        assert {:exit, _} = error.details.reason
+      case failure do
+        :raise -> assert {:error, %ArgumentError{}} = error.details.reason
+        :dead_pid -> assert {:exit, _} = error.details.reason
+        :missing -> assert error.details.reason == :noproc
+        kind -> assert error.details.reason == {kind, :via_unavailable}
       end
 
       assert error.details.retry == false
       refute_received {:blocking_flow_node_started, _}
     end
+  end
+
+  test "contains via lookup failures at the public validation boundary" do
+    owner = self()
+
+    for mode <- [:run, :finite, :start, :async], failure <- [:raise, :throw, :exit] do
+      token = make_ref()
+      route = {:via, BarrierVia, {owner, token}}
+
+      caller =
+        start_caller(fn ->
+          try do
+            case mode do
+              :run ->
+                Exec.run(BlockingFlow, %{value: 1}, %{test_pid: owner}, task_supervisor: route)
+
+              :finite ->
+                Exec.run(BlockingFlow, %{value: 1}, %{test_pid: owner},
+                  task_supervisor: route,
+                  timeout: 10_000
+                )
+
+              :start ->
+                Exec.start(BlockingFlow, %{value: 1}, %{test_pid: owner}, task_supervisor: route)
+
+              :async ->
+                Exec.run_async(BlockingFlow, %{value: 1}, %{test_pid: owner},
+                  task_supervisor: route
+                )
+            end
+          rescue
+            error -> {:error, error}
+          end
+        end)
+
+      assert_receive {:lookup, ^token, lookup_caller, ref}, 1_000
+      send(lookup_caller, {ref, failure})
+      assert {:error, error} = caller_result(caller)
+
+      assert error.__struct__ ==
+               if(mode == :async,
+                 do: InvalidInputError,
+                 else: Jido.Flow.Error.InvalidExecutionError
+               )
+
+      assert error.message == "Task Supervisor lookup failed"
+      assert error.details.task_supervisor == route
+
+      case failure do
+        :raise -> assert %ArgumentError{} = error.details.reason
+        kind -> assert error.details.reason == {kind, :via_unavailable}
+      end
+
+      refute_received {:blocking_flow_node_started, _}
+    end
+  end
+
+  test "keeps context.jido as host data through Actions, Instructions, and nested Flows" do
+    supervisor = start_route(:pid)
+    context = %{jido: %{host: :example}, marker: make_ref()}
+
+    flow = ContextFlow.flow()
+
+    parent =
+      Flow.new!(
+        name: "nested_host_context",
+        components: [
+          Subflow.new!(name: :child, flow: ContextFlow)
+        ],
+        output: Ref.result(:child)
+      )
+
+    for target <- [ContextData, Instruction.new!(target: ContextData), flow, parent] do
+      for timeout <- [:infinity, 10_000] do
+        assert Exec.run(target, %{}, context, task_supervisor: supervisor, timeout: timeout) ==
+                 {:ok, context}
+      end
+
+      handle = Exec.run_async(target, %{}, context, task_supervisor: supervisor)
+      assert Exec.await(handle) == {:ok, context}
+    end
+
+    for target <- [flow, parent] do
+      {:ok, execution} = Exec.start(target, %{}, context, task_supervisor: supervisor)
+      assert finish_execution(execution, :continue) == {:ok, context}
+    end
+
+    handle =
+      Exec.run_async(Continue, %{}, Map.merge(context, %{test_pid: self(), next: ContextData}),
+        task_supervisor: supervisor
+      )
+
+    assert_receive {:blocking_flow_node_started, worker}, 1_000
+    send(worker, :finish)
+    assert {:ok, %{jido: jido, marker: marker}} = Exec.await(handle)
+    assert jido == context.jido
+    assert marker == context.marker
   end
 
   test "returns capacity refusal for Action, Flow, and async control or target work" do
@@ -483,6 +615,14 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
     )
 
     {:via, PartitionSupervisor, {name, self()}}
+  end
+
+  defp monitor_worker(worker) do
+    monitor = Process.monitor(worker)
+    # Confirm the monitor before a different process can stop this worker.
+    assert {:monitored_by, monitors} = Process.info(worker, :monitored_by)
+    assert self() in monitors
+    monitor
   end
 
   defp start_caller(fun) do

--- a/test/jido_exec/supervisor_reference_test.exs
+++ b/test/jido_exec/supervisor_reference_test.exs
@@ -544,13 +544,30 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
     refute_received {:blocking_flow_node_started, _}
   end
 
-  test "rejects removed, duplicate, invalid, and absent routes before Action work" do
+  test "unknown options fail before Action work" do
+    for {_, {target, input, context}} <-
+          Fixtures.blocking_execution_forms(BlockingFlow, self()) do
+      assert {:error, error} = Exec.run(target, input, context, unknown: true)
+      assert error.message =~ "unknown"
+
+      handle = Exec.run_async(target, input, context, unknown: true)
+      assert {:error, error} = Exec.await(handle)
+      assert error.message =~ "unknown"
+      refute_received {:blocking_flow_node_started, _}
+    end
+
+    assert {:error, error} =
+             Exec.start(BlockingFlow, %{value: 1}, %{test_pid: self()}, unknown: true)
+
+    assert error.message =~ "unknown"
+    refute_received {:blocking_flow_node_started, _}
+  end
+
+  test "rejects duplicate, invalid, and absent routes before Action work" do
     supervisor = start_route(:pid)
 
     for target <- [BlockingAction, BlockingFlow],
         opts <- [
-          [jido: nil],
-          [jido: __MODULE__, task_supervisor: supervisor],
           [task_supervisor: supervisor, task_supervisor: supervisor],
           [task_supervisor: nil],
           [task_supervisor: "bad"],
@@ -562,32 +579,16 @@ defmodule JidoActionTest.Exec.SupervisorReferenceTest do
         ] do
       assert {:error, error} = Exec.run(target, %{value: 1}, %{test_pid: self()}, opts)
       assert is_exception(error)
-      assert error.details.option in [:jido, :task_supervisor]
-
-      if Keyword.has_key?(opts, :jido) do
-        assert error.message =~ "jido option was removed"
-        assert error.message =~ "task_supervisor:"
-      end
+      assert error.details.option == :task_supervisor
 
       refute_received {:blocking_flow_node_started, _}
     end
 
     for opts <- [
-          [jido: nil],
           [task_supervisor: "bad"],
           [task_supervisor: supervisor, task_supervisor: supervisor]
         ] do
       assert_raise InvalidInputError, fn -> Exec.run_async(BlockingAction, %{}, %{}, opts) end
-    end
-  end
-
-  test "rejects legacy Instruction jido routing even with an explicit new route" do
-    instruction = %Instruction{target: BlockingAction, opts: [jido: nil]}
-    assert {:error, %InvalidInputError{message: message}} = Exec.run(instruction)
-    assert message =~ "jido option was removed"
-
-    assert_raise InvalidInputError, ~r/jido option was removed/, fn ->
-      Exec.run_async(instruction, %{}, %{}, task_supervisor: start_route(:pid))
     end
   end
 

--- a/test/jido_exec/supervisor_reference_test.exs
+++ b/test/jido_exec/supervisor_reference_test.exs
@@ -1,0 +1,511 @@
+defmodule JidoActionTest.Exec.SupervisorReferenceTest do
+  use JidoActionTest.Case, async: false
+
+  alias Jido.Action.Error.{ExecutionFailureError, InvalidInputError}
+  alias Jido.Exec
+  alias Jido.Exec.Error.AsyncExecutionError
+  alias Jido.Flow
+  alias Jido.Flow.{Condition, Dispatch, Iterate, Reduce, Ref}
+  alias Jido.Flow.Map, as: FlowMap
+  alias Jido.Instruction
+  alias JidoActionTest.Fixtures.BlockingFlow
+  alias JidoActionTest.Fixtures.Execution, as: Fixtures
+  alias JidoActionTest.Fixtures.Execution.BlockingAction
+
+  defmodule Continue do
+    use Jido.Action, name: "supervisor_route_continue"
+
+    @impl true
+    def run(params, context) do
+      send(context.test_pid, {:blocking_flow_node_started, self()})
+
+      receive do
+        :finish -> {:continue, params, context.next}
+      end
+    end
+  end
+
+  defmodule BarrierVia do
+    def whereis_name({owner, token}) do
+      ref = make_ref()
+      send(owner, {:lookup, token, self(), ref})
+
+      receive do
+        {^ref, :raise} -> raise ArgumentError, "via registry stopped"
+        {^ref, pid} -> pid
+      end
+    end
+  end
+
+  for route_kind <- [:pid, :name, :registry, :partition] do
+    @route_kind route_kind
+    test "routes all run and async target forms through #{@route_kind}" do
+      route = start_route(@route_kind)
+      expected_supervisor = GenServer.whereis(route)
+      owner = self()
+
+      for {form, {target, input, context}} <-
+            Fixtures.blocking_execution_forms(BlockingFlow, owner),
+          mode <- [:run, :finite, :async] do
+        opts = [task_supervisor: route]
+
+        caller =
+          start_caller(fn ->
+            case mode do
+              :run ->
+                Exec.run(target, input, context, opts)
+
+              :finite ->
+                Exec.run(target, input, context, opts ++ [timeout: 10_000])
+
+              :async ->
+                handle = Exec.run_async(target, input, context, opts)
+                send(owner, {:async_handle, handle})
+                Exec.await(handle)
+            end
+          end)
+
+        if mode == :async do
+          assert_receive {:async_handle, handle}
+          assert handle.pid in Task.Supervisor.children(expected_supervisor)
+        end
+
+        assert_receive {:blocking_flow_node_started, worker}, 1_000, inspect({form, mode})
+        assert worker in Task.Supervisor.children(expected_supervisor)
+        refute worker in Task.Supervisor.children(Jido.Exec.TaskSupervisor)
+        monitor = Process.monitor(worker)
+        send(worker, :finish)
+        assert {:ok, %{value: _}} = caller_result(caller)
+        assert_receive {:DOWN, ^monitor, :process, ^worker, :normal}
+      end
+    end
+
+    test "retains #{@route_kind} through step, wave, and continue" do
+      route = start_route(@route_kind)
+      owner = self()
+
+      for operation <- [:step, :wave, :continue] do
+        {:ok, execution} =
+          Exec.start(BlockingFlow, %{value: operation}, %{test_pid: owner},
+            task_supervisor: route
+          )
+
+        caller = start_caller(fn -> finish_execution(execution, operation) end)
+        assert_receive {:blocking_flow_node_started, worker}, 1_000
+        assert worker in Task.Supervisor.children(route)
+        send(worker, :finish)
+        assert {:ok, %{value: ^operation}} = caller_result(caller)
+      end
+    end
+  end
+
+  test "keeps the caller partition key through Action, Flow, and Dispatch continuations" do
+    route = start_route(:partition)
+    owner = self()
+
+    dispatch =
+      Flow.new!(
+        name: "route_dispatch",
+        components: [
+          Dispatch.new!(
+            name: :dispatch,
+            decision: BlockingAction,
+            expander: Continue,
+            params: %{value: :continued}
+          )
+        ],
+        output: Ref.result(:dispatch)
+      )
+
+    for {target, next, count} <- [
+          {Continue, BlockingFlow, 2},
+          {Continue, BlockingAction, 2},
+          {dispatch, BlockingAction, 3}
+        ],
+        mode <- [:run, :finite, :async] do
+      caller =
+        start_caller(fn ->
+          opts = [task_supervisor: route]
+          context = %{test_pid: owner, next: next}
+
+          case mode do
+            :run ->
+              Exec.run(target, %{value: :continued}, context, opts)
+
+            :finite ->
+              Exec.run(target, %{value: :continued}, context, opts ++ [timeout: 10_000])
+
+            :async ->
+              target |> Exec.run_async(%{value: :continued}, context, opts) |> Exec.await()
+          end
+        end)
+
+      for _ <- 1..count do
+        assert_receive {:blocking_flow_node_started, worker}, 1_000
+        assert worker in Task.Supervisor.children(route)
+        send(worker, :finish)
+      end
+
+      assert {:ok, %{value: :continued}} = caller_result(caller)
+    end
+  end
+
+  test "keeps a partition route through Map, Reduce, and Iterate work" do
+    route = start_route(:partition)
+    owner = self()
+
+    flow =
+      Flow.new!(
+        name: "route_collections",
+        components: [
+          FlowMap.new!(
+            name: :mapped,
+            collection: [:a, :b],
+            action: BlockingAction,
+            params: %{value: Ref.item()}
+          ),
+          Reduce.new!(
+            name: :reduced,
+            collection: Ref.result(:mapped),
+            initial: %{},
+            action: BlockingAction,
+            params: %{value: Ref.item(:value)}
+          ),
+          Iterate.new!(
+            name: :loop,
+            after: [:reduced],
+            action: BlockingAction,
+            params: %{value: :iteration},
+            state: Iterate.State.new!(initial: %{}, update: Ref.body_result()),
+            completion: Condition.gte(Ref.iteration_index(), 1),
+            max_iterations: 1
+          )
+        ],
+        output: Ref.result(:loop)
+      )
+
+    caller =
+      start_caller(fn ->
+        Exec.run(flow, %{}, %{test_pid: owner}, task_supervisor: route, max_concurrency: 2)
+      end)
+
+    workers =
+      for _ <- 1..2 do
+        assert_receive {:blocking_flow_node_started, worker}, 1_000
+        assert worker in Task.Supervisor.children(route)
+        worker
+      end
+
+    Enum.each(workers, &send(&1, :finish))
+
+    for _ <- 1..3 do
+      assert_receive {:blocking_flow_node_started, worker}, 1_000
+      assert worker in Task.Supervisor.children(route)
+      send(worker, :finish)
+    end
+
+    assert {:ok, %{iterations: 1, output: %{value: :iteration}}} = caller_result(caller)
+  end
+
+  test "uses effective Instruction options for both async control and Action workers" do
+    stored = start_route(:pid)
+    override = start_route(:registry)
+
+    instruction = %Instruction{
+      target: BlockingAction,
+      opts: [task_supervisor: stored],
+      context: %{test_pid: self()}
+    }
+
+    for opts <- [[], [task_supervisor: override]] do
+      route = Keyword.get(opts, :task_supervisor, stored)
+      handle = Exec.run_async(instruction, %{}, %{}, opts)
+      assert_receive {:blocking_flow_node_started, worker}, 1_000
+      children = Task.Supervisor.children(route)
+      assert worker in children
+      assert handle.pid in children
+      send(worker, :finish)
+      assert {:ok, %{}} = Exec.await(handle)
+    end
+  end
+
+  test "keeps Exec tasks temporary when the host has a legacy restart default" do
+    name = __MODULE__.Restarting
+
+    ExUnit.CaptureIO.capture_io(:stderr, fn ->
+      start_supervised!({Task.Supervisor, name: name, restart: :permanent})
+    end)
+
+    supervisor = Process.whereis(name)
+    owner = self()
+
+    {caller, caller_monitor} =
+      spawn_monitor(fn ->
+        result = Exec.run(BlockingAction, %{}, %{test_pid: owner}, task_supervisor: name)
+        send(owner, {:held_result, result})
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> Process.exit(caller, :kill) end)
+
+    assert_receive {:blocking_flow_node_started, worker}, 1_000
+    :erlang.trace(supervisor, true, [:receive])
+    Process.exit(worker, :kill)
+    assert_receive {:trace, ^supervisor, :receive, {:EXIT, ^worker, :killed}}, 1_000
+
+    assert_receive {:held_result, {:error, %ExecutionFailureError{details: %{reason: :killed}}}},
+                   1_000
+
+    # The supervisor has received the exit before this call, so a restart
+    # would already be visible. The caller stays alive until this assertion.
+    assert Task.Supervisor.children(supervisor) == []
+    :erlang.trace(supervisor, false, [:receive])
+    send(caller, :stop)
+    assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :normal}
+  end
+
+  test "keeps two host supervision trees independent during shutdown" do
+    first = start_route(:pid)
+    second = start_route(:registry)
+
+    first_handle =
+      Exec.run_async(BlockingAction, %{}, %{test_pid: self()}, task_supervisor: first)
+
+    assert_receive {:blocking_flow_node_started, first_worker}
+    first_monitor = Process.monitor(first_worker)
+
+    second_handle =
+      Exec.run_async(BlockingAction, %{}, %{test_pid: self()}, task_supervisor: second)
+
+    assert_receive {:blocking_flow_node_started, second_worker}
+    assert first_worker in Task.Supervisor.children(first)
+    assert second_worker in Task.Supervisor.children(second)
+
+    Supervisor.stop(first)
+    assert_receive {:DOWN, ^first_monitor, :process, ^first_worker, :shutdown}
+    assert {:error, %AsyncExecutionError{}} = Exec.await(first_handle)
+    assert Process.alive?(second_worker)
+    send(second_worker, :finish)
+    assert {:ok, %{}} = Exec.await(second_handle)
+  end
+
+  test "named paused work uses a replacement while a PID route stays with its original process" do
+    name = __MODULE__.Replacement
+    original = start_supervised!({Task.Supervisor, name: name})
+    context = %{test_pid: self()}
+    {:ok, named} = Exec.start(BlockingFlow, %{value: :new}, context, task_supervisor: name)
+    {:ok, pinned} = Exec.start(BlockingFlow, %{value: :old}, context, task_supervisor: original)
+    stop_supervised!(name)
+    replacement = start_supervised!({Task.Supervisor, name: name})
+    refute original == replacement
+
+    assert {:ok, failed} = Exec.continue(pinned)
+
+    assert {:error, %ExecutionFailureError{details: %{task_supervisor: ^original}}} =
+             Exec.result(failed)
+
+    refute_received {:blocking_flow_node_started, _}
+
+    caller = start_caller(fn -> finish_execution(named, :continue) end)
+    assert_receive {:blocking_flow_node_started, worker}
+    assert worker in Task.Supervisor.children(replacement)
+    send(worker, :finish)
+    assert {:ok, %{value: :new}} = caller_result(caller)
+    assert Task.Supervisor.children(replacement) == []
+  end
+
+  test "contains supervisor shutdown during a synchronous Action or Flow call" do
+    owner = self()
+
+    for target <- [BlockingAction, BlockingFlow], timeout <- [:infinity, 10_000] do
+      supervisor = start_route(:pid)
+
+      caller =
+        start_caller(fn ->
+          Exec.run(target, %{value: 1}, %{test_pid: owner},
+            task_supervisor: supervisor,
+            timeout: timeout
+          )
+        end)
+
+      assert_receive {:blocking_flow_node_started, worker}
+      monitor = Process.monitor(worker)
+      Supervisor.stop(supervisor)
+      assert_receive {:DOWN, ^monitor, :process, ^worker, :shutdown}
+
+      assert {:error, %ExecutionFailureError{details: %{reason: :shutdown}}} =
+               caller_result(caller)
+    end
+  end
+
+  test "contains a task-start race after successful via lookup without fallback" do
+    owner = self()
+
+    for mode <- [:run, :async], failure <- [:dead_pid, :raise] do
+      supervisor = start_route(:pid)
+      token = make_ref()
+      route = {:via, BarrierVia, {owner, token}}
+
+      caller =
+        start_caller(fn ->
+          try do
+            case mode do
+              :run ->
+                Exec.run(BlockingAction, %{}, %{test_pid: owner}, task_supervisor: route)
+
+              :async ->
+                Exec.run_async(BlockingAction, %{}, %{test_pid: owner}, task_supervisor: route)
+            end
+          rescue
+            error -> {:error, error}
+          end
+        end)
+
+      assert_receive {:lookup, ^token, lookup_caller, ref}
+      send(lookup_caller, {ref, supervisor})
+      assert_receive {:lookup, ^token, lookup_caller, ref}
+      Supervisor.stop(supervisor)
+      send(lookup_caller, {ref, if(failure == :raise, do: :raise, else: supervisor)})
+      assert {:error, error} = caller_result(caller)
+
+      assert error.__struct__ ==
+               if(mode == :run, do: ExecutionFailureError, else: AsyncExecutionError)
+
+      assert error.details.task_supervisor == route
+
+      if failure == :raise do
+        assert {:error, %ArgumentError{}} = error.details.reason
+      else
+        assert {:exit, _} = error.details.reason
+      end
+
+      assert error.details.retry == false
+      refute_received {:blocking_flow_node_started, _}
+    end
+  end
+
+  test "returns capacity refusal for Action, Flow, and async control or target work" do
+    full = start_supervised!(Supervisor.child_spec({Task.Supervisor, max_children: 0}, id: :full))
+    one = start_supervised!(Supervisor.child_spec({Task.Supervisor, max_children: 1}, id: :one))
+
+    for target <- [BlockingAction, BlockingFlow], timeout <- [:infinity, 10_000] do
+      assert {:error,
+              %ExecutionFailureError{details: %{reason: :max_children, task_supervisor: ^full}}} =
+               Exec.run(target, %{value: 1}, %{test_pid: self()},
+                 task_supervisor: full,
+                 timeout: timeout
+               )
+    end
+
+    assert_raise AsyncExecutionError, fn ->
+      Exec.run_async(BlockingAction, %{}, %{}, task_supervisor: full)
+    end
+
+    handle = Exec.run_async(BlockingAction, %{}, %{}, task_supervisor: one)
+
+    assert {:error, %ExecutionFailureError{details: %{reason: :max_children}}} =
+             Exec.await(handle)
+
+    refute_received {:blocking_flow_node_started, _}
+  end
+
+  test "rejects removed, duplicate, invalid, and absent routes before Action work" do
+    supervisor = start_route(:pid)
+
+    for target <- [BlockingAction, BlockingFlow],
+        opts <- [
+          [jido: nil],
+          [jido: __MODULE__, task_supervisor: supervisor],
+          [task_supervisor: supervisor, task_supervisor: supervisor],
+          [task_supervisor: nil],
+          [task_supervisor: "bad"],
+          [task_supervisor: {:global, :unsupported}],
+          [task_supervisor: {:name, :remote}],
+          [task_supervisor: {:via, nil, :bad}],
+          [task_supervisor: {:via, __MODULE__, :bad}],
+          [task_supervisor: __MODULE__.Absent]
+        ] do
+      assert {:error, error} = Exec.run(target, %{value: 1}, %{test_pid: self()}, opts)
+      assert is_exception(error)
+      assert error.details.option in [:jido, :task_supervisor]
+
+      if Keyword.has_key?(opts, :jido) do
+        assert error.message =~ "jido option was removed"
+        assert error.message =~ "task_supervisor:"
+      end
+
+      refute_received {:blocking_flow_node_started, _}
+    end
+
+    for opts <- [
+          [jido: nil],
+          [task_supervisor: "bad"],
+          [task_supervisor: supervisor, task_supervisor: supervisor]
+        ] do
+      assert_raise InvalidInputError, fn -> Exec.run_async(BlockingAction, %{}, %{}, opts) end
+    end
+  end
+
+  test "rejects legacy Instruction jido routing even with an explicit new route" do
+    instruction = %Instruction{target: BlockingAction, opts: [jido: nil]}
+    assert {:error, %InvalidInputError{message: message}} = Exec.run(instruction)
+    assert message =~ "jido option was removed"
+
+    assert_raise InvalidInputError, ~r/jido option was removed/, fn ->
+      Exec.run_async(instruction, %{}, %{}, task_supervisor: start_route(:pid))
+    end
+  end
+
+  defp start_route(:pid),
+    do: start_supervised!(Supervisor.child_spec(Task.Supervisor, id: make_ref()))
+
+  defp start_route(:name) do
+    name = __MODULE__.Named
+    start_supervised!({Task.Supervisor, name: name})
+    name
+  end
+
+  defp start_route(:registry) do
+    start_supervised!({Registry, keys: :unique, name: __MODULE__.Registry})
+    route = {:via, Registry, {__MODULE__.Registry, make_ref()}}
+    start_supervised!({Task.Supervisor, name: route})
+    route
+  end
+
+  defp start_route(:partition) do
+    name = __MODULE__.Partitions
+
+    start_supervised!(
+      {PartitionSupervisor, child_spec: Task.Supervisor, name: name, partitions: 2}
+    )
+
+    {:via, PartitionSupervisor, {name, self()}}
+  end
+
+  defp start_caller(fun) do
+    owner = self()
+    {pid, monitor} = spawn_monitor(fn -> send(owner, {:caller_result, self(), fun.()}) end)
+    on_exit(fn -> Process.exit(pid, :kill) end)
+    {pid, monitor}
+  end
+
+  defp caller_result({pid, monitor}) do
+    assert_receive {:caller_result, ^pid, result}, 2_000
+    assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
+    result
+  end
+
+  defp finish_execution(execution, operation) do
+    if Exec.status(execution) == :running do
+      case apply(Exec, operation, [execution]) do
+        {:ok, _work, next} -> finish_execution(next, operation)
+        {:ok, next} -> Exec.result(next)
+      end
+    else
+      Exec.result(execution)
+    end
+  end
+end

--- a/test/jido_exec/supervisor_test.exs
+++ b/test/jido_exec/supervisor_test.exs
@@ -1,7 +1,6 @@
 defmodule JidoActionTest.Exec.SupervisorTest do
   use JidoActionTest.Case, async: true
 
-  alias Jido.Action.Error.InvalidInputError
   alias Jido.Exec
   alias Jido.Exec.Runtime
 
@@ -14,44 +13,12 @@ defmodule JidoActionTest.Exec.SupervisorTest do
     assert Jido.Exec.TaskSupervisor in Application.spec(:jido_action, :registered)
   end
 
-  test "returns the public Task Supervisor name for global and instance routes" do
-    instance = unique_module("JidoInstance")
-
-    assert Exec.task_supervisor_name(nil) == Jido.Exec.TaskSupervisor
-    assert Exec.task_supervisor_name(instance) == Module.concat(instance, TaskSupervisor)
-  end
-
-  test "resolves global and Jido instance Task Supervisors" do
-    instance = unique_module("JidoInstance")
-    instance_task_supervisor = Module.concat(instance, TaskSupervisor)
-    start_supervised!({Task.Supervisor, name: instance_task_supervisor})
-
-    assert Runtime.task_supervisor_name([]) == Jido.Exec.TaskSupervisor
-    assert Runtime.task_supervisor_name(jido: nil) == Jido.Exec.TaskSupervisor
-    assert Runtime.task_supervisor_name(jido: instance) == instance_task_supervisor
-
+  test "uses the package supervisor by default" do
     assert Runtime.task_supervisor([]) == {:ok, Jido.Exec.TaskSupervisor}
-    assert Runtime.task_supervisor(jido: instance) == {:ok, instance_task_supervisor}
   end
 
-  test "does not fall back when a Jido instance Task Supervisor is absent" do
-    instance = unique_module("MissingJidoInstance")
-    instance_task_supervisor = Module.concat(instance, TaskSupervisor)
-
-    assert {:error,
-            %InvalidInputError{
-              message: "Task Supervisor is not running",
-              details: %{jido: ^instance, task_supervisor: ^instance_task_supervisor}
-            }} = Runtime.task_supervisor(jido: instance)
-  end
-
-  test "rejects an invalid direct routing value" do
-    assert_raise ArgumentError, ~r/Jido instance must be an atom or nil/, fn ->
-      Exec.task_supervisor_name("invalid")
-    end
-
-    assert_raise ArgumentError, ~r/:jido must be an atom or nil/, fn ->
-      Runtime.task_supervisor_name(jido: "invalid")
-    end
+  test "removes the host-name helper" do
+    assert Code.ensure_loaded?(Exec)
+    refute function_exported?(Exec, :task_supervisor_name, 1)
   end
 end

--- a/test/jido_exec/telemetry_test.exs
+++ b/test/jido_exec/telemetry_test.exs
@@ -160,6 +160,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
       end)
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
+    worker_monitor = Process.monitor(worker)
     assert {:error, timeout_error} = Task.await(task, 1_000)
     assert %Jido.Action.Error.TimeoutError{} = timeout_error
 
@@ -173,6 +174,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
     assert error_metadata.error_type == :timeout
     assert measurements.duration >= 0
     refute_received {@action_stop, _, _}
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
     refute Process.alive?(worker)
   end
 
@@ -188,6 +190,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
       end)
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
+    worker_monitor = Process.monitor(worker)
     assert {:error, timeout_error} = Task.await(task, 1_000)
     assert %Jido.Flow.Error.TimeoutError{} = timeout_error
 
@@ -206,6 +209,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
     assert Map.drop(target_error, [:error, :error_type]) == target_start
     assert Map.drop(node_error, [:error, :error_type]) == node_start
     assert Map.drop(flow_error, [:error, :error_type]) == flow_start
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
     refute Process.alive?(worker)
   end
 
@@ -214,6 +218,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
     handle = Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
+    worker_monitor = Process.monitor(worker)
     assert :ok = Exec.cancel(handle)
 
     assert [
@@ -224,6 +229,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
     assert Map.drop(error_metadata, [:error, :error_type]) == start_metadata
     assert %Jido.Exec.Error.CancelledError{} = error_metadata.error
     assert error_metadata.error_type == :async_cancelled
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
     refute Process.alive?(worker)
   end
 
@@ -232,6 +238,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
     handle = Exec.run_async(BlockingFlow, %{value: 1}, %{test_pid: self()})
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
+    worker_monitor = Process.monitor(worker)
     assert :ok = Exec.cancel(handle)
 
     assert [
@@ -249,6 +256,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
     assert Map.drop(target_error, [:error, :error_type]) == target_start
     assert Map.drop(node_error, [:error, :error_type]) == node_start
     assert Map.drop(flow_error, [:error, :error_type]) == flow_start
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
     refute Process.alive?(worker)
   end
 

--- a/test/jido_exec/telemetry_test.exs
+++ b/test/jido_exec/telemetry_test.exs
@@ -300,7 +300,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
       token = make_ref()
       context = %{test_pid: self(), token: token}
       action = InlineControlledFlow.step_action("first")
-      supervisor = Exec.task_supervisor_name(__MODULE__)
+      supervisor = __MODULE__.TaskSupervisor
       start_supervised!({Task.Supervisor, name: supervisor})
 
       {target, input, prefixes} =
@@ -313,7 +313,7 @@ defmodule JidoActionTest.Exec.TelemetryTest do
              [[:jido, :flow], [:jido, :flow, :node], [:jido, :flow, :target]]}
         end
 
-      opts = [max_concurrency: 1, jido: __MODULE__]
+      opts = [max_concurrency: 1, task_supervisor: __MODULE__.TaskSupervisor]
       opts = if terminal == :timeout, do: Keyword.put(opts, :timeout, 2_000), else: opts
       handle = Exec.run_async(target, input, context, opts)
       caller_monitor = Process.monitor(handle.pid)

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -138,10 +138,13 @@ Use `jido_action` for validated work and data-first composition:
 ## Execution
 
 - Use `Jido.Exec.run/4` for the public validation and error boundary.
-- Use `jido: MyApp.Jido` with an Action, Instruction, or Flow when work must run
-  under the Task Supervisor for that running Jido core instance.
-- When a higher-level runtime builds a Jido instance supervision tree, use
-  `Jido.Exec.task_supervisor_name/1` for its Task Supervisor name.
+- Pass `task_supervisor: reference` for a local Task.Supervisor PID, registered
+  name, or via reference. The default is `Jido.Exec.TaskSupervisor`. The host
+  owns supervisor names. The `jido:` option and Exec name helper were removed.
+- Keep one explicit partition key in a via route. Exec carries the same route
+  through nested and continuation work. Names follow registration changes at
+  each task start; a PID remains bound to its original process. No route falls
+  back when its supervisor is absent or refuses work.
 - All run-to-completion targets accept `max_continuations` and
   `max_concurrency`. An Action does not use the concurrency limit itself, but
   it can continue to a Flow. `max_concurrency` defaults to `8`. Use `1` for

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -138,13 +138,9 @@ Use `jido_action` for validated work and data-first composition:
 ## Execution
 
 - Use `Jido.Exec.run/4` for the public validation and error boundary.
-- Pass `task_supervisor: reference` for a local Task.Supervisor PID, registered
-  name, or via reference. The default is `Jido.Exec.TaskSupervisor`. The host
-  owns supervisor names. The `jido:` option and Exec name helper were removed.
-- Keep one explicit partition key in a via route. Exec carries the same route
-  through nested and continuation work. Names follow registration changes at
-  each task start; a PID remains bound to its original process. No route falls
-  back when its supervisor is absent or refuses work.
+- Pass `task_supervisor: reference` for a local Task.Supervisor PID, name, or
+  via route. The host owns supervisor names and capacity. See
+  [Runtime Configuration](guides/configuration.md#task-supervisor-references).
 - All run-to-completion targets accept `max_continuations` and
   `max_concurrency`. An Action does not use the concurrency limit itself, but
   it can continue to a Flow. `max_concurrency` defaults to `8`. Use `1` for


### PR DESCRIPTION
Accept a local Task.Supervisor PID, registered name, Registry reference, or PartitionSupervisor route through `task_supervisor:`. Keep the selected route across nested work, async calls, and continuations. The default is `Jido.Exec.TaskSupervisor`.

Task start contains lookup, shutdown, race, and capacity failures. Tasks use temporary restart behavior. This removes host-name derivation and duplicate task-start wrappers.

The host owns naming and supplies its supervisor reference. Unknown options use normal validation, with no special checks for removed options. The configuration guide defines replacement, capacity, and ownership behavior.

The GenServer test now uses a normal test module. It checks responsiveness and completion through messages, without extracting source from a guide. Monitor barriers make cleanup assertions deterministic.

Validation: 821 tests passed with 94.67% coverage, and `mix quality` passed. The combined stack passed 881 tests with 94.89% coverage. A general test checks unknown options through run, async, and step-wise calls before Action work starts. [CI passed](https://github.com/agentjido/jido_action/actions/runs/33985807118) on all four supported runtime pairs.

Closes #237.
