### PR TITLE
refactor(exec)!: require handles for async cancellation

### DIFF
--- a/guides/execution.md
+++ b/guides/execution.md
@@ -80,7 +80,7 @@ change it. The stable map omits the exception's top-level stacktrace.
 For example, an error from a public cancellation call can be encoded directly:
 
 ```elixir
-{:error, error} = Jido.Exec.cancel(self())
+{:error, error} = Jido.Exec.cancel(:invalid)
 json = JSON.encode!(error)
 %{"type" => "async_invalid_handle"} = JSON.decode!(json)
 ```
@@ -122,8 +122,8 @@ active execution and returns `Jido.Exec.Error.AsyncTimeoutError`.
 
 The `timeout:` option on `run_async/4` is different. It limits the complete
 target execution and returns the normal Action or Flow timeout error.
-`cancel/1` stops active work and closes its telemetry spans. It cannot undo
-side effects that already completed.
+`cancel/1` requires the complete handle. It stops active work and closes its
+telemetry spans. It cannot undo side effects that already completed.
 
 Invalid handles and owner violations return
 `Jido.Exec.Error.InvalidHandleError`. An unexpected failure of the managed

--- a/lib/jido_exec.ex
+++ b/lib/jido_exec.ex
@@ -338,12 +338,14 @@ defmodule Jido.Exec do
   @doc """
   Cancels a caller-owned asynchronous execution.
 
+  Pass the complete handle returned by `run_async/4`.
+
   Cancellation stops active Action and Flow work. It does not undo side
   effects that already completed and it does not return a partial Flow
   execution value.
   """
-  @spec cancel(async_ref() | pid()) :: :ok | {:error, Exception.t()}
-  def cancel(async_ref_or_pid), do: Async.cancel(async_ref_or_pid)
+  @spec cancel(async_ref()) :: :ok | {:error, Exception.t()}
+  def cancel(async_ref), do: Async.cancel(async_ref)
 
   @doc """
   Starts a paused Flow execution.

--- a/lib/jido_exec/async.ex
+++ b/lib/jido_exec/async.ex
@@ -8,10 +8,6 @@ defmodule Jido.Exec.Async do
   @default_await_timeout 5_000
   @stop_wait_ms 1_000
   @max_receive_timeout 2_147_483_647
-  @owner_key {__MODULE__, :owner}
-  @ref_key {__MODULE__, :ref}
-  @state_key {__MODULE__, :state}
-  @handle_key {__MODULE__, :handle}
   @active 0
   @claimed 1
   @terminal 2
@@ -38,9 +34,6 @@ defmodule Jido.Exec.Async do
     logger_metadata = Logger.metadata()
 
     work = fn ->
-      Process.put(@owner_key, owner)
-      Process.put(@ref_key, ref)
-      Process.put(@state_key, state)
       Process.group_leader(self(), group_leader)
       Logger.metadata(logger_metadata)
 
@@ -51,16 +44,13 @@ defmodule Jido.Exec.Async do
 
     case Runtime.start_child(task_supervisor, work) do
       {:ok, pid} ->
-        handle = %{
+        %{
           ref: ref,
           pid: pid,
           owner: owner,
           monitor_ref: Process.monitor(pid),
           state: state
         }
-
-        register_handle(handle)
-        handle
 
       {:error, reason} ->
         raise Error.execution_error("Asynchronous execution process could not start", %{
@@ -99,7 +89,7 @@ defmodule Jido.Exec.Async do
   end
 
   @doc false
-  @spec cancel(async_ref() | pid()) :: :ok | {:error, Exception.t()}
+  @spec cancel(async_ref()) :: :ok | {:error, Exception.t()}
   def cancel(%{} = async_ref) do
     with :ok <- validate_handle(async_ref),
          :ok <- validate_owner(async_ref, :cancel) do
@@ -107,16 +97,6 @@ defmodule Jido.Exec.Async do
         :ok -> cancel_valid(async_ref)
         :consumed -> cleanup(async_ref)
       end
-    end
-  end
-
-  def cancel(pid) when is_pid(pid) do
-    case registered_handle(pid) do
-      %{owner: owner} = async_ref when owner == self() ->
-        cancel(async_ref)
-
-      _other ->
-        cancel_unregistered_pid(pid)
     end
   end
 
@@ -343,14 +323,10 @@ defmodule Jido.Exec.Async do
     cleanup(async_ref, result)
   end
 
-  defp cleanup(
-         %{ref: ref, pid: pid, monitor_ref: monitor_ref} = async_ref,
-         result \\ :ok
-       ) do
+  defp cleanup(%{ref: ref, pid: pid, monitor_ref: monitor_ref}, result \\ :ok) do
     Process.demonitor(monitor_ref, [:flush])
     flush_results(ref, pid)
     flush_down(monitor_ref, pid)
-    unregister_handle(async_ref)
     result
   end
 
@@ -408,9 +384,7 @@ defmodule Jido.Exec.Async do
      })}
   end
 
-  defp validate_owner(%{owner: owner}, operation), do: validate_owner_pid(owner, operation)
-
-  defp validate_owner_pid(owner, operation) do
+  defp validate_owner(%{owner: owner}, operation) do
     caller = self()
 
     if caller == owner do
@@ -456,65 +430,6 @@ defmodule Jido.Exec.Async do
       pid: async_ref.pid,
       ref: async_ref.ref
     })
-  end
-
-  defp register_handle(%{pid: pid} = async_ref) do
-    Process.put({@handle_key, pid}, async_ref)
-    :ok
-  end
-
-  defp registered_handle(pid), do: Process.get({@handle_key, pid})
-
-  defp unregister_handle(%{pid: pid, state: state}) do
-    case registered_handle(pid) do
-      %{state: ^state} -> Process.delete({@handle_key, pid})
-      _other -> nil
-    end
-
-    :ok
-  end
-
-  defp cancel_unregistered_pid(pid) do
-    if Process.alive?(pid) do
-      with {:ok, owner, ref, state} <- pid_identity(pid),
-           :ok <- validate_owner_pid(owner, :cancel) do
-        cancel(%{
-          ref: ref,
-          pid: pid,
-          owner: owner,
-          monitor_ref: Process.monitor(pid),
-          state: state
-        })
-      end
-    else
-      :ok
-    end
-  end
-
-  defp pid_identity(pid) do
-    case Process.info(pid, :dictionary) do
-      {:dictionary, dictionary} ->
-        with {@owner_key, owner} when is_pid(owner) <- List.keyfind(dictionary, @owner_key, 0),
-             {@ref_key, ref} when is_reference(ref) <- List.keyfind(dictionary, @ref_key, 0),
-             {@state_key, raw_state} <- List.keyfind(dictionary, @state_key, 0),
-             {:ok, state} <- state_from_term(raw_state) do
-          {:ok, owner, ref, state}
-        else
-          _value ->
-            {:error,
-             Error.invalid_handle_error("PID does not identify an asynchronous execution", %{
-               operation: :cancel,
-               pid: pid
-             })}
-        end
-
-      _other ->
-        {:error,
-         Error.invalid_handle_error("PID does not identify an asynchronous execution", %{
-           operation: :cancel,
-           pid: pid
-         })}
-    end
   end
 
   defp task_supervisor!(opts) when is_list(opts) do

--- a/lib/jido_exec/async.ex
+++ b/lib/jido_exec/async.ex
@@ -358,24 +358,17 @@ defmodule Jido.Exec.Async do
 
   defp validate_handle(value), do: invalid_handle(value)
 
-  defp validate_state(state) do
-    case state_from_term(state) do
-      {:ok, _state} -> :ok
-      :error -> invalid_handle(state)
-    end
-  end
-
-  defp state_from_term({:jido_exec_async_state, token} = state) do
+  defp validate_state({:jido_exec_async_state, token} = state) do
     if :atomics.get(token, 1) in [@active, @claimed, @terminal] do
-      {:ok, state}
+      :ok
     else
-      :error
+      invalid_handle(state)
     end
   rescue
-    ArgumentError -> :error
+    ArgumentError -> invalid_handle(state)
   end
 
-  defp state_from_term(_state), do: :error
+  defp validate_state(state), do: invalid_handle(state)
 
   defp invalid_handle(value) do
     {:error,

--- a/test/fixtures/inline_consumer/mix.exs
+++ b/test/fixtures/inline_consumer/mix.exs
@@ -5,6 +5,8 @@ defmodule InlineConsumer.MixProject do
     [
       app: :inline_consumer,
       version: "0.1.0",
+      # Rapid rebuilds can share a directory timestamp. Compare module names.
+      reliable_dir_mtime: false,
       deps: [],
       releases: [inline_consumer: [include_erts: false]]
     ]

--- a/test/jido_exec/async_error_test.exs
+++ b/test/jido_exec/async_error_test.exs
@@ -5,15 +5,15 @@ defmodule JidoActionTest.Exec.AsyncErrorTest do
   alias JidoActionTest.Fixtures.Actions.Add
   alias JidoActionTest.Fixtures.Execution.BlockingAction
 
-  test "encodes the PID error returned by cancel" do
+  test "encodes a PID rejected as an invalid cancellation handle" do
     assert {:error, %Error.InvalidHandleError{} = error} = Jido.Exec.cancel(self())
 
     decoded = error |> JSON.encode!() |> JSON.decode!()
 
     assert decoded["type"] == "async_invalid_handle"
     assert decoded["message"] == error.message
-    assert decoded["details"]["pid"] == inspect(self())
-    assert error.details.pid == self()
+    assert decoded["details"]["value"] == inspect(self())
+    assert error.details == %{operation: :cancel, value: self()}
   end
 
   test "encodes nested invalid values from each public handle operation" do

--- a/test/jido_exec/async_execution_test.exs
+++ b/test/jido_exec/async_execution_test.exs
@@ -163,12 +163,10 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
       spawn(fn ->
         send(test_pid, {:non_owner_await, Exec.await(handle, 10)})
         send(test_pid, {:non_owner_cancel, Exec.cancel(handle)})
-        send(test_pid, {:non_owner_pid_cancel, Exec.cancel(handle.pid)})
       end)
 
     assert_receive {:non_owner_await, {:error, %Error.InvalidHandleError{}}}, 1_000
     assert_receive {:non_owner_cancel, {:error, %Error.InvalidHandleError{}}}, 1_000
-    assert_receive {:non_owner_pid_cancel, {:error, %Error.InvalidHandleError{}}}, 1_000
     refute non_owner == handle.owner
     assert Process.alive?(worker)
     assert :ok = Exec.cancel(handle)
@@ -219,7 +217,7 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
     assert :ok = Exec.cancel(handle)
   end
 
-  test "validates handles, timeouts, and direct PID cancellation" do
+  test "validates handles and timeouts" do
     assert {:error, %Error.InvalidHandleError{}} = Exec.await(%{}, 10)
     assert {:error, %Error.InvalidHandleError{}} = Exec.cancel(:invalid)
 
@@ -227,8 +225,38 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
     assert_receive {:blocking_flow_node_started, worker}, 1_000
     assert {:error, %Error.InvalidHandleError{}} = Exec.await(handle, :soon)
     worker_monitor = Process.monitor(worker)
-    assert :ok = Exec.cancel(handle.pid)
+    assert :ok = Exec.cancel(handle)
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, 1_000
+  end
+
+  test "rejects a live PID without stopping the execution" do
+    handle = Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
+
+    try do
+      assert_receive {:blocking_flow_node_started, worker}, 1_000
+      assert {:error, %Error.InvalidHandleError{} = error} = Exec.cancel(handle.pid)
+      assert error.message == "Invalid asynchronous execution handle"
+      assert error.details == %{operation: :cancel, value: handle.pid}
+
+      send(worker, :finish)
+      assert {:ok, %{value: 1}} = Exec.await(handle, 1_000)
+    after
+      Exec.cancel(handle)
+    end
+  end
+
+  test "rejects a dead PID without consuming its handle" do
+    %{pid: pid, monitor_ref: monitor_ref} = handle = Exec.run_async(Add, %{value: 1})
+
+    try do
+      assert_receive {:DOWN, ^monitor_ref, :process, ^pid, _reason}, 1_000
+      assert {:error, %Error.InvalidHandleError{} = error} = Exec.cancel(pid)
+      assert error.message == "Invalid asynchronous execution handle"
+      assert error.details == %{operation: :cancel, value: pid}
+      assert {:ok, %{value: 2}} = Exec.await(handle, 1_000)
+    after
+      Exec.cancel(handle)
+    end
   end
 
   test "reports a handle whose process is no longer running" do

--- a/test/jido_exec/async_execution_test.exs
+++ b/test/jido_exec/async_execution_test.exs
@@ -254,6 +254,7 @@ defmodule JidoActionTest.Exec.AsyncExecutionTest do
       assert error.message == "Invalid asynchronous execution handle"
       assert error.details == %{operation: :cancel, value: pid}
       assert {:ok, %{value: 2}} = Exec.await(handle, 1_000)
+      assert :ok = Exec.cancel(handle)
     after
       Exec.cancel(handle)
     end

--- a/test/jido_exec/async_mailbox_hygiene_test.exs
+++ b/test/jido_exec/async_mailbox_hygiene_test.exs
@@ -26,13 +26,6 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
     refute_handle_messages(handle)
   end
 
-  test "cancel removes result and monitor messages" do
-    handle = Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
-    assert_receive {:blocking_flow_node_started, _worker}, 1_000
-    assert :ok = Exec.cancel(handle)
-    refute_handle_messages(handle)
-  end
-
   test "await accepts a queued result after a matching normal DOWN" do
     with_released_action(2, fn handle ->
       result_message = receive_result_message(handle)
@@ -135,12 +128,12 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
     end)
   end
 
-  test "cancel by PID claims the shared handle and leaves no mailbox residue" do
+  test "cancel consumes the handle and repeated cancellation leaves no mailbox residue" do
     handle = Exec.run_async(BlockingAction, %{value: 1}, %{test_pid: self()})
     assert_receive {:blocking_flow_node_started, worker}, 1_000
     worker_monitor = monitor_worker(worker)
 
-    assert :ok = Exec.cancel(handle.pid)
+    assert :ok = Exec.cancel(handle)
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
 
     assert {:error, %Error.InvalidHandleError{details: %{operation: :await}}} =

--- a/test/jido_exec/async_mailbox_hygiene_test.exs
+++ b/test/jido_exec/async_mailbox_hygiene_test.exs
@@ -135,6 +135,7 @@ defmodule JidoActionTest.Exec.AsyncMailboxHygieneTest do
 
     assert :ok = Exec.cancel(handle)
     assert_receive {:DOWN, ^worker_monitor, :process, ^worker, :killed}, 1_000
+    refute_handle_messages(handle)
 
     assert {:error, %Error.InvalidHandleError{details: %{operation: :await}}} =
              Exec.await(handle, 0)


### PR DESCRIPTION
## Description

Require the handle from `Jido.Exec.run_async/4` for cancellation. Remove PID lookup, handle reconstruction, and process-dictionary registration. This removes 65 net lines and preserves handle ownership, repeated cancellation, result handling, and cleanup. AgentServer already passes the handle. State validation now returns its result directly. Existing tests check cleanup after the first cancellation and cancellation after a successful await.

## Type of Change

- [x] Breaking change

## Breaking Changes

`cancel(pid)` returns the generic `InvalidHandleError`, whether the PID is live or dead. Its details contain `operation: :cancel` and `value: pid`. Pass the complete async handle to cancel work.

## Testing

- [x] Focused tests: 40 passed before the change; the three regression checks failed for the expected reasons; all 41 final tests passed.
- [x] Full suite: 882 passed, 94.86% coverage, warnings treated as errors. Includes existing Mix release tests. All 882 tests also pass on Elixir 1.18.5 / OTP 27, with 94.81% coverage.
- [x] `mix quality`: format, compile, Doctor, docs, Credo, and Dialyzer passed.
- [x] `mix deps.audit`: no vulnerabilities found.
- [x] [Final CI passed](https://github.com/agentjido/jido_action/actions/runs/33988391103) on commit `36fb593`: all quality checks and OTP/Elixir 27/1.18, 28/1.18, 28/1.19, and 29/1.20.
- [x] Benchmark smoke: all 38 cases passed before and after, with matching runtime, settings, methods, and tool hash. Both source trees were clean.

For both async smoke cases:

| Measurement | Before | After |
| --- | ---: | ---: |
| Owned helper starts | 8 | 8 |
| Helpers remaining | 0 | 0 |
| Observed peak process memory, bytes | 27,232 | 26,000 |

All 38 cases left zero owned helpers. These smoke runs use two timing samples and one resource sample per case. The measurements do not establish a speed change or an exact memory peak.

## Checklist

- [x] Followed project style and conventional commit rules.
- [x] Updated existing API documentation.
- [x] Added public behavior tests for live and dead PID rejection; removed a duplicate cleanup test.
- [x] All local tests and quality checks pass.
- [x] The build-test consumer uses `reliable_dir_mtime: false` so rapid rebuilds compare module names. A controlled same-timestamp reproduction failed before this setting and passed after it.
- [x] Left the generated changelog unchanged.

## Related Issues

Closes #236.
