### PR TITLE
refactor(exec)!: unify Action invocation and Flow contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Public action functions:
 - `validate_output/1`
 - `run/2`
 
+Every Action must implement `run/2`. A missing implementation stops compilation.
+
 An Action can also implement `on_before_validate_params/1` when raw input must
 be prepared before Zoi validation. Prefer Zoi coercion and other schema rules
 when they can express the required change.
@@ -199,6 +201,8 @@ Pass execution options to `Jido.Exec`.
 ## Compose A Flow
 
 Use `Jido.Flow` when several actions must execute as one validated graph.
+Flow modules provide a definition through `flow/0` and share the Executable
+validation callbacks. Their generated `run/2` delegates to Exec as a convenience.
 
 ```elixir
 defmodule MyApp.Actions.Notify do

--- a/README.md
+++ b/README.md
@@ -201,8 +201,6 @@ Pass execution options to `Jido.Exec`.
 ## Compose A Flow
 
 Use `Jido.Flow` when several actions must execute as one validated graph.
-Flow modules provide a definition through `flow/0` and share the Executable
-validation callbacks. Their generated `run/2` delegates to Exec as a convenience.
 
 ```elixir
 defmodule MyApp.Actions.Notify do

--- a/guides/actions.md
+++ b/guides/actions.md
@@ -28,13 +28,28 @@ end
 - `validate_params/1` and `validate_output/1`; and
 - the `Jido.Executable` descriptor used by `Jido.Exec`.
 
-The module must implement `run/2`.
+The module must implement `run/2`. A missing implementation stops compilation.
 
 `Jido.Action` declares the `run/2` callback and the optional input-preparation
 hook. `Jido.Executable` declares the descriptor, `validate_params/1`, and
-`validate_output/1` callbacks shared by Action and Flow modules. The generators
-implement both behaviours. Runtime contract checks remain in place for all
+`validate_output/1` callbacks shared by Action and Flow modules. An Action
+implements both behaviours. A Flow implements `Jido.Executable` and supplies
+`flow/0` as its definition. Runtime contract checks remain in place for all
 module targets, including modules that do not declare the behaviours.
+
+## Migrate Earlier v3 Beta Actions
+
+Earlier v3 beta versions supplied a default `run/2` that returned a runtime
+configuration error. That implementation and its `defoverridable` entry are
+removed. The generator now declares `run/2` without a body. The Elixir compiler
+rejects an Action that does not implement it, including during runtime module
+compilation and ordinary Mix builds.
+
+Add an explicit `run/2` body to every Action, including schema-only fixtures.
+Use the callback example above. Replace calls to the removed default through
+`super/2` with application code. Generated inline Actions already supply their
+own callback. Existing Action result, validation, and extra-value rules stay
+the same.
 
 ## Use An Inline Step For Small Local Work
 

--- a/guides/actions.md
+++ b/guides/actions.md
@@ -37,20 +37,6 @@ implements both behaviours. A Flow implements `Jido.Executable` and supplies
 `flow/0` as its definition. Runtime contract checks remain in place for all
 module targets, including modules that do not declare the behaviours.
 
-## Migrate Earlier v3 Beta Actions
-
-Earlier v3 beta versions supplied a default `run/2` that returned a runtime
-configuration error. That implementation and its `defoverridable` entry are
-removed. The generator now declares `run/2` without a body. The Elixir compiler
-rejects an Action that does not implement it, including during runtime module
-compilation and ordinary Mix builds.
-
-Add an explicit `run/2` body to every Action, including schema-only fixtures.
-Use the callback example above. Replace calls to the removed default through
-`super/2` with application code. Generated inline Actions already supply their
-own callback. Existing Action result, validation, and extra-value rules stay
-the same.
-
 ## Use An Inline Step For Small Local Work
 
 A Flow module can define a small Step body without a separate Action module:

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -79,23 +79,6 @@ Runic workflow and the source map. It is not a storage format.
 directly when you need runtime options. Exec uses the descriptor to select
 native Flow execution; it does not call this convenience function.
 
-## Migrate Earlier v3 Beta Flow Modules
-
-Earlier v3 beta Flow modules declared the `Jido.Action` behaviour, and target
-validation required `run/2`. Flow modules now implement `Jido.Executable`.
-They require `__jido_executable__/0`, `flow/0`, `validate_params/1`, and
-`validate_output/1`. A Flow module without `run/2` is a valid Exec target.
-
-Code that uses `use Jido.Flow` keeps its generated `run/2` convenience function.
-Recompile these modules to update their behaviour metadata. For a handwritten
-Flow module, remove `@behaviour Jido.Action` and any `@impl` annotation on its
-optional `run/2` helper. Keep the descriptor and all three required functions.
-
-Use `Jido.Executable.resolve/1` to identify target kind and
-`Jido.Executable.validate/1` to check its callbacks. Do not use Action behaviour
-metadata or the presence of `run/2` to identify every executable. Action-only
-Flow positions still require an Action target.
-
 ## Reuse A Step Target
 
 `step_action/1` returns the Action module for an inline or explicit

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -53,8 +53,8 @@ declarations. Remove those parentheses once if you want the form shown above.
 
 ## Generated API
 
-A Flow module exposes the Action-compatible and Flow-specific functions that
-an application needs:
+A Flow module exposes its definition, validation, metadata, and convenience
+functions:
 
 ```elixir
 MyApp.Flows.Greeting.name()
@@ -76,7 +76,25 @@ version. Put changing values in input or context, not in module construction.
 Runic workflow and the source map. It is not a storage format.
 
 `run/2` delegates to `Jido.Exec.run/4` with default options. Use `Jido.Exec`
-directly when you need runtime options.
+directly when you need runtime options. Exec uses the descriptor to select
+native Flow execution; it does not call this convenience function.
+
+## Migrate Earlier v3 Beta Flow Modules
+
+Earlier v3 beta Flow modules declared the `Jido.Action` behaviour, and target
+validation required `run/2`. Flow modules now implement `Jido.Executable`.
+They require `__jido_executable__/0`, `flow/0`, `validate_params/1`, and
+`validate_output/1`. A Flow module without `run/2` is a valid Exec target.
+
+Code that uses `use Jido.Flow` keeps its generated `run/2` convenience function.
+Recompile these modules to update their behaviour metadata. For a handwritten
+Flow module, remove `@behaviour Jido.Action` and any `@impl` annotation on its
+optional `run/2` helper. Keep the descriptor and all three required functions.
+
+Use `Jido.Executable.resolve/1` to identify target kind and
+`Jido.Executable.validate/1` to check its callbacks. Do not use Action behaviour
+metadata or the presence of `run/2` to identify every executable. Action-only
+Flow positions still require an Action target.
 
 ## Reuse A Step Target
 

--- a/guides/flows.md
+++ b/guides/flows.md
@@ -1,7 +1,12 @@
 # Flows
 
-A `Jido.Flow` is the canonical authoring value for a local workflow. It is
-Action-compatible and lowers to native Runic workflow data for execution.
+A `Jido.Flow` is the canonical authoring value for a local workflow. It lowers
+to native Runic workflow data for execution through `Jido.Exec`.
+
+Action and Flow modules share the `Jido.Executable` descriptor and validation
+callbacks. A Flow module provides `flow/0` as its definition. It does not
+implement the Action behaviour. Its generated `run/2` is a convenience call to
+Exec. See [Flow Modules](flow-modules.md#generated-api).
 
 ## Canonical Value
 

--- a/guides/flows.md
+++ b/guides/flows.md
@@ -3,10 +3,7 @@
 A `Jido.Flow` is the canonical authoring value for a local workflow. It lowers
 to native Runic workflow data for execution through `Jido.Exec`.
 
-Action and Flow modules share the `Jido.Executable` descriptor and validation
-callbacks. A Flow module provides `flow/0` as its definition. It does not
-implement the Action behaviour. Its generated `run/2` is a convenience call to
-Exec. See [Flow Modules](flow-modules.md#generated-api).
+See [Flow Modules](flow-modules.md#generated-api) for the module API.
 
 ## Canonical Value
 

--- a/guides/v2-to-v3-migration.md
+++ b/guides/v2-to-v3-migration.md
@@ -10,10 +10,6 @@ version 2 code are outside the scope of this guide.
 
 Upgrade one area at a time. Compile and test the application after each area.
 
-For code that already uses an earlier v3 beta, see the
-[Action callback migration](actions.md#migrate-earlier-v3-beta-actions) and
-[Flow module migration](flow-modules.md#migrate-earlier-v3-beta-flow-modules).
-
 ## Update The Dependency
 
 Change the package version in `mix.exs`:

--- a/guides/v2-to-v3-migration.md
+++ b/guides/v2-to-v3-migration.md
@@ -10,6 +10,10 @@ version 2 code are outside the scope of this guide.
 
 Upgrade one area at a time. Compile and test the application after each area.
 
+For code that already uses an earlier v3 beta, see the
+[Action callback migration](actions.md#migrate-earlier-v3-beta-actions) and
+[Flow module migration](flow-modules.md#migrate-earlier-v3-beta-flow-modules).
+
 ## Update The Dependency
 
 Change the package version in `mix.exs`:

--- a/lib/jido_action.ex
+++ b/lib/jido_action.ex
@@ -37,6 +37,9 @@ defmodule Jido.Action do
   It validates input, calls the Action, validates normal output, and normalizes
   failures.
 
+  Every Action must implement `run/2`. The generator declares the function
+  without a default body, so a missing implementation stops compilation.
+
   ## Effects and policy
 
   `run/2` can be pure or can perform I/O. Keep one Action focused on one unit
@@ -344,20 +347,10 @@ defmodule Jido.Action do
               | {:error, Jido.Action.Error.InvalidInputError.t()}
       def validate_output(output), do: Action.validate_output_for(output, __MODULE__)
 
-      @doc """
-      Executes the Action with the given parameters and context.
-
-      The `run/2` function must be implemented in the module using Jido.Action.
-      """
+      @doc "Executes the Action with the given parameters and context."
       @impl Jido.Action
       @spec run(map(), map()) :: Jido.Action.result()
-      def run(params, context) do
-        "run/2 must be implemented in your Action"
-        |> Error.config_error()
-        |> then(&{:error, &1})
-      end
-
-      defoverridable run: 2
+      def run(params, context)
     end
   end
 

--- a/lib/jido_action.ex
+++ b/lib/jido_action.ex
@@ -37,8 +37,7 @@ defmodule Jido.Action do
   It validates input, calls the Action, validates normal output, and normalizes
   failures.
 
-  Every Action must implement `run/2`. The generator declares the function
-  without a default body, so a missing implementation stops compilation.
+  Every Action must implement `run/2`. A missing implementation stops compilation.
 
   ## Effects and policy
 

--- a/lib/jido_exec/action/runner.ex
+++ b/lib/jido_exec/action/runner.ex
@@ -14,6 +14,12 @@ defmodule Jido.Exec.Action.Runner do
           | {:continue, Transition.t()}
           | {:error, target_phase(), Exception.t()}
 
+  @typep extras :: :no_extras | {:extras, term()}
+  @typep invocation_result ::
+           {:ok, term(), extras()}
+           | {:continue, Transition.t()}
+           | {:error, target_phase(), Exception.t(), extras()}
+
   @doc "Runs one Action Instruction through the isolated Action boundary."
   @spec run(Instruction.t(), keyword()) ::
           {:ok, term()}
@@ -22,70 +28,52 @@ defmodule Jido.Exec.Action.Runner do
           | {:error, Exception.t()}
           | {:error, Exception.t(), term()}
   def run(%Instruction{target: action} = instruction, run_opts \\ []) do
-    task_supervisor = Keyword.fetch!(run_opts, :task_supervisor)
-
-    case run_isolated(task_supervisor, fn -> do_run(instruction) end) do
-      {:ok, result} -> result
-      {:exit, reason} -> {:error, process_exit_error(action, reason)}
-      {:start_error, reason} -> {:error, process_start_error(action, task_supervisor, reason)}
-    end
-  end
-
-  defp do_run(%Instruction{target: action} = instruction) do
-    with {:ok, params} <- validate_params(action, instruction.params) do
-      case invoke_result(action, params, instruction.context) do
-        {:ok, output, extras} ->
-          case validate_output(action, output) do
-            {:ok, output} -> success_result(output, extras)
-            {:error, error} -> error_result(error, extras)
-          end
-
-        {:error, error, extras} ->
-          error_result(error, extras)
-
-        {:continue, %Transition{} = transition} ->
-          {:continue, transition}
-      end
-    end
+    action
+    |> invoke_isolated(instruction.params, instruction.context, run_opts)
+    |> direct_result()
   end
 
   @doc false
   @spec run_target(module(), term(), map(), keyword()) :: target_result()
   def run_target(action, params, context, run_opts) do
+    action
+    |> invoke_isolated(params, context, run_opts)
+    |> target_result()
+  end
+
+  @spec invoke_isolated(module(), term(), map(), keyword()) :: invocation_result()
+  defp invoke_isolated(action, params, context, run_opts) do
     task_supervisor = Keyword.fetch!(run_opts, :task_supervisor)
 
-    case run_isolated(task_supervisor, fn -> do_run_target(action, params, context) end) do
+    case run_isolated(task_supervisor, fn -> invoke(action, params, context) end) do
       {:ok, result} ->
         result
 
       {:exit, reason} ->
-        {:error, :execution, process_exit_error(action, reason)}
+        {:error, :execution, process_exit_error(action, reason), :no_extras}
 
       {:start_error, reason} ->
-        {:error, :execution, process_start_error(action, task_supervisor, reason)}
+        {:error, :execution, process_start_error(action, task_supervisor, reason), :no_extras}
     end
   end
 
-  defp do_run_target(action, params, context) do
-    case validate_params(action, params) do
-      {:ok, params} -> run_validated_target(action, params, context)
-      {:error, error} -> {:error, :input, error}
-    end
-  end
+  defp invoke(action, params, context) do
+    with {:ok, params} <- validate_params(action, params) do
+      case invoke_result(action, params, context) do
+        {:ok, output, extras} ->
+          case validate_output(action, output) do
+            {:ok, output} -> {:ok, output, extras}
+            {:error, error} -> {:error, :output, error, extras}
+          end
 
-  defp run_validated_target(action, params, context) do
-    case invoke_result(action, params, context) do
-      {:ok, output, _extras} ->
-        case validate_output(action, output) do
-          {:ok, output} -> {:ok, output}
-          {:error, error} -> {:error, :output, error}
-        end
+        {:error, error, extras} ->
+          {:error, :execution, error, extras}
 
-      {:error, error, _extras} ->
-        {:error, :execution, error}
-
-      {:continue, %Transition{} = transition} ->
-        {:continue, transition}
+        {:continue, %Transition{} = transition} ->
+          {:continue, transition}
+      end
+    else
+      {:error, error} -> {:error, :input, error, :no_extras}
     end
   end
 
@@ -143,11 +131,15 @@ defmodule Jido.Exec.Action.Runner do
        ), :no_extras}
   end
 
-  defp success_result(output, :no_extras), do: {:ok, output}
-  defp success_result(output, {:extras, extras}), do: {:ok, output, extras}
+  defp direct_result({:ok, output, :no_extras}), do: {:ok, output}
+  defp direct_result({:ok, output, {:extras, extras}}), do: {:ok, output, extras}
+  defp direct_result({:error, _phase, error, :no_extras}), do: {:error, error}
+  defp direct_result({:error, _phase, error, {:extras, extras}}), do: {:error, error, extras}
+  defp direct_result({:continue, transition}), do: {:continue, transition}
 
-  defp error_result(error, :no_extras), do: {:error, error}
-  defp error_result(error, {:extras, extras}), do: {:error, error, extras}
+  defp target_result({:ok, output, _extras}), do: {:ok, output}
+  defp target_result({:error, phase, error, _extras}), do: {:error, phase, error}
+  defp target_result({:continue, transition}), do: {:continue, transition}
 
   defp invalid_continuation_input(action, input) do
     {:error,

--- a/lib/jido_exec/action/runner.ex
+++ b/lib/jido_exec/action/runner.ex
@@ -28,32 +28,33 @@ defmodule Jido.Exec.Action.Runner do
           | {:error, Exception.t()}
           | {:error, Exception.t(), term()}
   def run(%Instruction{target: action} = instruction, run_opts \\ []) do
-    action
-    |> invoke_isolated(instruction.params, instruction.context, run_opts)
-    |> direct_result()
+    invoke_isolated(action, instruction.params, instruction.context, run_opts, &direct_result/1)
   end
 
   @doc false
   @spec run_target(module(), term(), map(), keyword()) :: target_result()
   def run_target(action, params, context, run_opts) do
-    action
-    |> invoke_isolated(params, context, run_opts)
-    |> target_result()
+    invoke_isolated(action, params, context, run_opts, &target_result/1)
   end
 
-  @spec invoke_isolated(module(), term(), map(), keyword()) :: invocation_result()
-  defp invoke_isolated(action, params, context, run_opts) do
+  @spec invoke_isolated(module(), term(), map(), keyword(), (invocation_result() -> result)) ::
+          result
+        when result: var
+  defp invoke_isolated(action, params, context, run_opts, to_result) do
     task_supervisor = Keyword.fetch!(run_opts, :task_supervisor)
 
-    case run_isolated(task_supervisor, fn -> invoke(action, params, context) end) do
+    # Discard Flow extras before the worker copies its reply to the caller.
+    case run_isolated(task_supervisor, fn -> to_result.(invoke(action, params, context)) end) do
       {:ok, result} ->
         result
 
       {:exit, reason} ->
-        {:error, :execution, process_exit_error(action, reason), :no_extras}
+        to_result.({:error, :execution, process_exit_error(action, reason), :no_extras})
 
       {:start_error, reason} ->
-        {:error, :execution, process_start_error(action, task_supervisor, reason), :no_extras}
+        to_result.(
+          {:error, :execution, process_start_error(action, task_supervisor, reason), :no_extras}
+        )
     end
   end
 

--- a/lib/jido_executable.ex
+++ b/lib/jido_executable.ex
@@ -17,9 +17,11 @@ defmodule Jido.Executable do
   A module callback must identify the module that owns the callback.
 
   This behaviour declares the module descriptor and data validation callbacks.
-  `Jido.Action` owns the `run/2` callback. Both Action and Flow module generators
-  implement these behaviours. `validate/1` also checks the required functions
-  at runtime; a behaviour declaration alone does not make a module executable.
+  Both Action and Flow module generators implement this behaviour. An Action
+  also implements `Jido.Action`, which requires `run/2`. A Flow requires
+  `flow/0` instead. Its generated `run/2` is a convenience call to `Jido.Exec`.
+  `validate/1` checks the required functions for each target kind at runtime;
+  a behaviour declaration alone does not make a module executable.
 
   A Flow module must return one stable `%Jido.Flow{}` from `flow/0` for the life
   of the loaded module version. Each validation or execution operation
@@ -109,20 +111,14 @@ defmodule Jido.Executable do
   @spec validate(t() | target() | term()) :: :ok | {:error, Exception.t()}
   def validate(%__MODULE__{kind: :action, target: target})
       when is_atom(target) and not is_nil(target) do
-    validate_module_callbacks(target)
+    validate_module_callbacks(target, {:run, 2})
   end
 
   def validate(%__MODULE__{kind: :flow, target: %Flow{}}), do: :ok
 
   def validate(%__MODULE__{kind: :flow, target: target})
       when is_atom(target) and not is_nil(target) do
-    with :ok <- validate_module_callbacks(target) do
-      if function_exported?(target, :flow, 0) do
-        :ok
-      else
-        invalid_executable_contract(target, "missing flow/0")
-      end
-    end
+    validate_module_callbacks(target, {:flow, 0})
   end
 
   def validate(%__MODULE__{} = executable) do
@@ -139,20 +135,16 @@ defmodule Jido.Executable do
     end
   end
 
-  defp validate_module_callbacks(module) do
-    cond do
-      not function_exported?(module, :run, 2) ->
-        invalid_executable_contract(module, "missing run/2")
+  defp validate_module_callbacks(module, kind_callback) do
+    callbacks = [kind_callback, {:validate_params, 1}, {:validate_output, 1}]
 
-      not function_exported?(module, :validate_params, 1) ->
-        invalid_executable_contract(module, "missing validate_params/1")
-
-      not function_exported?(module, :validate_output, 1) ->
-        invalid_executable_contract(module, "missing validate_output/1")
-
-      true ->
-        :ok
-    end
+    Enum.reduce_while(callbacks, :ok, fn {callback, arity}, :ok ->
+      if function_exported?(module, callback, arity) do
+        {:cont, :ok}
+      else
+        {:halt, invalid_executable_contract(module, "missing #{callback}/#{arity}")}
+      end
+    end)
   end
 
   defp resolve_loaded_module(module) do

--- a/lib/jido_flow.ex
+++ b/lib/jido_flow.ex
@@ -85,10 +85,8 @@ defmodule Jido.Flow do
   operation materializes it once. Put changing runtime data in Flow input or
   context.
 
-  Flow modules implement `Jido.Executable` and provide `flow/0`,
-  `validate_params/1`, and `validate_output/1`. The generated `run/2` delegates
-  to `Jido.Exec` with default options. Exec uses the Flow definition directly;
-  a Flow does not implement the `Jido.Action` behaviour.
+  Flow modules implement `Jido.Executable` and provide their definition through
+  `flow/0`. The generated `run/2` delegates to `Jido.Exec` with default options.
 
   A Choice is one Flow component. It evaluates data-only conditions in authored
   order, runs the first matching target, and uses a required routing fallback

--- a/lib/jido_flow.ex
+++ b/lib/jido_flow.ex
@@ -85,6 +85,11 @@ defmodule Jido.Flow do
   operation materializes it once. Put changing runtime data in Flow input or
   context.
 
+  Flow modules implement `Jido.Executable` and provide `flow/0`,
+  `validate_params/1`, and `validate_output/1`. The generated `run/2` delegates
+  to `Jido.Exec` with default options. Exec uses the Flow definition directly;
+  a Flow does not implement the `Jido.Action` behaviour.
+
   A Choice is one Flow component. It evaluates data-only conditions in authored
   order, runs the first matching target, and uses a required routing fallback
   when no option matches.

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -9,7 +9,6 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
     module_compiler = __MODULE__
 
     quote location: :keep do
-      @behaviour Jido.Action
       @behaviour Jido.Executable
       use Jido.Flow.DSL
       @before_compile Jido.Flow.DSL.ModuleCompiler
@@ -93,8 +92,8 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       @spec compiled() :: Jido.Flow.Compiled.t()
       def compiled()
 
-      @doc "Runs this Flow with the given parameters and context."
-      @spec run(map(), map()) :: Jido.Action.result()
+      @doc "Runs this Flow through Jido.Exec with default execution options."
+      @spec run(map(), map()) :: Jido.Exec.exec_result()
       def run(params, context)
     end
   end
@@ -198,7 +197,6 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
 
       # This is a convenience entry point. Exec selects native Flow execution
       # from the descriptor and does not call this through the Action runner.
-      @impl Jido.Action
       def run(params, context), do: Jido.Exec.run(__MODULE__, params, context)
     end
   end

--- a/test/jido_action/action_test.exs
+++ b/test/jido_action/action_test.exs
@@ -22,27 +22,26 @@ defmodule JidoActionTest.ActionTest do
       assert NoSchema.schema() == []
     end
 
-    test "runtime compiled action exposes metadata and default run error" do
+    test "a missing run callback is reported during compilation" do
       module = unique_module("RuntimeDefaultAction")
 
-      create_module(
-        module,
-        quote do
-          use Jido.Action,
-            name: "runtime_default_action",
-            description: "Runtime default action"
-        end
-      )
+      {_error, diagnostics} =
+        Code.with_diagnostics(fn ->
+          assert_raise CompileError, fn ->
+            create_module(
+              module,
+              quote do
+                use Jido.Action,
+                  name: "runtime_default_action",
+                  description: "Runtime default action"
+              end
+            )
+          end
+        end)
 
-      assert module.name() == "runtime_default_action"
-      assert module.description() == "Runtime default action"
-      assert module.schema() == []
-      assert module.output_schema() == []
-
-      assert {:error, %Jido.Action.Error.ConfigurationError{message: message}} =
-               module.run(%{}, %{})
-
-      assert message =~ "run/2 must be implemented"
+      assert Enum.any?(diagnostics, fn diagnostic ->
+               diagnostic.message =~ "implementation not provided for predefined def run/2"
+             end)
     end
 
     test "runtime compiled action supports non-literal options" do
@@ -90,6 +89,9 @@ defmodule JidoActionTest.ActionTest do
             name: "runtime_schema_variable_action",
             schema: Zoi.object(%{value: input_type}),
             output_schema: Zoi.object(%{result: output_type})
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 
@@ -117,6 +119,9 @@ defmodule JidoActionTest.ActionTest do
                   Zoi.integer()
                   |> Zoi.refine({JidoActionTest.ActionTest, :at_least, [4]})
               })
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 
@@ -197,6 +202,9 @@ defmodule JidoActionTest.ActionTest do
           use Jido.Action,
             name: "counted_static_schema_action",
             schema: JidoActionTest.ActionTest.counted_static_schema(unquote(counter))
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 
@@ -214,6 +222,9 @@ defmodule JidoActionTest.ActionTest do
         module,
         quote do
           use Jido.Action, JidoActionTest.ActionTest.counted_options(unquote(counter))
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 
@@ -328,6 +339,9 @@ defmodule JidoActionTest.ActionTest do
             output_schema:
               Zoi.object(%{})
               |> Zoi.transform({JidoActionTest.ActionTest, :invalid_transform, []})
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 
@@ -397,6 +411,9 @@ defmodule JidoActionTest.ActionTest do
 
           @impl true
           def on_before_validate_params(_params), do: {:error, :unsafe_input}
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 
@@ -432,6 +449,9 @@ defmodule JidoActionTest.ActionTest do
           use Jido.Action,
             name: "strict_params_action",
             schema: Zoi.object(%{value: Zoi.integer()}, unrecognized_keys: :error)
+
+          @impl true
+          def run(params, _context), do: {:ok, params}
         end
       )
 

--- a/test/jido_action/inline_host_build_test.exs
+++ b/test/jido_action/inline_host_build_test.exs
@@ -61,6 +61,19 @@ defmodule Jido.Action.InlineHostBuildTest do
     assert output =~ "INLINE_HOST_BUILD_OK"
   end
 
+  test "a missing Action callback fails ordinary compilation", fixture do
+    File.write!(Path.join(fixture.directory, "lib/missing_action.ex"), """
+    defmodule InlineConsumer.MissingAction do
+      use Jido.Action, name: "missing_action"
+    end
+    """)
+
+    {output, status} = child(fixture, ~s|Mix.CLI.main(["compile"])|)
+    assert status != 0
+    assert output =~ "run/2"
+    assert output =~ "implementation not provided"
+  end
+
   defp owner_source do
     """
     defmodule InlineConsumer.Bound do

--- a/test/jido_exec/action_invocation_test.exs
+++ b/test/jido_exec/action_invocation_test.exs
@@ -1,0 +1,178 @@
+defmodule JidoActionTest.Exec.ActionInvocationTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Action.{Error, Output}
+  alias Jido.{Exec, Flow, Instruction}
+  alias Jido.Flow.{Ref, Step}
+
+  defmodule FinalAction do
+    use Jido.Action, name: "invocation_final"
+
+    @impl true
+    def run(params, _context), do: {:ok, params}
+  end
+
+  defmodule Probe do
+    @behaviour Jido.Action
+    @behaviour Jido.Executable
+
+    @impl true
+    def __jido_executable__, do: Jido.Executable.action(__MODULE__)
+
+    @impl true
+    def validate_params(params) do
+      record(params, :input)
+
+      if params.mode == :input_error,
+        do: {:error, Error.validation_error("input rejected", %{source: :probe})},
+        else: {:ok, Map.put(params, :validated_input, true)}
+    end
+
+    @impl true
+    def run(%{validated_input: true} = params, %{invocation: invocation}) do
+      record(params, :execution)
+      true = invocation == params.invocation
+
+      case params.mode do
+        :execution_error -> {:error, Error.execution_error("work rejected"), params.extras}
+        :invalid_output -> {:ok, 42, params.extras}
+        :envelope -> {:ok, Output.raw(42), params.extras}
+        :continue -> {:continue, %{value: 42}, FinalAction}
+        _ -> {:ok, Map.put(params, :ran, true), params.extras}
+      end
+    end
+
+    @impl true
+    def validate_output(%{ran: true} = params) do
+      record(params, :output)
+
+      if params.mode == :output_error,
+        do: {:error, Error.validation_error("output rejected", %{source: :probe})},
+        else: {:ok, %{value: 42}}
+    end
+
+    defp record(%{counter: counter}, phase) do
+      worker = self()
+      Agent.update(counter, &[{phase, worker} | &1])
+    end
+  end
+
+  for {mode, phases} <- [
+        success: [:input, :execution, :output],
+        input_error: [:input],
+        execution_error: [:input, :execution],
+        output_error: [:input, :execution, :output],
+        invalid_output: [:input, :execution],
+        envelope: [:input, :execution],
+        continue: [:input, :execution]
+      ] do
+    test "#{mode} runs each required phase once in one isolated worker" do
+      counter = start_supervised!({Agent, fn -> [] end})
+      supervisor = start_supervised!(Task.Supervisor)
+      invocation = make_ref()
+      params = %{counter: counter, mode: unquote(mode), extras: nil, invocation: invocation}
+      context = %{invocation: invocation}
+
+      for {path, kind, run} <- paths(params, context, supervisor) do
+        Agent.update(counter, fn _ -> [] end)
+        result = run.()
+        assert_result(result, kind, unquote(mode))
+
+        calls = Agent.get(counter, &Enum.reverse/1)
+        assert Enum.map(calls, &elem(&1, 0)) == unquote(phases), to_string(path)
+        assert [worker] = calls |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+        refute worker == self()
+
+        for pid <- Enum.uniq([worker | Task.Supervisor.children(supervisor)]) do
+          monitor = Process.monitor(pid)
+          assert_receive {:DOWN, ^monitor, :process, ^pid, reason}
+          assert reason in [:normal, :noproc]
+        end
+
+        assert Task.Supervisor.children(supervisor) == []
+      end
+    end
+  end
+
+  defp paths(params, context, supervisor) do
+    instruction = Instruction.new!(target: Probe, params: params, context: context)
+
+    flow =
+      Flow.new!(
+        name: "invocation_probe",
+        components: [Step.new!(name: "probe", action: Probe, params: Ref.input([]))],
+        output: Ref.result("probe")
+      )
+
+    opts = [task_supervisor: supervisor]
+
+    [
+      {:action, :action, fn -> Exec.run(Probe, params, context, opts) end},
+      {:instruction, :action, fn -> Exec.run(instruction, %{}, %{}, opts) end},
+      {:action_timeout, :action,
+       fn -> Exec.run(Probe, params, context, [timeout: 5_000] ++ opts) end},
+      {:action_async, :action,
+       fn -> Probe |> Exec.run_async(params, context, opts) |> Exec.await() end},
+      {:flow, :flow, fn -> Exec.run(flow, params, context, opts) end},
+      {:flow_timeout, :flow, fn -> Exec.run(flow, params, context, [timeout: 5_000] ++ opts) end},
+      {:flow_async, :flow,
+       fn -> flow |> Exec.run_async(params, context, opts) |> Exec.await() end},
+      {:step, :flow, fn -> finish_steps(flow, params, context, opts, :step) end},
+      {:wave, :flow, fn -> finish_steps(flow, params, context, opts, :wave) end}
+    ]
+  end
+
+  defp finish_steps(flow, params, context, opts, operation) do
+    {:ok, execution} = Exec.start(flow, params, context, opts)
+    finish_steps(execution, operation)
+  end
+
+  defp finish_steps(execution, operation) do
+    if Exec.status(execution) in [:succeeded, :failed] do
+      Exec.result(execution)
+    else
+      {:ok, _work, execution} = apply(Exec, operation, [execution])
+      finish_steps(execution, operation)
+    end
+  end
+
+  defp assert_result(result, kind, mode) when mode in [:success, :envelope] do
+    output = if mode == :envelope, do: Output.raw(42), else: %{value: 42}
+    expected = if kind == :action, do: {:ok, output, nil}, else: {:ok, output}
+    assert result == expected
+  end
+
+  defp assert_result(result, :action, :continue), do: assert(result == {:ok, %{value: 42}})
+
+  defp assert_result(result, kind, mode) do
+    error =
+      if kind == :action and mode in [:execution_error, :output_error, :invalid_output] do
+        assert {:error, error, nil} = result
+        error
+      else
+        assert {:error, error} = result
+        error
+      end
+
+    expected_type =
+      if mode in [:input_error, :output_error],
+        do: Error.InvalidInputError,
+        else: Error.ExecutionFailureError
+
+    assert error.__struct__ == expected_type
+
+    if kind == :flow do
+      expected_phase =
+        case mode do
+          :input_error -> :step_input
+          mode when mode in [:output_error, :invalid_output] -> :step_output
+          _ -> :step_execution
+        end
+
+      assert error.details.phase == expected_phase
+      assert error.details.node == "probe"
+    end
+
+    if mode in [:input_error, :output_error], do: assert(error.details.source == :probe)
+  end
+end

--- a/test/jido_exec/action_worker_reply_test.exs
+++ b/test/jido_exec/action_worker_reply_test.exs
@@ -1,0 +1,123 @@
+defmodule JidoActionTest.Exec.ActionWorkerReplyTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Action.Error
+  alias Jido.{Exec, Flow}
+  alias Jido.Flow.{Ref, Step}
+
+  defmodule LargeExtras do
+    @behaviour Jido.Action
+    @behaviour Jido.Executable
+
+    @impl true
+    def __jido_executable__, do: Jido.Executable.action(__MODULE__)
+
+    @impl true
+    def validate_params(params), do: {:ok, params}
+
+    @impl true
+    def validate_output(%{mode: :output_error}),
+      do: {:error, Error.validation_error("output rejected")}
+
+    def validate_output(output), do: {:ok, output}
+
+    @impl true
+    def run(%{owner: owner, ref: ref, mode: mode}, _context) do
+      send(owner, {ref, :ready, self()})
+
+      receive do
+        {^ref, :release} ->
+          # Build the large value only in the worker, after tracing is ready.
+          extras = Enum.to_list(1..100_000)
+
+          if mode == :execution_error,
+            do: {:error, Error.execution_error("work rejected"), extras},
+            else: {:ok, %{mode: mode}, extras}
+      end
+    end
+  end
+
+  for kind <- [:action, :flow], mode <- [:success, :execution_error, :output_error] do
+    test "#{kind} converts #{mode} extras before the worker sends its reply" do
+      supervisor = start_supervised!(Task.Supervisor)
+      ref = make_ref()
+      params = %{owner: self(), ref: ref, mode: unquote(mode)}
+      target = target(unquote(kind))
+
+      caller =
+        Task.Supervisor.async_nolink(supervisor, fn ->
+          Exec.run(target, params, %{}, task_supervisor: supervisor)
+        end)
+
+      assert_receive {^ref, :ready, worker}, 1_000
+      monitor = Process.monitor(worker)
+
+      try do
+        assert :erlang.trace(worker, true, [:send, {:tracer, self()}]) == 1
+        send(worker, {ref, :release})
+
+        assert_receive {:trace, ^worker, :send, {reply_ref, ^worker, reply}, recipient}
+                       when is_reference(reply_ref) and is_pid(recipient),
+                       1_000
+
+        assert_receive {:DOWN, ^monitor, :process, ^worker, :normal}, 1_000
+
+        result = Task.await(caller)
+        assert_reply(reply, result, unquote(kind), unquote(mode))
+
+        # All send traces must arrive before checking for another worker reply.
+        delivered = :erlang.trace_delivered(:all)
+        assert_receive {:trace_delivered, :all, ^delivered}, 1_000
+        refute_received {:trace, ^worker, :send, {^reply_ref, ^worker, _}, _}
+      after
+        Process.exit(worker, :kill)
+        Process.demonitor(monitor, [:flush])
+        Task.shutdown(caller, :brutal_kill)
+      end
+    end
+  end
+
+  defp target(:action), do: LargeExtras
+
+  defp target(:flow) do
+    Flow.new!(
+      name: "large_extras",
+      components: [Step.new!(name: "probe", action: LargeExtras, params: Ref.input([]))],
+      output: Ref.result("probe")
+    )
+  end
+
+  defp assert_reply(reply, result, :action, mode) do
+    assert reply == result
+    assert {status, value, extras} = reply
+    assert length(extras) == 100_000
+    assert hd(extras) == 1
+    assert List.last(extras) == 100_000
+    assert_value(status, value, mode)
+  end
+
+  defp assert_reply(reply, result, :flow, mode) do
+    # One copy of the extras needs at least 200,000 words.
+    assert :erts_debug.flat_size(reply) < 1_000
+
+    if mode == :success do
+      assert reply == {:ok, %{mode: :success}}
+      assert result == reply
+    else
+      phase = if mode == :output_error, do: :output, else: :execution
+      assert {:error, ^phase, error} = reply
+      assert_value(:error, error, mode)
+      assert {:error, public_error} = result
+      assert public_error.__struct__ == error.__struct__
+      assert public_error.message == error.message
+    end
+  end
+
+  defp assert_value(:ok, %{mode: :success}, :success), do: :ok
+
+  defp assert_value(:error, error, :execution_error),
+    do: assert(error.__struct__ == Error.ExecutionFailureError)
+
+  defp assert_value(:error, error, :output_error),
+    do: assert(error.__struct__ == Error.InvalidInputError)
+end

--- a/test/jido_exec/flow_adapter_test.exs
+++ b/test/jido_exec/flow_adapter_test.exs
@@ -157,9 +157,8 @@ defmodule JidoActionTest.Exec.FlowAdapterTest do
     def run(_params, _context), do: {:ok, %{}}
   end
 
-  defmodule MissingRunFlow do
+  defmodule MissingDefinitionCallback do
     def __jido_executable__, do: Jido.Executable.flow(__MODULE__)
-    def flow, do: JidoActionTest.Fixtures.FlowAuthoring.math_flow!()
     def validate_params(params), do: {:ok, params}
     def validate_output(output), do: {:ok, output}
   end
@@ -212,7 +211,8 @@ defmodule JidoActionTest.Exec.FlowAdapterTest do
       assert Error.owned?(error)
     end
 
-    assert {:error, %InvalidDefinitionError{}} = Exec.start(MissingRunFlow)
+    assert {:error, %InvalidDefinitionError{details: %{reason: "missing flow/0"}}} =
+             Exec.start(MissingDefinitionCallback)
 
     assert {:error,
             %InvalidDefinitionError{

--- a/test/jido_executable_test.exs
+++ b/test/jido_executable_test.exs
@@ -2,6 +2,8 @@ defmodule JidoActionTest.ExecutableTest do
   use ExUnit.Case, async: true
 
   alias Jido.Executable
+  alias Jido.{Exec, Flow, Instruction}
+  alias Jido.Flow.{Ref, Subflow}
   alias JidoActionTest.Fixtures.MathFlow
 
   alias JidoActionTest.Fixtures.Actions.{
@@ -27,6 +29,43 @@ defmodule JidoActionTest.ExecutableTest do
     def __jido_executable__, do: raise("descriptor failed")
   end
 
+  defmodule FlowWithoutRun do
+    @behaviour Jido.Executable
+
+    @impl true
+    def __jido_executable__, do: Executable.flow(__MODULE__)
+    def flow, do: MathFlow.flow()
+    @impl true
+    defdelegate validate_params(params), to: MathFlow
+    @impl true
+    defdelegate validate_output(output), to: MathFlow
+  end
+
+  defmodule ContinueToFlow do
+    use Jido.Action, name: "continue_to_flow_without_run"
+
+    @impl true
+    def run(params, _context), do: {:continue, params, FlowWithoutRun}
+  end
+
+  defmodule MissingFlowDefinition do
+    def __jido_executable__, do: Executable.flow(__MODULE__)
+    def validate_params(params), do: {:ok, params}
+    def validate_output(output), do: {:ok, output}
+  end
+
+  defmodule MissingFlowParams do
+    def __jido_executable__, do: Executable.flow(__MODULE__)
+    def flow, do: MathFlow.flow()
+    def validate_output(output), do: {:ok, output}
+  end
+
+  defmodule MissingFlowOutput do
+    def __jido_executable__, do: Executable.flow(__MODULE__)
+    def flow, do: MathFlow.flow()
+    def validate_params(params), do: {:ok, params}
+  end
+
   test "the Executable behaviour declares identity and validation callbacks" do
     assert Enum.sort(Executable.behaviour_info(:callbacks)) ==
              [__jido_executable__: 0, validate_output: 1, validate_params: 1]
@@ -41,6 +80,7 @@ defmodule JidoActionTest.ExecutableTest do
         module.__info__(:attributes) |> Keyword.get_values(:behaviour) |> List.flatten()
 
       assert Executable in behaviours
+      assert Jido.Action in behaviours == (module == Add)
 
       for {callback, arity} <- Executable.behaviour_info(:callbacks) do
         assert function_exported?(module, callback, arity)
@@ -104,6 +144,51 @@ defmodule JidoActionTest.ExecutableTest do
     assert {:error, missing_output} = Executable.validate(MissingValidateOutput)
     assert missing_output.details.executable == MissingValidateOutput
     assert missing_output.details.reason == "missing validate_output/1"
+  end
+
+  test "Flow validation requires definition and validation callbacks, without run/2" do
+    refute function_exported?(FlowWithoutRun, :run, 2)
+    assert :ok = Executable.validate(FlowWithoutRun)
+
+    for {module, reason} <- [
+          {MissingFlowDefinition, "missing flow/0"},
+          {MissingFlowParams, "missing validate_params/1"},
+          {MissingFlowOutput, "missing validate_output/1"}
+        ] do
+      assert {:error, error} = Executable.validate(module)
+      assert error.message == "module is not a valid Jido executable"
+      assert error.details == %{executable: module, reason: reason}
+    end
+  end
+
+  test "a Flow without run/2 executes through every public entry" do
+    input = %{value: 3}
+    expected = {:ok, %{value: 8}}
+    instruction = Instruction.new!(target: FlowWithoutRun, params: input)
+
+    parent =
+      Flow.new!(
+        name: "flow_without_run_parent",
+        components: [Subflow.new!(name: "child", flow: FlowWithoutRun, params: Ref.input([]))],
+        output: Ref.result("child")
+      )
+
+    assert Exec.run(FlowWithoutRun, input) == expected
+    assert Exec.run(instruction) == expected
+    assert Exec.run(parent, input) == expected
+    assert Exec.run(ContinueToFlow, input) == expected
+    assert FlowWithoutRun |> Exec.run_async(input) |> Exec.await() == expected
+
+    for target <- [FlowWithoutRun, instruction, parent] do
+      assert {:ok, execution} = Exec.start(target, input)
+      assert {:ok, execution} = Exec.continue(execution)
+      assert Exec.result(execution) == expected
+    end
+  end
+
+  test "generated Flow run/2 is a convenience call through Exec" do
+    assert MathFlow.run(%{value: 3}, %{}) == Exec.run(MathFlow, %{value: 3})
+    assert MathFlow.run(%{value: "bad"}, %{}) == Exec.run(MathFlow, %{value: "bad"})
   end
 
   test "callback-only modules are not executable targets" do

--- a/test/jido_flow/dsl/flow_test.exs
+++ b/test/jido_flow/dsl/flow_test.exs
@@ -134,7 +134,7 @@ defmodule Jido.Flow.DSL.FlowTest do
     assert flow.output == Ref.result("loop")
   end
 
-  test "a Flow module exposes only the required Flow and Action-compatible helpers" do
+  test "a Flow module exposes its definition, validation, and convenience helpers" do
     module = Jido.Flow.DSL.FlowTest.MixedFlow
 
     for {name, arity} <- [

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -12,6 +12,7 @@ Use `jido_action` for validated work and data-first composition:
 ## Action Definitions
 
 - Use `use Jido.Action` for public actions.
+- Implement `run/2` in every Action. A missing body is a compile error.
 - Provide stable `name` and useful `description` values.
 - Use Zoi schemas for `schema` and `output_schema`; omit them or use `[]` only when validation is intentionally empty.
 - Keep `run/2` strict: return `{:ok, result}`, `{:ok, result, extra}`,
@@ -54,6 +55,8 @@ Use `jido_action` for validated work and data-first composition:
 
 - Use the compile-time `Jido.Flow` DSL as the primary developer authoring
   surface.
+- Resolve target kinds with `Jido.Executable`. A Flow requires `flow/0` and
+  validation callbacks; its generated `run/2` is a convenience function.
 - Add `:jido_action` to `.formatter.exs` `import_deps` to keep DSL declarations
   without parentheses. No formatter plugin is required.
 - Give every component a stable string name.


### PR DESCRIPTION
Use one input, work, and output pipeline for Action invocation. Direct calls retain extras. Flow workers discard unused extras before sending their reply, which avoids copying data that the caller cannot use.

Actions must implement `run/2`; a missing callback fails ordinary compilation. Flow modules use the Executable contract and no longer declare the Action behaviour. Generated Flow `run/2` remains a convenience call.

Tests cover phase order, once-only validation, success and error extras, worker replies, timeout, and cleanup. The docs describe these contracts without repeated transition examples.

Validation: focused invocation tests and docs checks passed. The combined enhancement suite passed with 94.89% coverage, `mix quality`, and the dependency audit. PR CI checks each supported runtime pair.

Closes #239.
