### PR TITLE
refactor(flow): share graph diagnostics and bound list accumulation

### DIFF
--- a/guides/flow-storage.md
+++ b/guides/flow-storage.md
@@ -208,18 +208,6 @@ records, expressions, conditions, lists, maps, and graph references. They do
 not return a partial Flow. Unknown-reference errors suppress a derived cycle
 error because that cycle result would be misleading.
 
-Graph diagnostics report duplicate occurrences first, then missing output
-references, then missing dependencies in component order. Within each
-component, missing dependency names are sorted. This preserves the stored
-diagnostic order; canonical construction checks explicit `after` names in
-author order. Both use the same graph rules. Duplicate or missing-reference
-errors suppress cycle analysis. Terminal Dispatch checks run only after
-those graph checks pass.
-
-Sharing these rules does not change the stored version, Registry contract,
-resource limits, or JSON error paths. Use `diagnose/2` for the complete error
-group; `decode/2` continues to return its first error.
-
 Document size, collection size, nesting, root type, and document version
 errors are terminal. Diagnostics do not traverse a document after one of
 these failures.

--- a/guides/flow-storage.md
+++ b/guides/flow-storage.md
@@ -208,6 +208,18 @@ records, expressions, conditions, lists, maps, and graph references. They do
 not return a partial Flow. Unknown-reference errors suppress a derived cycle
 error because that cycle result would be misleading.
 
+Graph diagnostics report duplicate occurrences first, then missing output
+references, then missing dependencies in component order. Within each
+component, missing dependency names are sorted. This preserves the stored
+diagnostic order; canonical construction checks explicit `after` names in
+author order. Both use the same graph rules. Duplicate or missing-reference
+errors suppress cycle analysis. Terminal Dispatch checks run only after
+those graph checks pass.
+
+Sharing these rules does not change the stored version, Registry contract,
+resource limits, or JSON error paths. Use `diagnose/2` for the complete error
+group; `decode/2` continues to return its first error.
+
 Document size, collection size, nesting, root type, and document version
 errors are terminal. Diagnostics do not traverse a document after one of
 these failures.

--- a/guides/flows.md
+++ b/guides/flows.md
@@ -96,20 +96,8 @@ InputBinding, FanOut, and FanIn.
 `validate_executable/1` also checks Action and child Flow contracts. Neither
 function runs Action work.
 
-All authoring forms share the graph rules for duplicate component names,
-missing dependencies, cycles, and terminal Dispatch. `new/1` and `validate/1`
-keep the first error. For a component's missing dependencies, explicit
-`after` names are checked in author order before inferred references.
-
-### Beta Diagnostic Migration
-
-The public validation calls, exception types, messages, and detail keys do
-not change. DSL graph errors now point to the source declaration for a
-missing reference, duplicate component, or cycle. Update tests that expected
-the module's first line for these errors to expect the declaration line.
-For duplicate names across component kinds, the error points to the second
-occurrence. Source locations remain outside the canonical Flow value and
-do not change its semantic identity.
+All authoring forms use the same graph rules. DSL errors identify the source
+declaration; `new/1` and `validate/1` return the first error.
 
 Continue with [Flow DSL](flow-language.livemd),
 [Direct Construction And Builder](flow-builder.md), and

--- a/guides/flows.md
+++ b/guides/flows.md
@@ -96,6 +96,21 @@ InputBinding, FanOut, and FanIn.
 `validate_executable/1` also checks Action and child Flow contracts. Neither
 function runs Action work.
 
+All authoring forms share the graph rules for duplicate component names,
+missing dependencies, cycles, and terminal Dispatch. `new/1` and `validate/1`
+keep the first error. For a component's missing dependencies, explicit
+`after` names are checked in author order before inferred references.
+
+### Beta Diagnostic Migration
+
+The public validation calls, exception types, messages, and detail keys do
+not change. DSL graph errors now point to the source declaration for a
+missing reference, duplicate component, or cycle. Update tests that expected
+the module's first line for these errors to expect the declaration line.
+For duplicate names across component kinds, the error points to the second
+occurrence. Source locations remain outside the canonical Flow value and
+do not change its semantic identity.
+
 Continue with [Flow DSL](flow-language.livemd),
 [Direct Construction And Builder](flow-builder.md), and
 [Store Flows As JSON](flow-storage.md).

--- a/lib/jido_flow.ex
+++ b/lib/jido_flow.ex
@@ -141,7 +141,7 @@ defmodule Jido.Flow do
   def new(%__MODULE__{} = flow), do: flow |> Map.from_struct() |> new()
 
   def new(attrs) do
-    with {:ok, attrs} <- Validation.new(attrs) do
+    with {:ok, attrs} <- Validation.validate(attrs) do
       {:ok, struct!(__MODULE__, attrs)}
     end
   end

--- a/lib/jido_flow/codec.ex
+++ b/lib/jido_flow/codec.ex
@@ -34,7 +34,6 @@ defmodule Jido.Flow.Codec do
   alias Jido.Flow.Dispatch
   alias Jido.Flow.Error
   alias Jido.Flow.Expression
-  alias Jido.Flow.Graph
   alias Jido.Flow.Iterate
   alias Jido.Flow.Map, as: FlowMap
   alias Jido.Flow.Reduce
@@ -300,18 +299,37 @@ defmodule Jido.Flow.Codec do
   end
 
   defp diagnose_canonical_document(attrs) do
-    graph_errors = graph_diagnostics(attrs.components, attrs.output)
-
-    cond do
-      graph_errors != [] ->
-        diagnostic_failure(graph_errors)
-
-      true ->
-        case Flow.new(attrs) do
-          {:ok, flow} -> {:ok, flow}
-          {:error, error} -> diagnostic_failure([ensure_json_path(error, [])])
-        end
+    case Validation.diagnose(attrs) do
+      {:ok, attrs} -> {:ok, struct!(Flow, attrs)}
+      {:error, issues} -> issues |> canonical_errors() |> diagnostic_failure()
     end
+  end
+
+  defp canonical_errors(issues) do
+    # Stored documents have always reported graph errors before a nil output's
+    # required-field error. Canonical construction keeps the opposite priority.
+    issues =
+      case issues do
+        [%{kind: :output_required}, _graph_issue | _rest] -> tl(issues)
+        _other -> issues
+      end
+
+    issues
+    |> Enum.chunk_by(fn
+      %{kind: :unknown_dependency, location: [:components, index]} -> {:component, index}
+      _issue -> :other
+    end)
+    |> Enum.flat_map(fn
+      [%{kind: :unknown_dependency, location: [:components, _index]} | _rest] = group ->
+        Enum.sort_by(group, & &1.error.details.component)
+
+      group ->
+        group
+    end)
+    |> Enum.map(fn %{error: error, location: location} ->
+      error = %{error | details: Map.put(error.details, :path, location)}
+      ensure_json_path(error, [])
+    end)
   end
 
   defp diagnose_components(values, registry) when is_list(values) do
@@ -1091,100 +1109,6 @@ defmodule Jido.Flow.Codec do
 
   defp diagnose_constructor({:error, error}, path) do
     {:error, ensure_json_path(error, path)}
-  end
-
-  defp graph_diagnostics(components, output) do
-    duplicate_errors = duplicate_component_errors(components)
-    reference_errors = unknown_reference_errors(components, output)
-
-    cycle_errors =
-      if duplicate_errors == [] and reference_errors == [] do
-        case Graph.analyze(components) do
-          %{remaining: []} ->
-            []
-
-          %{remaining: names} ->
-            [
-              Error.validation_error("flow dependency graph contains a cycle", %{
-                components: names,
-                path: ["components"]
-              })
-            ]
-        end
-      else
-        []
-      end
-
-    dispatch_errors =
-      if duplicate_errors == [] and reference_errors == [] and cycle_errors == [] do
-        components
-        |> Validation.dispatch_diagnostics(output)
-        |> Enum.map(&ensure_json_path(&1, []))
-      else
-        []
-      end
-
-    duplicate_errors ++ reference_errors ++ cycle_errors ++ dispatch_errors
-  end
-
-  defp duplicate_component_errors(components) do
-    components
-    |> Enum.with_index()
-    |> Enum.reduce({MapSet.new(), []}, fn {component, index}, {seen, errors} ->
-      name = Jido.Flow.Component.name_of(component)
-
-      if MapSet.member?(seen, name) do
-        error =
-          Error.validation_error("duplicate component name", %{
-            name: name,
-            path: ["components", index, "name"]
-          })
-
-        {seen, [error | errors]}
-      else
-        {MapSet.put(seen, name), errors}
-      end
-    end)
-    |> elem(1)
-    |> Enum.reverse()
-  end
-
-  defp unknown_reference_errors(components, output) do
-    known = components |> Enum.map(&Jido.Flow.Component.name_of/1) |> MapSet.new()
-
-    output_errors =
-      output
-      |> Expression.result_refs()
-      |> Enum.uniq()
-      |> unknown_reference_errors_for(known, :output, ["output"])
-
-    component_errors =
-      components
-      |> Enum.with_index()
-      |> Enum.flat_map(fn {component, index} ->
-        component
-        |> Jido.Flow.Component.effective_dependencies()
-        |> unknown_reference_errors_for(
-          known,
-          Jido.Flow.Component.name_of(component),
-          ["components", index]
-        )
-      end)
-
-    output_errors ++ component_errors
-  end
-
-  defp unknown_reference_errors_for(names, known, owner, path) do
-    names
-    |> Enum.reject(&MapSet.member?(known, &1))
-    |> Enum.uniq()
-    |> Enum.map(fn name ->
-      Error.validation_error("Flow reference points to an unknown component", %{
-        owner: owner,
-        component: name,
-        path: path
-      })
-    end)
   end
 
   defp collect_values(fields, initial_errors \\ []) do

--- a/lib/jido_flow/codec.ex
+++ b/lib/jido_flow/codec.ex
@@ -1057,13 +1057,13 @@ defmodule Jido.Flow.Codec do
               path: path ++ ["entries", index, "key"]
             })
 
-          {map, errors ++ [error]}
+          {map, [error | errors]}
         else
           {Map.put(map, key, value), errors}
         end
       end)
 
-    if errors == [], do: {:ok, map}, else: {:error, errors}
+    if errors == [], do: {:ok, map}, else: {:error, Enum.reverse(errors)}
   end
 
   defp exact_value_as_value(record, field, expected, path) do
@@ -1140,12 +1140,13 @@ defmodule Jido.Flow.Codec do
             path: ["components", index, "name"]
           })
 
-        {seen, errors ++ [error]}
+        {seen, [error | errors]}
       else
         {MapSet.put(seen, name), errors}
       end
     end)
     |> elem(1)
+    |> Enum.reverse()
   end
 
   defp unknown_reference_errors(components, output) do
@@ -1203,13 +1204,13 @@ defmodule Jido.Flow.Codec do
     {decoded, errors} =
       Enum.reduce(values, {[], []}, fn value, {decoded, errors} ->
         case validator.(value) do
-          {:ok, item} -> {decoded ++ [item], errors}
-          {:error, nested} when is_list(nested) -> {decoded, errors ++ nested}
-          {:error, error} -> {decoded, errors ++ [error]}
+          {:ok, item} -> {[item | decoded], errors}
+          {:error, nested} when is_list(nested) -> {decoded, Enum.reverse(nested, errors)}
+          {:error, error} -> {decoded, [error | errors]}
         end
       end)
 
-    if errors == [], do: {:ok, decoded}, else: {:error, errors}
+    if errors == [], do: {:ok, Enum.reverse(decoded)}, else: {:error, Enum.reverse(errors)}
   end
 
   defp unknown_field_errors(record, allowed, path) do

--- a/lib/jido_flow/codec.ex
+++ b/lib/jido_flow/codec.ex
@@ -1128,9 +1128,11 @@ defmodule Jido.Flow.Codec do
     {decoded, errors} =
       Enum.reduce(values, {[], []}, fn value, {decoded, errors} ->
         case validator.(value) do
-          {:ok, item} -> {[item | decoded], errors}
-          {:error, nested} when is_list(nested) -> {decoded, Enum.reverse(nested, errors)}
-          {:error, error} -> {decoded, [error | errors]}
+          {:ok, item} when errors == [] -> {[item | decoded], []}
+          {:ok, _item} -> {[], errors}
+          {:error, []} -> {decoded, errors}
+          {:error, nested} when is_list(nested) -> {[], Enum.reverse(nested, errors)}
+          {:error, error} -> {[], [error | errors]}
         end
       end)
 

--- a/lib/jido_flow/component.ex
+++ b/lib/jido_flow/component.ex
@@ -186,7 +186,7 @@ defmodule Jido.Flow.Component do
       |> Enum.reduce_while({:ok, []}, fn value, {:ok, names} ->
         case name(value) do
           {:ok, name} ->
-            {:cont, {:ok, names ++ [name]}}
+            {:cont, {:ok, [name | names]}}
 
           {:error, _error} ->
             {:halt,
@@ -210,7 +210,9 @@ defmodule Jido.Flow.Component do
     end
   end
 
-  defp reject_duplicate_after({:ok, names}) do
+  defp reject_duplicate_after({:ok, reversed_names}) do
+    names = Enum.reverse(reversed_names)
+
     case names -- Enum.uniq(names) do
       [] ->
         {:ok, names}

--- a/lib/jido_flow/dsl/lowerer.ex
+++ b/lib/jido_flow/dsl/lowerer.ex
@@ -4,6 +4,7 @@ defmodule Jido.Flow.DSL.Lowerer do
   alias Jido.Flow
   alias Jido.Flow.Condition
   alias Jido.Flow.Error
+  alias Jido.Flow.Validation
   alias Jido.Flow.Ref
   alias Jido.Flow.Step, as: FlowStep
   alias Jido.Flow.Subflow
@@ -35,14 +36,19 @@ defmodule Jido.Flow.DSL.Lowerer do
 
     with :ok <- validate_output_position(entities),
          {:ok, components, output} <- lower_entities(entities) do
-      Flow.new(%{
+      attrs = %{
         name: Keyword.fetch!(opts, :name),
         description: Keyword.get(opts, :description),
         schema: Keyword.get(opts, :schema, []),
         output_schema: Keyword.get(opts, :output_schema, []),
         components: components,
         output: output
-      })
+      }
+
+      case Validation.diagnose(attrs) do
+        {:ok, attrs} -> {:ok, struct!(Flow, attrs)}
+        {:error, [issue | _rest]} -> {:error, attach_validation_location(issue, entities)}
+      end
     end
   end
 
@@ -312,6 +318,25 @@ defmodule Jido.Flow.DSL.Lowerer do
         error = Error.validation_error("output must be the final Flow declaration")
         {:error, attach_entity_location(error, Enum.at(entities, index))}
     end
+  end
+
+  defp attach_validation_location(%{error: error, location: location}, entities) do
+    entity =
+      case location do
+        [:output | _rest] ->
+          Enum.find(entities, &match?(%Output{}, &1))
+
+        [:components, index | _rest] when is_integer(index) ->
+          entities |> Enum.reject(&match?(%Output{}, &1)) |> Enum.at(index)
+
+        [:components] ->
+          Enum.find(entities, &(Map.get(&1, :name) in error.details.components))
+
+        _other ->
+          nil
+      end
+
+    if entity, do: attach_entity_location(error, entity), else: error
   end
 
   defp attach_entity_location(%{details: details} = error, entity) when is_map(details) do

--- a/lib/jido_flow/validation.ex
+++ b/lib/jido_flow/validation.ex
@@ -19,13 +19,40 @@ defmodule Jido.Flow.Validation do
   @module_config_keys [:name, :description, :schema, :output_schema]
   @artifact_config_keys @module_config_keys ++ [:components, :output]
 
-  @doc false
-  @spec new(map() | keyword()) :: {:ok, map()} | {:error, Exception.t()}
-  def new(attrs), do: validate_attrs(attrs)
+  @typedoc false
+  @type issue :: %{
+          kind:
+            :definition
+            | :output_required
+            | :duplicate_name
+            | :unknown_dependency
+            | :cycle
+            | :dispatch,
+          error: Exception.t(),
+          location: [atom() | String.t() | non_neg_integer()]
+        }
 
   @doc false
   @spec validate(map() | keyword()) :: {:ok, map()} | {:error, Exception.t()}
-  def validate(attrs), do: validate_attrs(attrs)
+  def validate(attrs) do
+    case diagnose(attrs) do
+      {:ok, attrs} -> {:ok, attrs}
+      {:error, [issue | _rest]} -> {:error, issue.error}
+    end
+  end
+
+  @doc false
+  @spec diagnose(map() | keyword()) :: {:ok, map()} | {:error, [issue()]}
+  def diagnose(attrs) do
+    case normalize_attrs(attrs) do
+      {:ok, attrs} ->
+        issues = output_issues(attrs.output) ++ graph_issues(attrs.components, attrs.output)
+        if issues == [], do: {:ok, attrs}, else: {:error, issues}
+
+      {:error, error} ->
+        {:error, [issue(:definition, error, Map.get(error.details, :path, []))]}
+    end
+  end
 
   @doc false
   @spec validate_executable(map() | keyword()) :: {:ok, map()} | {:error, Exception.t()}
@@ -36,36 +63,10 @@ defmodule Jido.Flow.Validation do
   end
 
   @doc false
-  @spec dispatch_diagnostics([Component.t()], term()) :: [Exception.t()]
-  def dispatch_diagnostics(components, output) do
-    dispatches =
-      components
-      |> Enum.with_index()
-      |> Enum.filter(fn {component, _index} -> match?(%Dispatch{}, component) end)
-
-    case dispatches do
-      [] ->
-        []
-
-      [{%Dispatch{name: name}, index}] ->
-        dispatch_sink_errors(components, name, index) ++ dispatch_output_errors(output, name)
-
-      [_first, {%Dispatch{} = second, index} | _rest] ->
-        [
-          Error.validation_error("Flow can contain only one Dispatch component", %{
-            component: second.name,
-            components: Enum.map(dispatches, fn {%Dispatch{name: name}, _index} -> name end),
-            path: [:components, index]
-          })
-        ]
-    end
-  end
-
-  @doc false
   @spec prepare_executable(map() | keyword(), [module()]) ::
           {:ok, map(), %{optional(module()) => Jido.Flow.t()}} | {:error, Exception.t()}
   def prepare_executable(attrs, module_stack \\ []) do
-    with {:ok, flow} <- validate_attrs(attrs),
+    with {:ok, flow} <- validate(attrs),
          {:ok, subflows} <- validate_component_targets(flow.components, module_stack, %{}) do
       {:ok, flow, subflows}
     end
@@ -91,24 +92,20 @@ defmodule Jido.Flow.Validation do
   def invalid_subject(value),
     do: {:error, Error.validation_error("expected a Jido.Flow artifact", %{value: value})}
 
-  defp validate_attrs(attrs) when is_list(attrs) do
+  defp normalize_attrs(attrs) when is_list(attrs) do
     if Keyword.keyword?(attrs),
-      do: attrs |> Map.new() |> validate_attrs(),
+      do: attrs |> Map.new() |> normalize_attrs(),
       else: {:error, Error.validation_error("flow configuration must be a map")}
   end
 
-  defp validate_attrs(%{} = attrs) do
+  defp normalize_attrs(%{} = attrs) do
     with :ok <- known_keys(attrs, @artifact_config_keys),
          {:ok, name} <- name(Map.get(attrs, :name)),
          {:ok, description} <- description(Map.get(attrs, :description)),
          {:ok, schema} <- schema(Map.get(attrs, :schema, []), "schema"),
          {:ok, output_schema} <- schema(Map.get(attrs, :output_schema, []), "output_schema"),
          {:ok, components} <- components(Map.get(attrs, :components, [])),
-         {:ok, output} <- output(Map.get(attrs, :output)),
-         :ok <- unique_names(components),
-         :ok <- known_dependencies(components, output),
-         :ok <- acyclic(components),
-         :ok <- validate_terminal_dispatch(components, output) do
+         {:ok, output} <- output(Map.get(attrs, :output)) do
       {:ok,
        %{
          name: name,
@@ -121,7 +118,7 @@ defmodule Jido.Flow.Validation do
     end
   end
 
-  defp validate_attrs(_attrs),
+  defp normalize_attrs(_attrs),
     do: {:error, Error.validation_error("flow configuration must be a map")}
 
   defp known_keys(attrs, allowed) do
@@ -195,8 +192,7 @@ defmodule Jido.Flow.Validation do
 
   defp components(_values), do: {:error, Error.validation_error("flow components must be a list")}
 
-  defp output(nil),
-    do: {:error, Error.validation_error("Flow output is required", %{path: [:output]})}
+  defp output(nil), do: {:ok, nil}
 
   defp output(value) do
     with {:ok, value} <- Expression.normalize(value),
@@ -205,60 +201,123 @@ defmodule Jido.Flow.Validation do
     end
   end
 
-  defp unique_names(components) do
-    names = Enum.map(components, &Component.name_of/1)
+  defp output_issues(nil) do
+    [
+      issue(
+        :output_required,
+        Error.validation_error("Flow output is required", %{path: [:output]}),
+        [:output]
+      )
+    ]
+  end
 
-    case names -- Enum.uniq(names) do
-      [] -> :ok
-      [name | _] -> {:error, Error.validation_error("duplicate component name", %{name: name})}
+  defp output_issues(_output), do: []
+
+  defp graph_issues(components, output) do
+    {known, duplicates} = duplicate_name_issues(components)
+    references = unknown_dependency_issues(components, output, known)
+
+    case duplicates ++ references do
+      [] ->
+        case Graph.analyze(components) do
+          %{remaining: []} ->
+            dispatch_issues(components, output)
+
+          %{remaining: names} ->
+            [
+              issue(
+                :cycle,
+                Error.validation_error("flow dependency graph contains a cycle", %{
+                  components: names
+                }),
+                [:components]
+              )
+            ]
+        end
+
+      issues ->
+        issues
     end
   end
 
-  defp known_dependencies(components, output) do
-    known = components |> Enum.map(&Component.name_of/1) |> MapSet.new()
+  defp duplicate_name_issues(components) do
+    {known, issues} =
+      components
+      |> Enum.with_index()
+      |> Enum.reduce({MapSet.new(), []}, fn {component, index}, {known, issues} ->
+        name = Component.name_of(component)
 
-    with :ok <- known_refs(Expression.result_refs(output), known, :output) do
-      Enum.reduce_while(components, :ok, fn component, :ok ->
-        dependencies =
-          Component.after_of(component) ++ Component.reference_dependencies(component)
-
-        case known_refs(dependencies, known, Component.name_of(component)) do
-          :ok -> {:cont, :ok}
-          {:error, error} -> {:halt, {:error, error}}
+        if MapSet.member?(known, name) do
+          error = Error.validation_error("duplicate component name", %{name: name})
+          {known, [issue(:duplicate_name, error, [:components, index, :name]) | issues]}
+        else
+          {MapSet.put(known, name), issues}
         end
       end)
-    end
+
+    {known, Enum.reverse(issues)}
   end
 
-  defp known_refs(names, known, owner) do
-    case Enum.find(names, &(not MapSet.member?(known, &1))) do
-      nil ->
-        :ok
+  defp unknown_dependency_issues(components, output, known) do
+    output_issues = unknown_refs(Expression.result_refs(output), known, :output, [:output])
 
-      name ->
-        {:error,
-         Error.validation_error("Flow reference points to an unknown component", %{
-           owner: owner,
-           component: name
-         })}
-    end
+    component_issues =
+      components
+      |> Enum.with_index()
+      |> Enum.flat_map(fn {component, index} ->
+        # Preserve the canonical first-error order. Codec sorts each component's
+        # missing dependencies when it presents the same issues as JSON errors.
+        names = Component.after_of(component) ++ Component.reference_dependencies(component)
+        unknown_refs(names, known, Component.name_of(component), [:components, index])
+      end)
+
+    output_issues ++ component_issues
   end
 
-  defp acyclic(components) do
-    case Graph.analyze(components) do
-      %{remaining: []} ->
-        :ok
+  defp unknown_refs(names, known, owner, location) do
+    names
+    |> Enum.uniq()
+    |> Enum.reject(&MapSet.member?(known, &1))
+    |> Enum.map(fn name ->
+      error =
+        Error.validation_error("Flow reference points to an unknown component", %{
+          owner: owner,
+          component: name
+        })
 
-      %{remaining: names} ->
-        {:error,
-         Error.validation_error("flow dependency graph contains a cycle", %{components: names})}
-    end
+      issue(:unknown_dependency, error, location)
+    end)
   end
 
-  defp validate_terminal_dispatch(components, output) do
-    case dispatch_diagnostics(components, output) do
-      [] -> :ok
-      [error | _rest] -> {:error, error}
+  defp issue(kind, error, location), do: %{kind: kind, error: error, location: location}
+
+  defp dispatch_issues(components, output) do
+    components
+    |> dispatch_errors(output)
+    |> Enum.map(&issue(:dispatch, &1, &1.details.path))
+  end
+
+  defp dispatch_errors(components, output) do
+    dispatches =
+      components
+      |> Enum.with_index()
+      |> Enum.filter(fn {component, _index} -> match?(%Dispatch{}, component) end)
+
+    case dispatches do
+      [] ->
+        []
+
+      [{%Dispatch{name: name}, index}] ->
+        dispatch_sink_errors(components, name, index) ++ dispatch_output_errors(output, name)
+
+      [_first, {%Dispatch{} = second, index} | _rest] ->
+        [
+          Error.validation_error("Flow can contain only one Dispatch component", %{
+            component: second.name,
+            components: Enum.map(dispatches, fn {%Dispatch{name: name}, _index} -> name end),
+            path: [:components, index]
+          })
+        ]
     end
   end
 
@@ -378,7 +437,7 @@ defmodule Jido.Flow.Validation do
 
       :error ->
         with {:ok, child} <- load_child_flow(module),
-             {:ok, child} <- validate_attrs(Map.from_struct(child)),
+             {:ok, child} <- validate(Map.from_struct(child)),
              :ok <- reject_dispatch_subflow(child, module),
              {:ok, subflows} <-
                validate_component_targets(child.components, [module | module_stack], subflows) do

--- a/test/jido_exec/action_process_test.exs
+++ b/test/jido_exec/action_process_test.exs
@@ -51,9 +51,13 @@ defmodule JidoActionTest.Exec.ActionProcessTest do
           Exec.run(target, input, context)
         end)
 
+      on_exit(fn -> Process.exit(caller, :kill) end)
       assert_receive {:blocking_flow_node_started, worker}, 2_000, to_string(form)
       refute worker == caller
       worker_monitor = Process.monitor(worker)
+      # Confirm the monitor before caller cleanup can terminate this worker.
+      assert {:monitored_by, monitors} = Process.info(worker, :monitored_by)
+      assert self() in monitors
 
       Process.exit(caller, :kill)
 
@@ -70,9 +74,12 @@ defmodule JidoActionTest.Exec.ActionProcessTest do
         Exec.run(BlockingAction, %{value: 1}, %{test_pid: owner}, timeout: 10_000)
       end)
 
+    on_exit(fn -> Process.exit(caller, :kill) end)
     assert_receive {:blocking_flow_node_started, worker}, 1_000
     refute worker == caller
     worker_monitor = Process.monitor(worker)
+    assert {:monitored_by, monitors} = Process.info(worker, :monitored_by)
+    assert self() in monitors
 
     Process.exit(caller, :kill)
 

--- a/test/jido_exec/execution_guard_interruption_test.exs
+++ b/test/jido_exec/execution_guard_interruption_test.exs
@@ -9,6 +9,7 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
   alias JidoActionTest.Fixtures.Execution, as: ExecFixtures
   alias JidoActionTest.Fixtures.Actions.RecorderAction
 
+  @node_start [:jido, :flow, :node, :start]
   @node_stop [:jido, :flow, :node, :stop]
 
   test "marks a mutation indeterminate when its owner exits during Action work" do
@@ -20,15 +21,16 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
       )
 
     assert {:ok, execution} = Exec.start(flow, %{}, %{test_pid: self()})
-    {caller, caller_monitor} = spawn_monitor(fn -> Exec.step(execution) end)
+    {caller, caller_monitor, helper, helper_monitor} = start_step(execution)
 
     assert_receive {:blocking_flow_node_started, worker}, 1_000
-    worker_monitor = Process.monitor(worker)
+    worker_monitor = monitor_process(worker)
     Process.exit(caller, :kill)
 
     assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :killed}, 1_000
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
-    assert_guard_indeterminate(execution)
+    assert_receive {:DOWN, ^helper_monitor, :process, ^helper, :normal}, 1_000
+    assert :atomics.get(execution.guard, 2) == 1
 
     assert {:error, %InvalidExecutionError{details: %{reason: :indeterminate}}} =
              Exec.step(execution)
@@ -43,12 +45,13 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
       :telemetry.attach(handler, @node_stop, &__MODULE__.kill_owner_after_node_stop/4, self())
 
     on_exit(fn -> :telemetry.detach(handler) end)
-    {caller, caller_monitor} = spawn_monitor(fn -> Exec.step(execution) end)
+    {caller, caller_monitor, helper, helper_monitor} = start_step(execution)
 
     assert_receive {RecorderAction, %{value: :once}}, 1_000
     assert_receive {:node_stopped_before_guard_advance, ^caller}, 1_000
     assert_receive {:DOWN, ^caller_monitor, :process, ^caller, :killed}, 1_000
-    assert_guard_indeterminate(execution)
+    assert_receive {:DOWN, ^helper_monitor, :process, ^helper, :normal}, 1_000
+    assert :atomics.get(execution.guard, 2) == 1
 
     assert {:error, %InvalidExecutionError{details: %{reason: :indeterminate}}} =
              Exec.step(execution)
@@ -88,7 +91,7 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
       end)
 
     assert_receive {:guard_claimed, ^owner, helper}, 1_000
-    helper_monitor = Process.monitor(helper)
+    helper_monitor = monitor_process(helper)
 
     {claimant, claimant_monitor} =
       spawn_monitor(fn -> send(test_pid, {:failed_claim, ExecutionGuard.claim(execution)}) end)
@@ -147,17 +150,50 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
     Process.exit(self(), :kill)
   end
 
-  defp assert_guard_indeterminate(%{guard: guard}) do
-    assert await_guard_state(guard, 10_000) == :indeterminate
+  def capture_guard_before_node_start(
+        @node_start,
+        _measurements,
+        %{execution_id: execution_id},
+        {test_pid, execution_id, token}
+      ) do
+    send(test_pid, {token, :guard_ready, self()})
+    receive do: ({^token, :resume} -> :ok)
   end
 
-  defp await_guard_state(_guard, 0), do: :not_indeterminate
+  def capture_guard_before_node_start(_event, _measurements, _metadata, _config), do: :ok
 
-  defp await_guard_state(guard, attempts) do
-    case :atomics.get(guard, 2) do
-      1 -> :indeterminate
-      _state -> await_guard_state(guard, attempts - 1)
-    end
+  defp start_step(execution) do
+    token = make_ref()
+    handler = {__MODULE__, token}
+
+    :ok =
+      :telemetry.attach(
+        handler,
+        @node_start,
+        &__MODULE__.capture_guard_before_node_start/4,
+        {self(), execution.id, token}
+      )
+
+    on_exit(fn -> :telemetry.detach(handler) end)
+    {caller, caller_monitor} = spawn_monitor(fn -> Exec.step(execution) end)
+    on_exit(fn -> Process.exit(caller, :kill) end)
+    assert_receive {^token, :guard_ready, ^caller}, 1_000
+
+    # At node start the mutation is claimed, but no Action worker exists yet.
+    # Caller death alone does not confirm that this helper handled its DOWN.
+    assert {:monitors, [{:process, helper}]} = Process.info(caller, :monitors)
+    helper_monitor = monitor_process(helper)
+    :ok = :telemetry.detach(handler)
+    send(caller, {token, :resume})
+    {caller, caller_monitor, helper, helper_monitor}
+  end
+
+  defp monitor_process(pid) do
+    monitor = Process.monitor(pid)
+    # Confirm registration before another process can stop the monitored PID.
+    assert {:monitored_by, monitors} = Process.info(pid, :monitored_by)
+    assert self() in monitors
+    monitor
   end
 
   defp recorder_flow(name) do

--- a/test/jido_flow/accumulation_test.exs
+++ b/test/jido_flow/accumulation_test.exs
@@ -92,6 +92,36 @@ defmodule Jido.Flow.AccumulationTest do
              end)
   end
 
+  test "Codec checks values after errors and preserves mixed nested error order" do
+    {document, registry} = document()
+    missing_atom = %{"$type" => "atom"}
+    bad_ref = %{"$ref" => %{"source" => "unsupported", "component" => 42, "path" => 42}}
+
+    output = [
+      [1, [], 2],
+      missing_atom,
+      [[], bad_ref, [3, 4], missing_atom],
+      %{"$type" => "map", "entries" => [%{"key" => "ok", "value" => []}]},
+      bad_ref
+    ]
+
+    assert {:error, %Error.Invalid{errors: [first | _] = errors}} =
+             Codec.diagnose(%{document | "output" => output}, registry)
+
+    assert Enum.map(errors, & &1.details.path) ==
+             [["output", 1, "id"]] ++
+               Enum.map(["source", "component", "path"], &["output", 2, 1, "$ref", &1]) ++
+               [["output", 2, 3, "id"]] ++
+               Enum.map(["source", "component", "path"], &["output", 4, "$ref", &1])
+
+    assert {:error, decoded_error} = Codec.decode(%{document | "output" => output}, registry)
+    assert decoded_error.message == first.message
+    assert decoded_error.details == first.details
+
+    valid = [[], [1, [], 2], []]
+    assert {:ok, %{output: ^valid}} = Codec.diagnose(%{document | "output" => valid}, registry)
+  end
+
   test "Codec preserves duplicate map key order and its first error" do
     {document, registry} = document()
 

--- a/test/jido_flow/accumulation_test.exs
+++ b/test/jido_flow/accumulation_test.exs
@@ -1,0 +1,113 @@
+defmodule Jido.Flow.AccumulationTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Flow
+  alias Jido.Flow.{Codec, Component, Error, Registry, Step}
+
+  defp document do
+    registry = Registry.new!(%{"action" => {:action, UnloadedAction}, "schema" => {:schema, []}})
+
+    flow =
+      Flow.new!(
+        name: "ordered",
+        components: [Step.new!(name: "one", action: UnloadedAction)],
+        output: %{}
+      )
+
+    {:ok, document} = Codec.encode(flow, registry)
+    {document, registry}
+  end
+
+  test "after names preserve normalized order and error precedence" do
+    names = ["last", :first] ++ Enum.map(1..128, &"name_#{&1}")
+    assert {:ok, normalized} = Component.after_names(names)
+    assert normalized == Enum.map(names, &to_string/1)
+
+    assert {:error, %{message: "component after contains a duplicate", details: %{name: "first"}}} =
+             Component.after_names([:first, "last", "first", "last"])
+
+    assert {:error, %{message: "component after must contain component names"}} =
+             Component.after_names([:first, "first", nil])
+
+    assert {:error, %{message: "component after must be a proper list"}} =
+             Component.after_names(["first" | :tail])
+  end
+
+  test "after validation has bounded reduction growth" do
+    # Eight times the input permits twice the linear growth. This checks BEAM
+    # work, not wall time, and catches repeated copies of the accumulated list.
+    counts =
+      for size <- [2048, 16_384] do
+        names = Enum.map(1..size, &"name_#{&1}")
+
+        Task.async(fn ->
+          :erlang.garbage_collect()
+          {:reductions, before} = Process.info(self(), :reductions)
+          assert {:ok, ^names} = Component.after_names(names)
+          {:reductions, after_count} = Process.info(self(), :reductions)
+          after_count - before
+        end)
+        |> Task.await()
+      end
+
+    [small, large] = counts
+    assert large < small * 16
+  end
+
+  test "Codec preserves broad values and ordered nested error groups" do
+    {document, registry} = document()
+    values = Enum.map(0..255, &[&1, &1 + 1])
+    assert {:ok, %{output: ^values}} = Codec.diagnose(%{document | "output" => values}, registry)
+
+    invalid =
+      Enum.map(0..127, fn _ ->
+        [
+          %{"$ref" => %{"source" => "unsupported", "component" => 42, "path" => 42}},
+          %{"$type" => "atom"}
+        ]
+      end)
+
+    assert {:error, %Error.Invalid{errors: errors}} =
+             Codec.diagnose(%{document | "output" => invalid}, registry)
+
+    assert Enum.map(errors, & &1.details.path) ==
+             Enum.flat_map(0..127, fn index ->
+               Enum.map(["source", "component", "path"], &["output", index, 0, "$ref", &1]) ++
+                 [["output", index, 1, "id"]]
+             end)
+  end
+
+  test "Codec reports duplicate occurrences in source order" do
+    {document, registry} = document()
+    [step] = document["components"]
+    names = ["first", "second", "second", "first", "first", "second"]
+    components = Enum.map(names, &%{step | "name" => &1})
+
+    assert {:error, %Error.Invalid{errors: errors}} =
+             Codec.diagnose(%{document | "components" => components}, registry)
+
+    assert Enum.map(errors, &{&1.details.name, &1.details.path}) ==
+             Enum.map(Enum.with_index(Enum.drop(names, 2), 2), fn {name, index} ->
+               {name, ["components", index, "name"]}
+             end)
+  end
+
+  test "Codec preserves duplicate map key order and its first error" do
+    {document, registry} = document()
+
+    entries =
+      Enum.map(["first", "second", "second", "first", "second"], &%{"key" => &1, "value" => 1})
+
+    invalid = %{document | "output" => %{"$type" => "map", "entries" => entries}}
+
+    assert {:error, %Error.Invalid{errors: [first | _] = errors}} =
+             Codec.diagnose(invalid, registry)
+
+    assert Enum.map(errors, & &1.details.path) ==
+             Enum.map(2..4, &["output", "entries", &1, "key"])
+
+    assert {:error, decoded_error} = Codec.decode(invalid, registry)
+    assert decoded_error.message == first.message
+    assert decoded_error.details == first.details
+  end
+end

--- a/test/jido_flow/graph_validation_test.exs
+++ b/test/jido_flow/graph_validation_test.exs
@@ -1,0 +1,424 @@
+defmodule Jido.Flow.GraphValidationTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Expr
+  alias Jido.Flow
+
+  alias Jido.Flow.{
+    Builder,
+    Choice,
+    Codec,
+    Condition,
+    Dispatch,
+    Error,
+    Iterate,
+    Ref,
+    Registry,
+    Step,
+    Subflow
+  }
+
+  alias Jido.Flow.Map, as: FlowMap
+  alias Jido.Flow.Reduce
+  alias JidoActionTest.Fixtures.NestedFlow
+
+  defmodule ProbeAction do
+    use Jido.Action, name: "graph_probe"
+    @impl true
+    def run(_params, _context), do: raise("validation must not run Action work")
+  end
+
+  defp registry do
+    Registry.new!(%{
+      "action" => {:action, ProbeAction},
+      "schema" => {:schema, []},
+      "flow" => {:flow, NestedFlow}
+    })
+  end
+
+  defp stored(components, output) do
+    %{
+      "type" => "jido.flow",
+      "version" => 1,
+      "name" => "graph",
+      "description" => nil,
+      "schema" => "schema",
+      "output_schema" => "schema",
+      "components" => components,
+      "output" => output
+    }
+  end
+
+  defp stored_step(name, after_names) do
+    %{
+      "kind" => "step",
+      "name" => name,
+      "action" => "action",
+      "after" => after_names,
+      "params" => %{"$type" => "map", "entries" => []},
+      "meta" => %{"$type" => "map", "entries" => []}
+    }
+  end
+
+  defp stored_ref(name),
+    do: %{"$ref" => %{"source" => "result", "component" => name, "path" => []}}
+
+  defp step(name, after_names), do: Step.new!(name: name, action: ProbeAction, after: after_names)
+
+  test "direct, Builder, DSL, and stored graphs agree on valid and invalid dependencies" do
+    cases = [
+      {[{"one", []}, {"two", ["one"]}], "two", :ok},
+      {[{"two", ["one"]}, {"one", []}], "two", :ok},
+      {[{"one", []}, {"two", []}], "two", :ok},
+      {[{"one", ["missing"]}], "one", :error},
+      {[{"one", []}], "missing", :error},
+      {[{"one", ["one"]}], "one", :error},
+      {[{"one", ["two"]}, {"two", ["one"]}], "one", :error},
+      {[{"one", []}, {"one", []}], "one", :error}
+    ]
+
+    for {{edges, output, expected}, index} <- Enum.with_index(cases) do
+      components = Enum.map(edges, fn {name, after_names} -> step(name, after_names) end)
+      direct = Flow.new(name: "graph", components: components, output: Ref.result(output))
+
+      built =
+        Enum.reduce(edges, Builder.new(name: "graph"), fn {name, after_names}, builder ->
+          Builder.step(builder, name, ProbeAction, %{}, after: after_names)
+        end)
+        |> Builder.output(Ref.result(output))
+        |> Builder.build()
+
+      document =
+        stored(
+          Enum.map(edges, fn {name, after_names} -> stored_step(name, after_names) end),
+          stored_ref(output)
+        )
+
+      decoded = Codec.decode(document, registry())
+      module = Module.concat(__MODULE__, "DependencyCase#{index}")
+
+      declarations =
+        Enum.map_join(edges, "\n", fn {name, after_names} ->
+          "step #{inspect(name)}, action: #{inspect(ProbeAction)}, params: %{}, after: #{inspect(after_names)}"
+        end)
+
+      source = """
+      defmodule #{inspect(module)} do
+        use Jido.Flow, name: "graph"
+        flow do
+          #{declarations}
+          output(result(#{inspect(output)}))
+        end
+      end
+      """
+
+      case expected do
+        :ok ->
+          assert {:ok, flow} = direct
+          assert {:ok, ^flow} = built
+          assert {:ok, ^flow} = decoded
+          Code.compile_string(source)
+          assert module.flow() == flow
+          assert {:ok, ^flow} = Flow.validate(flow)
+
+        :error ->
+          assert {:error, %Error.InvalidDefinitionError{}} = direct
+          assert {:error, %Error.InvalidDefinitionError{}} = built
+          assert {:error, %Error.InvalidDefinitionError{}} = decoded
+          assert_raise CompileError, fn -> Code.compile_string(source) end
+      end
+    end
+  end
+
+  test "canonical first errors and Codec aggregates retain their different dependency order" do
+    component = step("one", ["z_missing", "a_missing"])
+
+    assert {:error, error} =
+             Flow.new(name: "graph", components: [component], output: Ref.result("one"))
+
+    assert error.details == %{owner: "one", component: "z_missing"}
+
+    document = stored([stored_step("one", component.after)], stored_ref("one"))
+    assert {:error, %Error.Invalid{errors: errors}} = Codec.diagnose(document, registry())
+
+    assert Enum.map(errors, & &1.details) == [
+             %{owner: "one", component: "a_missing", path: ["components", 0]},
+             %{owner: "one", component: "z_missing", path: ["components", 0]}
+           ]
+
+    assert {:error, first} = Codec.decode(document, registry())
+    assert first.details == hd(errors).details
+  end
+
+  test "duplicates and missing references aggregate without cycle or Dispatch cascades" do
+    components = [stored_step("same", ["z_missing", "a_missing"]), stored_step("same", ["same"])]
+    output = [stored_ref("out_z"), stored_ref("out_a"), stored_ref("out_z")]
+
+    assert {:error, %Error.Invalid{errors: errors}} =
+             Codec.diagnose(stored(components, output), registry())
+
+    assert Enum.map(errors, & &1.details) == [
+             %{name: "same", path: ["components", 1, "name"]},
+             %{owner: :output, component: "out_z", path: ["output"]},
+             %{owner: :output, component: "out_a", path: ["output"]},
+             %{owner: "same", component: "a_missing", path: ["components", 0]},
+             %{owner: "same", component: "z_missing", path: ["components", 0]}
+           ]
+
+    assert {:error, error} =
+             Flow.new(
+               name: "graph",
+               components: [step("same", ["missing"]), step("same", [])],
+               output: Ref.result("missing_output")
+             )
+
+    assert error.details == %{name: "same"}
+  end
+
+  test "nil output retains canonical and stored graph error precedence" do
+    components = [step("same", []), step("same", [])]
+
+    assert {:error, %{message: "Flow output is required", details: %{path: [:output]}}} =
+             Flow.new(name: "graph", components: components, output: nil)
+
+    assert {:error, %Error.Invalid{errors: [duplicate]}} =
+             Codec.diagnose(
+               stored([stored_step("same", []), stored_step("same", [])], nil),
+               registry()
+             )
+
+    assert duplicate.message == "duplicate component name"
+
+    assert {:error, %Error.Invalid{errors: [required]}} =
+             Codec.diagnose(stored([stored_step("one", [])], nil), registry())
+
+    assert required.message == "Flow output is required"
+    assert required.details.path == ["output"]
+  end
+
+  test "all component expression fields contribute static dependencies" do
+    ref = fn name -> Ref.result(name) end
+
+    components = [
+      Step.new!(name: "step", action: ProbeAction, params: ref.("dep_step")),
+      Subflow.new!(name: "child", flow: NestedFlow, params: ref.("dep_child")),
+      Choice.new!(
+        name: "choice",
+        options: [
+          Choice.Option.new!(
+            name: "yes",
+            action: ProbeAction,
+            condition: Condition.any([true, Condition.eq(ref.("dep_condition"), 1)]),
+            params: ref.("dep_option")
+          )
+        ],
+        fallback: [action: ProbeAction, params: ref.("dep_fallback")]
+      ),
+      FlowMap.new!(
+        name: "mapped",
+        action: ProbeAction,
+        collection: ref.("dep_collection"),
+        params: [Ref.item(), ref.("dep_map_params")]
+      ),
+      Reduce.new!(
+        name: "reduced",
+        action: ProbeAction,
+        collection: ref.("dep_reduce_collection"),
+        initial: ref.("dep_reduce_initial"),
+        params: [Ref.accumulator(), ref.("dep_reduce_params")]
+      ),
+      Iterate.new!(
+        name: "iterated",
+        action: ProbeAction,
+        params: [Ref.state(), ref.("dep_iterate_params")],
+        state: [
+          schema: [],
+          initial: ref.("dep_initial"),
+          update: [Ref.body_result(), ref.("dep_update")]
+        ],
+        completion: Condition.eq(Ref.iteration_index(), ref.("dep_completion")),
+        max_iterations: 1
+      )
+    ]
+
+    dependencies = [
+      "dep_step",
+      "dep_child",
+      "dep_condition",
+      "dep_option",
+      "dep_fallback",
+      "dep_collection",
+      "dep_map_params",
+      "dep_reduce_collection",
+      "dep_reduce_initial",
+      "dep_reduce_params",
+      "dep_iterate_params",
+      "dep_initial",
+      "dep_update",
+      "dep_completion"
+    ]
+
+    producers = Enum.map(dependencies, &step(&1, []))
+    flow = Flow.new!(name: "graph", components: producers ++ components, output: %{})
+    assert {:ok, document} = Codec.encode(flow, registry())
+    document = %{document | "components" => Enum.drop(document["components"], length(producers))}
+    assert {:error, %Error.Invalid{errors: errors}} = Codec.diagnose(document, registry())
+    assert Enum.sort(Enum.map(errors, & &1.details.component)) == Enum.sort(dependencies)
+    assert Enum.all?(errors, &(&1.message == "Flow reference points to an unknown component"))
+
+    assert {:error, %{details: %{component: "dep_step"}}} =
+             Flow.validate(%{flow | components: components})
+  end
+
+  test "Dispatch checks use graph sinks and the complete result" do
+    dispatch = Dispatch.new!(name: "next", decision: ProbeAction, expander: ProbeAction)
+    flow = Flow.new!(name: "graph", components: [dispatch], output: Ref.result("next"))
+    assert {:ok, document} = Codec.encode(flow, registry())
+    [stored_dispatch] = document["components"]
+
+    invalid = %{
+      document
+      | "components" => [stored_dispatch, stored_step("independent", [])],
+        "output" => [stored_ref("next")]
+    }
+
+    assert {:error, %Error.Invalid{errors: errors}} = Codec.diagnose(invalid, registry())
+
+    assert Enum.map(errors, &{&1.message, &1.details.path}) == [
+             {"Dispatch must be the final component in the Flow", ["components", 0]},
+             {"Flow output must be the complete Dispatch result", ["output"]}
+           ]
+
+    assert {:error, %{message: "Dispatch must be the final component in the Flow"}} =
+             Flow.new(
+               name: "graph",
+               components: [dispatch, step("independent", [])],
+               output: [Ref.result("next")]
+             )
+
+    assert {:error, %Error.Invalid{errors: [multiple]}} =
+             Codec.diagnose(
+               %{
+                 document
+                 | "components" => [stored_dispatch, %{stored_dispatch | "name" => "second"}]
+               },
+               registry()
+             )
+
+    assert multiple.details.path == ["components", 1]
+
+    assert {:error, %{message: "Dispatch must be the final component in the Flow"}} =
+             Builder.new(name: "graph")
+             |> Builder.dispatch("next", ProbeAction, ProbeAction, %{})
+             |> Builder.step("independent", ProbeAction, %{})
+             |> Builder.output([Ref.result("next")])
+             |> Builder.build()
+
+    source = """
+    defmodule Jido.Flow.GraphValidationTest.NonterminalDispatch do
+      use Jido.Flow, name: "graph"
+      flow do
+        dispatch "next", decision: #{inspect(ProbeAction)}, expander: #{inspect(ProbeAction)}, params: %{}
+        step "independent", action: #{inspect(ProbeAction)}, params: %{}
+        output([result("next")])
+      end
+    end
+    """
+
+    error =
+      assert_raise CompileError, ~r/Dispatch must be the final component/, fn ->
+        Code.compile_string(source, "nonterminal_dispatch.ex")
+      end
+
+    assert error.file == "nonterminal_dispatch.ex"
+    assert error.line == 4
+  end
+
+  test "Dispatch parameter references precede terminal graph rules" do
+    dispatch =
+      Dispatch.new!(
+        name: "next",
+        decision: ProbeAction,
+        expander: ProbeAction,
+        params: Expr.new!(:all, [false, Ref.result("missing")])
+      )
+
+    assert {:error, error} = Flow.new(name: "graph", components: [dispatch], output: %{})
+    assert error.details == %{owner: "next", component: "missing"}
+
+    flow =
+      Flow.new!(
+        name: "graph",
+        components: [step("missing", []), dispatch],
+        output: Ref.result("next")
+      )
+
+    assert {:ok, document} = Codec.encode(flow, registry())
+
+    assert {:error, %Error.Invalid{errors: [error]}} =
+             Codec.diagnose(%{document | "components" => tl(document["components"])}, registry())
+
+    assert error.details == %{owner: "next", component: "missing", path: ["components", 0]}
+  end
+
+  test "missing references and cycles identify their source declaration" do
+    cases = [
+      {"missing_component",
+       ~s|step "one", action: #{inspect(ProbeAction)}, params: %{}, after: ["absent"]|,
+       ~s|output(result("one"))|, 4},
+      {"missing_output", ~s|step "one", action: #{inspect(ProbeAction)}, params: %{}|,
+       ~s|output(result("absent"))|, 5},
+      {"self_cycle", ~s|step "one", action: #{inspect(ProbeAction)}, params: %{}, after: ["one"]|,
+       ~s|output(result("one"))|, 4}
+    ]
+
+    for {name, declaration, output, line} <- cases do
+      module = Module.concat(__MODULE__, name)
+
+      source =
+        "defmodule #{inspect(module)} do\nuse Jido.Flow, name: #{inspect(name)}\nflow do\n#{declaration}\n#{output}\nend\nend"
+
+      file = name <> ".ex"
+      error = assert_raise CompileError, fn -> Code.compile_string(source, file) end
+      assert error.file == file
+      assert error.line == line
+    end
+  end
+
+  test "a duplicate across component kinds points to the second occurrence" do
+    source = """
+    defmodule Jido.Flow.GraphValidationTest.CrossKindDuplicate do
+      use Jido.Flow, name: "cross_kind_duplicate"
+      flow do
+        step "same", action: #{inspect(ProbeAction)}, params: %{}
+        map "same", collection: [], action: #{inspect(ProbeAction)}, params: %{}
+        reduce "same", collection: [], initial: %{}, action: #{inspect(ProbeAction)}, params: %{}
+        output(result("same"))
+      end
+    end
+    """
+
+    error =
+      assert_raise CompileError, ~r/duplicate component name/, fn ->
+        Code.compile_string(source, "cross_kind_duplicate.ex")
+      end
+
+    assert error.file == "cross_kind_duplicate.ex"
+    assert error.line == 5
+  end
+
+  test "unloaded targets remain valid for inert construction and decoding" do
+    component = Step.new!(name: "one", action: NotLoadedAction, params: Expr.new!(:add, [1, 2]))
+
+    assert {:ok, flow} =
+             Flow.new(name: "graph", components: [component], output: Ref.result("one"))
+
+    assert {:ok, ^flow} = Flow.validate(flow)
+
+    registry =
+      Registry.new!(%{"unloaded" => {:action, NotLoadedAction}, "schema" => {:schema, []}})
+
+    assert {:ok, document} = Codec.encode(flow, registry)
+    assert {:ok, ^flow} = Codec.diagnose(document, registry)
+  end
+end

--- a/test/jido_flow/graph_validation_test.exs
+++ b/test/jido_flow/graph_validation_test.exs
@@ -407,6 +407,46 @@ defmodule Jido.Flow.GraphValidationTest do
     assert error.line == 5
   end
 
+  test "cycle errors retain blocked nodes and point to the first authored blocked component" do
+    edges = [{"blocked", ["one"]}, {"one", ["two"]}, {"two", ["one"]}]
+    components = Enum.map(edges, fn {name, dependencies} -> step(name, dependencies) end)
+
+    assert {:error, canonical} =
+             Flow.new(
+               name: "blocked_cycle",
+               components: components,
+               output: Ref.result("blocked")
+             )
+
+    assert canonical.message == "flow dependency graph contains a cycle"
+    assert Enum.sort(canonical.details.components) == ["blocked", "one", "two"]
+
+    document =
+      stored(
+        Enum.map(edges, fn {name, dependencies} -> stored_step(name, dependencies) end),
+        stored_ref("blocked")
+      )
+
+    assert {:error, %Error.Invalid{errors: [stored_error]}} = Codec.diagnose(document, registry())
+    assert stored_error.details == Map.put(canonical.details, :path, ["components"])
+
+    source = """
+    defmodule Jido.Flow.GraphValidationTest.BlockedCycle do
+      use Jido.Flow, name: "blocked_cycle"
+      flow do
+        step "blocked", action: #{inspect(ProbeAction)}, params: %{}, after: ["one"]
+        step "one", action: #{inspect(ProbeAction)}, params: %{}, after: ["two"]
+        step "two", action: #{inspect(ProbeAction)}, params: %{}, after: ["one"]
+        output(result("blocked"))
+      end
+    end
+    """
+
+    error = assert_raise CompileError, fn -> Code.compile_string(source, "blocked_cycle.ex") end
+    assert error.file == "blocked_cycle.ex"
+    assert error.line == 4
+  end
+
   test "unloaded targets remain valid for inert construction and decoding" do
     component = Step.new!(name: "one", action: NotLoadedAction, params: Expr.new!(:add, [1, 2]))
 


### PR DESCRIPTION
Use one internal graph validator for Flow construction and Codec. Keep construction's first error, Codec's ordered errors and JSON paths, and the source location of DSL errors.

List collectors prepend and reverse instead of repeatedly appending. After an error, the decoder releases successful values that it cannot return and continues all validation checks. Empty nested error groups preserve valid data.

Tests cover error order, duplicate names, missing references, cycles, storage limits, and collector retention. The guides contain only the current diagnostic rules.

Validation: docs checks and PR CI passed. The combined enhancement suite passed with 94.88% coverage, `mix quality`, and the dependency audit. Bounded probes confirm near-proportional list growth; they do not establish a general speedup.

Closes #241.
