### PR TITLE
perf: reduce execution and validation allocations

### DIFF
--- a/bench/release.exs
+++ b/bench/release.exs
@@ -1,0 +1,66 @@
+# Reuse the isolated consumer and its bounded OS-process runner.
+if Mix.env() != :test, do: raise("run this probe with MIX_ENV=test")
+alias JidoActionTest.InlineBuild, as: Build
+[output] = System.argv()
+File.mkdir_p!(output)
+
+temporary =
+  Path.join(System.tmp_dir!(), "jido-bench-release-#{System.unique_integer([:positive])}")
+
+File.mkdir_p!(temporary)
+previous_target = System.get_env("BENCH_RELEASE_TARGET")
+
+try do
+  fixture = Build.setup(%{tmp_dir: temporary})
+
+  File.cp!(
+    Path.join(__DIR__, "support/release_fixture.exs"),
+    Path.join(fixture.app, "lib/benchmark.ex")
+  )
+
+  File.cp!(
+    Path.join(__DIR__, "support/release_probe.exs"),
+    Path.join(fixture.scripts, "probe.exs")
+  )
+
+  {log, status} = Build.mix(fixture, ["release"])
+  if status != 0, do: raise(log)
+  release = Path.join(fixture.build, "rel/inline_consumer")
+  bytes = fn paths -> Enum.sum(Enum.map(paths, &File.stat!(&1).size)) end
+  files = Path.wildcard(Path.join(release, "**/*")) |> Enum.filter(&File.regular?/1)
+
+  generated =
+    Path.wildcard(Path.join(release, "lib/*/ebin/Elixir.Jido.Action.Generated.Inline.*.beam"))
+
+  File.rm_rf!(fixture.app)
+  File.mkdir_p!(fixture.app)
+
+  samples =
+    for target <- ["inline", "explicit"], run <- 1..3 do
+      System.put_env("BENCH_RELEASE_TARGET", target)
+      %{run: run, result: Build.release_probe(fixture)}
+    end
+
+  {head, 0} = System.cmd("git", ["rev-parse", "HEAD"])
+
+  report = %{
+    commit: String.trim(head),
+    elixir: System.version(),
+    otp: List.to_string(:erlang.system_info(:otp_release)),
+    release_bytes: bytes.(files),
+    generated_module_count: length(generated),
+    generated_beam_bytes: bytes.(generated),
+    samples: samples,
+    limits:
+      "Same release, fresh VM per sample; two-step inline and explicit flows. ERTS excluded. Boot memory is after application startup, before target use. First-call time excludes VM boot. Source removed before execution."
+  }
+
+  File.write!(Path.join(output, "release.json"), JSON.encode!(report))
+  IO.puts("Wrote #{output}/release.json")
+after
+  File.rm_rf!(temporary)
+
+  if previous_target,
+    do: System.put_env("BENCH_RELEASE_TARGET", previous_target),
+    else: System.delete_env("BENCH_RELEASE_TARGET")
+end

--- a/bench/run.exs
+++ b/bench/run.exs
@@ -1,17 +1,17 @@
 Code.require_file("support/suite.exs", __DIR__)
 
 {opts, args, invalid} =
-  OptionParser.parse(System.argv(), strict: [profile: :string, output: :string])
+  OptionParser.parse(System.argv(), strict: [profile: :string, output: :string, filter: :string])
 
 if args != [] or invalid != [],
   do:
     raise(
       ArgumentError,
-      "usage: mix run bench/run.exs --profile short|scale|smoke --output DIRECTORY"
+      "usage: mix run bench/run.exs --profile short|scale|smoke|backlog --filter CASE_SUBSTRING --output DIRECTORY"
     )
 
 profile = Keyword.get(opts, :profile, "short")
 output = Keyword.get(opts, :output, "bench/results/#{profile}")
-report = JidoActionBench.Suite.run(profile)
+report = JidoActionBench.Suite.run(profile, Keyword.get(opts, :filter))
 JidoActionBench.Suite.write!(report, output)
 IO.puts("Wrote #{output}/report.json and report.md")

--- a/bench/support/boundary_cases.exs
+++ b/bench/support/boundary_cases.exs
@@ -1,0 +1,237 @@
+defmodule JidoActionBench.Record do
+  @moduledoc false
+  defstruct [:value]
+end
+
+defmodule JidoActionBench.BoundaryCases do
+  @moduledoc false
+  alias Jido.{Exec, Expr, Flow}
+  alias Jido.Flow.{Codec, Expression, Identity, Ref, Step}
+  alias JidoActionBench.{ComponentCases, Echo, Fixtures, Record, SmallResult}
+
+  def workloads do
+    expression_cases() ++
+      schema_cases() ++ codec_cases() ++ retention_cases() ++ [identity_case()]
+  end
+
+  defp expression_cases do
+    data = %{
+      list: Enum.to_list(1..2_000),
+      map: Map.new(1..1_000, &{&1, &1}),
+      nested: List.duplicate(%{a: [1, 2, 3], b: %{c: 7}}, 200)
+    }
+
+    walks =
+      for {shape, value} <- data do
+        [
+          simple("expr/validate/#{shape}", fn -> Expr.validate(value) end, :ok),
+          simple(
+            "expr/equal/#{shape}",
+            fn ->
+              Expr.evaluate(Expr.new!(:eq, [Ref.input(:value), Ref.input(:value)]),
+                resolve: fn _ -> {:ok, value} end,
+                max_nodes: 100_000
+              )
+            end,
+            {:ok, true}
+          ),
+          simple(
+            "expression/validate/#{shape}",
+            fn -> Expression.validate(%{value: value}) end,
+            :ok
+          ),
+          simple(
+            "expression/normalize/#{shape}",
+            fn -> Expression.normalize(%{value: value}) end,
+            {:ok, %{value: value}}
+          )
+        ]
+      end
+      |> List.flatten()
+
+    membership =
+      for match <- [:first, :last, :miss] do
+        operand = %{values: Enum.to_list(1..32)}
+        other = %{values: Enum.to_list(2..33)}
+        candidates = List.duplicate(other, 31)
+
+        candidates =
+          case match do
+            :first -> [operand | candidates]
+            :last -> candidates ++ [operand]
+            :miss -> [other | candidates]
+          end
+
+        expression = Expr.new!(:in, [operand, candidates])
+        simple("expr/member/#{match}", fn -> Expr.evaluate(expression) end, {:ok, match != :miss})
+      end
+
+    invalid = %{items: [1, %{value: [2, fn -> :invalid end]}]}
+    expected_error = validation_error(Expression.validate(invalid))
+
+    walks ++
+      membership ++
+      [
+        simple(
+          "expression/invalid/nested",
+          fn -> validation_error(Expression.validate(invalid)) end,
+          expected_error
+        )
+      ]
+  end
+
+  defp validation_error({:error, %{__struct__: type, message: message, details: details}}),
+    do: %{type: type, message: message, details: details}
+
+  defp schema_cases do
+    for kind <- [:object, :struct], coerce <- [false, true], count <- [0, 200] do
+      schema =
+        if kind == :object,
+          do: Zoi.object(%{value: Zoi.integer()}, coerce: coerce),
+          else: Zoi.struct(Record, %{value: Zoi.integer()}, coerce: coerce)
+
+      extra =
+        Map.new(
+          for index <- List.duplicate(:unused, count) |> Enum.with_index(),
+              do: {"unused#{elem(index, 1)}", elem(index, 1)}
+        )
+
+      input =
+        if kind == :struct and not coerce,
+          do: Map.merge(%Record{value: 7}, extra),
+          else: Map.put(extra, :value, 7)
+
+      expected = {:ok, Map.put(extra, :value, 7)}
+
+      simple(
+        "schema/#{kind}/#{coerce}/#{count}",
+        fn -> Jido.Action.Validation.open_validate(schema, input, %{}) end,
+        expected
+      )
+    end
+  end
+
+  defp codec_cases do
+    for count <- [16, 2_000] do
+      params = %{"values" => Map.new(1..count, &{"k#{&1}", &1})}
+
+      flow =
+        Flow.new!(
+          name: "codec_benchmark",
+          components: [Step.new!(name: "echo", action: Echo, params: params)],
+          output: Ref.result("echo")
+        )
+
+      {:ok, document, registry} = Codec.encode(flow)
+
+      [
+        simple(
+          "codec/registry/#{count}",
+          fn -> Flow.Registry.from_flow(flow) end,
+          {:ok, registry}
+        ),
+        simple(
+          "codec/encode_explicit/#{count}",
+          fn -> Codec.encode(flow, registry) end,
+          {:ok, document}
+        ),
+        simple(
+          "codec/encode_convenience/#{count}",
+          fn -> Codec.encode(flow) end,
+          {:ok, document, registry}
+        ),
+        simple("codec/decode/#{count}", fn -> Codec.decode(document, registry) end, {:ok, flow})
+      ]
+    end
+    |> List.flatten()
+  end
+
+  defp retention_cases do
+    leaf = Enum.to_list(1..500)
+    parent = :binary.copy(<<42>>, 1_048_576)
+
+    data = [
+      {:small, 42},
+      {:list, Enum.to_list(1..5_000)},
+      {:shared, List.duplicate(leaf, 16)},
+      {:binary, parent},
+      {:slice, binary_part(parent, 100, 512)}
+    ]
+
+    flow =
+      Flow.new!(
+        name: "context_retention",
+        components: [
+          Step.new!(
+            name: "small",
+            action: SmallResult,
+            params: %{value: Ref.input(:value), fail: false}
+          )
+        ],
+        output: Ref.result("small")
+      )
+
+    for {kind, payload} <- data, location <- [:input, :context] do
+      %{
+        id: "payload/#{location}/#{kind}",
+        setup: fn context ->
+          context = if location == :context, do: Map.put(context, :unused, payload), else: context
+          input = %{value: if(location == :input, do: payload, else: 42)}
+
+          {:ok, execution} =
+            Exec.start(flow, input, context, task_supervisor: JidoActionBench.TaskSupervisor)
+
+          Fixtures.barrier(context)
+          execution
+        end,
+        run: &Exec.continue/1,
+        check: fn {:ok, finished} ->
+          ComponentCases.expect!(Exec.result(finished), {:ok, %{value: 42}})
+        end,
+        retained: fn paused, {:ok, finished} ->
+          %{paused_execution: paused, finished_execution: finished}
+        end
+      }
+    end
+  end
+
+  defp identity_case do
+    digest = :crypto.hash(:sha256, "benchmark") |> Base.encode16(case: :lower)
+    # The independent formatter fixes the expected UUID bytes across candidates.
+    expected =
+      for index <- 0..255 do
+        <<a::32, b::16, c::16, d::16, e::48, _::binary>> =
+          :crypto.hash(
+            :sha256,
+            :erlang.term_to_binary({:jido_flow_item_identity, 1, digest, "node", index}, [
+              :deterministic
+            ])
+          )
+
+        :io_lib.format(~c"~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b", [
+          a,
+          b,
+          Bitwise.bor(Bitwise.band(c, 0x0FFF), 0x8000),
+          Bitwise.bor(Bitwise.band(d, 0x3FFF), 0x8000),
+          e
+        ])
+        |> IO.iodata_to_binary()
+      end
+
+    simple(
+      "identity/items/256",
+      fn -> Enum.map(0..255, &Identity.item_uuid(digest, "node", &1)) end,
+      expected
+    )
+  end
+
+  def simple(id, run, expected) do
+    %{
+      id: id,
+      setup: fn _ -> nil end,
+      run: fn _ -> run.() end,
+      check: &ComponentCases.expect!(&1, expected),
+      retained: fn _, result -> %{result: result} end
+    }
+  end
+end

--- a/bench/support/component_cases.exs
+++ b/bench/support/component_cases.exs
@@ -1,0 +1,346 @@
+defmodule JidoActionBench.Accumulate do
+  @moduledoc false
+  use Jido.Action, name: "benchmark_accumulate"
+
+  @impl true
+  def run(%{value: value, amount: amount}, context) do
+    JidoActionBench.Fixtures.barrier(context)
+    {:ok, %{value: value + amount}}
+  end
+end
+
+defmodule JidoActionBench.Continue do
+  @moduledoc false
+  use Jido.Action, name: "benchmark_continue"
+
+  @impl true
+  def run(params, context) do
+    JidoActionBench.Fixtures.barrier(context)
+    {:continue, params, JidoActionBench.Child}
+  end
+end
+
+defmodule JidoActionBench.ComponentCases do
+  @moduledoc false
+  alias Jido.{Exec, Expr, Flow}
+  alias Jido.Flow.{Choice, Dispatch, Iterate, Reduce, Ref, Step}
+  alias Jido.Flow.Map, as: FlowMap
+  alias JidoActionBench.{Accumulate, Continue, Echo, Fixtures}
+
+  @opts [task_supervisor: JidoActionBench.TaskSupervisor, max_concurrency: 4]
+
+  def workloads do
+    collections =
+      for kind <- [:map, :reduce, :iterate],
+          count <- [0, 1, 16],
+          workload <-
+            cases(
+              "component/#{kind}/#{count}",
+              graph(kind, count),
+              input(count),
+              expected(kind, count)
+            ),
+          do: workload
+
+    choices =
+      for selected <- [1, 16, 0],
+          workload <-
+            cases(
+              "component/choice/#{selected}",
+              graph(:choice, 16),
+              %{selected: selected},
+              {:ok, %{value: selected}}
+            ),
+          do: workload
+
+    metadata =
+      for kind <- [:map, :reduce, :iterate, :choice, :dispatch],
+          payload <- [:small, :list, :binary] do
+        flow = graph(kind, 1)
+
+        meta =
+          case payload do
+            :small -> %{}
+            :list -> %{notes: Enum.to_list(1..5_000)}
+            :binary -> %{notes: :binary.copy(<<42>>, 1_048_576)}
+          end
+
+        flow = %{flow | components: Enum.map(flow.components, &%{&1 | meta: meta})}
+        modes = if kind == :dispatch, do: [:compile, :run], else: [:compile, :continue]
+
+        cases(
+          "captures/#{kind}/#{payload}",
+          flow,
+          Map.put(input(1), :selected, 1),
+          expected(kind, 1),
+          modes
+        )
+      end
+      |> List.flatten()
+
+    collections ++
+      choices ++
+      metadata ++
+      dependency_cases() ++
+      reduce_payload_cases() ++
+      output_cases() ++
+      cases("component/dispatch", graph(:dispatch, 1), %{value: 42}, {:ok, %{value: 42}}, [
+        :compile,
+        :run
+      ]) ++
+      execution_modes()
+  end
+
+  def graph(:map, _count) do
+    component =
+      FlowMap.new!(
+        name: "work",
+        collection: Ref.input(:items),
+        action: Echo,
+        params: %{value: Ref.item()}
+      )
+
+    flow(component, %{items: Ref.result("work")})
+  end
+
+  def graph(:reduce, _count) do
+    component =
+      Reduce.new!(
+        name: "work",
+        collection: Ref.input(:items),
+        initial: %{value: 0},
+        action: Accumulate,
+        params: %{value: Ref.accumulator(:value), amount: Ref.item()}
+      )
+
+    flow(component, Ref.result("work"))
+  end
+
+  def graph(:iterate, count) do
+    component =
+      Iterate.new!(
+        name: "work",
+        action: Accumulate,
+        params: %{value: Ref.state(:value), amount: 1},
+        state: Iterate.State.new!(initial: %{value: 0}, update: Ref.body_result()),
+        completion: Expr.new!(:eq, [Ref.state(:value), count]),
+        max_iterations: max(count, 1)
+      )
+
+    flow(component, %{value: Ref.result("work", [:state, :value])})
+  end
+
+  def graph(:choice, count) do
+    component =
+      Choice.new!(
+        name: "work",
+        options:
+          for(
+            index <- 1..count,
+            do: [
+              name: "o#{index}",
+              condition: Expr.new!(:eq, [Ref.input(:selected), index]),
+              action: Echo,
+              params: %{value: index}
+            ]
+          ),
+        fallback: [action: Echo, params: %{value: 0}]
+      )
+
+    flow(component, Ref.result("work"))
+  end
+
+  def graph(:dispatch, _count) do
+    component =
+      Dispatch.new!(
+        name: "work",
+        decision: Echo,
+        expander: Continue,
+        params: %{value: Ref.input(:value)}
+      )
+
+    flow(component, Ref.result("work"))
+  end
+
+  def cases(id, flow, input, expected, modes \\ [:compile, :start, :continue, :run]) do
+    {:ok, compiled} = Flow.compile(flow)
+
+    Enum.map(modes, fn mode ->
+      setup = fn context ->
+        if mode == :continue do
+          {:ok, execution} = Exec.start(flow, input, context, @opts)
+          Fixtures.barrier(context)
+          execution
+        else
+          context
+        end
+      end
+
+      run =
+        case mode do
+          :compile -> fn _ -> Flow.compile(flow) end
+          :start -> fn context -> Exec.start(flow, input, context, @opts) end
+          :continue -> fn execution -> Exec.continue(execution) end
+          :run -> fn context -> Exec.run(flow, input, context, @opts) end
+        end
+
+      check =
+        case mode do
+          :compile ->
+            fn {:ok, value} -> expect!(value.compilation_digest, compiled.compilation_digest) end
+
+          :start ->
+            fn {:ok, execution} ->
+              {:ok, finished} = Exec.continue(execution)
+              expect!(Exec.result(finished), expected)
+            end
+
+          :continue ->
+            fn {:ok, execution} -> expect!(Exec.result(execution), expected) end
+
+          :run ->
+            fn value -> expect!(value, expected) end
+        end
+
+      retained =
+        case mode do
+          :compile ->
+            fn _, {:ok, value} ->
+              %{compiled: value, workflow: value.workflow, index: value.component_index}
+            end
+
+          :start ->
+            fn _, {:ok, execution} -> %{started_execution: execution} end
+
+          :continue ->
+            fn paused, {:ok, finished} ->
+              %{
+                paused_execution: paused,
+                finished_execution: finished,
+                result: Exec.result(finished)
+              }
+            end
+
+          :run ->
+            fn _, result -> %{result: result} end
+        end
+
+      %{id: "#{id}/#{mode}", setup: setup, run: run, check: check, retained: retained}
+    end)
+  end
+
+  defp dependency_cases do
+    for size <- [0, 1_000], mode <- [:fail_fast, :collect_errors] do
+      producer = Step.new!(name: "producer", action: Echo, params: %{unused: Ref.input(:unused)})
+
+      mapped =
+        FlowMap.new!(
+          name: "work",
+          collection: Ref.input(:items),
+          action: Echo,
+          on_error: mode,
+          params: %{value: Ref.item(), ignored: Ref.result("producer", :unused)}
+        )
+
+      # The Action consumes a reference but emits a small result.
+      mapped = %{
+        mapped
+        | action: JidoActionBench.SmallResult,
+          params: Map.put(mapped.params, :fail, false)
+      }
+
+      flow =
+        Flow.new!(
+          name: "map_dependencies",
+          components: [producer, mapped],
+          output: %{items: Ref.result("work")}
+        )
+
+      input = %{items: Enum.to_list(1..16), unused: List.duplicate(7, size)}
+
+      item =
+        if mode == :collect_errors, do: %{status: :ok, value: %{value: 42}}, else: %{value: 42}
+
+      expected = {:ok, %{items: List.duplicate(item, 16)}}
+      cases("map_dependencies/#{mode}/#{size}", flow, input, expected, [:continue])
+    end
+    |> List.flatten()
+  end
+
+  defp output_cases do
+    for count <- [4, 16], output <- [:terminal, :all] do
+      flow = Fixtures.graph(:serial, count)
+      flow = if output == :terminal, do: %{flow | output: Ref.result("s#{count}")}, else: flow
+
+      expected =
+        if output == :terminal,
+          do: {:ok, %{value: 42}},
+          else: {:ok, Map.new(1..count, &{"s#{&1}", %{value: 42}})}
+
+      cases("outputs/#{output}/#{count}", flow, %{value: 42}, expected, [:continue])
+    end
+    |> List.flatten()
+  end
+
+  defp reduce_payload_cases do
+    for count <- [0, 16], size <- [0, 1_000] do
+      flow = graph(:reduce, count)
+      [component] = flow.components
+      component = %{component | initial: Ref.input(:initial)}
+      flow = %{flow | components: [component]}
+      initial = %{value: 0, unused: List.duplicate(7, size)}
+      input = Map.put(input(count), :initial, initial)
+      expected = if count == 0, do: {:ok, initial}, else: expected(:reduce, count)
+      cases("reduce_initial/#{count}/#{size}", flow, input, expected, [:continue])
+    end
+    |> List.flatten()
+  end
+
+  defp execution_modes do
+    flow = Fixtures.graph(:parallel, 8)
+    expected = {:ok, Map.new(1..8, &{"s#{&1}", %{value: 42}})}
+
+    for mode <- [:step, :wave, :continue] do
+      %{
+        id: "scheduling/#{mode}/8",
+        setup: fn context ->
+          {:ok, execution} = Exec.start(flow, %{value: 42}, context, @opts)
+          execution
+        end,
+        run: &finish(&1, mode),
+        check: fn finished -> expect!(Exec.result(finished), expected) end,
+        retained: fn _, finished -> %{finished_execution: finished} end
+      }
+    end
+  end
+
+  defp finish(%{status: status} = execution, _) when status != :running, do: execution
+
+  defp finish(execution, :continue) do
+    {:ok, finished} = Exec.continue(execution)
+    finished
+  end
+
+  defp finish(execution, mode) do
+    {:ok, _, next} = apply(Exec, mode, [execution])
+    finish(next, mode)
+  end
+
+  defp flow(component, output),
+    do: Flow.new!(name: "bench_component", components: [component], output: output)
+
+  defp input(0), do: %{items: [], value: 42}
+  defp input(count), do: %{items: Enum.to_list(1..count), value: 42}
+  defp expected(:map, count), do: {:ok, %{items: Enum.map(input(count).items, &%{value: &1})}}
+  defp expected(:reduce, count), do: {:ok, %{value: div(count * (count + 1), 2)}}
+  defp expected(:iterate, count), do: {:ok, %{value: count}}
+  defp expected(:choice, count), do: {:ok, %{value: count}}
+  defp expected(:dispatch, _), do: {:ok, %{value: 42}}
+
+  def expect!(actual, expected) do
+    if actual != expected,
+      do: raise("component benchmark returned an incorrect result: #{inspect(actual, limit: 5)}")
+
+    :ok
+  end
+end

--- a/bench/support/fixtures.exs
+++ b/bench/support/fixtures.exs
@@ -38,12 +38,23 @@ defmodule JidoActionBench.Fixtures do
     end
   end
 
-  def workloads(count, payload) when count in 1..32 do
-    input = %{value: payload(payload)}
-    action_workloads(input) ++ flow_workloads(count, input)
-  end
+  def workloads(sizes, payloads) do
+    unless Enum.all?(sizes, &(&1 in 1..32)),
+      do: raise(ArgumentError, "graph size must be in 1..32")
 
-  def workloads(_count, _payload), do: raise(ArgumentError, "graph size must be in 1..32")
+    actions =
+      for payload <- payloads,
+          workload <- action_workloads(%{value: payload(payload)}),
+          do: Map.put(workload, :id, "#{workload.name}/#{payload}")
+
+    flows =
+      for count <- sizes,
+          payload <- payloads,
+          workload <- flow_workloads(count, %{value: payload(payload)}),
+          do: Map.put(workload, :id, "#{workload.name}/#{payload}/#{count}")
+
+    actions ++ flows
+  end
 
   def graph(shape, count) when count in 1..32 do
     components =
@@ -77,7 +88,7 @@ defmodule JidoActionBench.Fixtures do
         setup: fn context -> context end,
         run: fn context -> action(mode, input, context) end,
         check: &expect!(&1, {:ok, input}),
-        retained: input
+        retained: fn _prepared, result -> %{result: result} end
       }
     end
   end
@@ -115,30 +126,34 @@ defmodule JidoActionBench.Fixtures do
       max_concurrency: if(shape == :serial, do: 1, else: 4)
     ]
 
-    common = %{setup: fn context -> context end, retained: {flow, compiled, input}}
+    common = %{setup: fn context -> context end}
 
     [
       Map.merge(common, %{
         name: "#{shape}/validate",
         run: fn _ -> Flow.validate_executable(flow) end,
-        check: &expect!(&1, {:ok, flow})
+        check: &expect!(&1, {:ok, flow}),
+        retained: fn _, {:ok, value} -> %{flow: value} end
       }),
       Map.merge(common, %{
         name: "#{shape}/compile",
         run: fn _ -> Flow.compile(flow) end,
         check: fn {:ok, result} ->
           expect!(result.compilation_digest, compiled.compilation_digest)
-        end
+        end,
+        retained: fn _, {:ok, value} -> %{compiled: value} end
       }),
       Map.merge(common, %{
         name: "#{shape}/run",
         run: fn context -> Exec.run(flow, input, context, opts) end,
-        check: &expect!(&1, expected)
+        check: &expect!(&1, expected),
+        retained: fn _, result -> %{result: result} end
       }),
       Map.merge(common, %{
         name: "#{shape}/prepared_reuse",
         run: fn context -> run_prepared(flow, compiled, input, context, opts) end,
-        check: &expect!(&1, expected)
+        check: &expect!(&1, expected),
+        retained: fn _, result -> %{result: result} end
       }),
       %{
         name: "#{shape}/paused_continue",
@@ -150,10 +165,12 @@ defmodule JidoActionBench.Fixtures do
         end,
         run: fn execution ->
           {:ok, finished} = Exec.continue(execution)
-          Exec.result(finished)
+          finished
         end,
-        check: &expect!(&1, expected),
-        retained: {flow, compiled, input}
+        check: fn finished -> expect!(Exec.result(finished), expected) end,
+        retained: fn paused, finished ->
+          %{paused_execution: paused, finished_execution: finished}
+        end
       }
     ]
   end

--- a/bench/support/lifecycle_cases.exs
+++ b/bench/support/lifecycle_cases.exs
@@ -1,0 +1,197 @@
+defmodule JidoActionBench.Block do
+  @moduledoc false
+  use Jido.Action, name: "benchmark_block"
+
+  @impl true
+  def run(_params, %{bench_owner: owner, bench_tag: tag}) do
+    send(owner, {tag, :ready, self()})
+    receive do: ({^tag, :release} -> {:ok, %{value: 42}})
+  end
+end
+
+defmodule JidoActionBench.LifecycleCases do
+  @moduledoc false
+  alias Jido.Exec
+  alias JidoActionBench.{Block, ComponentCases, Echo, Fixtures}
+  @opts [task_supervisor: JidoActionBench.TaskSupervisor]
+
+  def workloads do
+    Enum.map([:cancel, :await_timeout, :call_timeout, :caller_exit], &termination/1) ++
+      Enum.map([0, 1_000], &mailbox/1) ++
+      Enum.map([:none, :fast, :blocked], &telemetry/1)
+  end
+
+  defp termination(mode) do
+    %{
+      id: "lifecycle/#{mode}",
+      setup: fn context -> context end,
+      run: fn context -> terminate(mode, context) end,
+      check: fn :ok -> :ok end,
+      retained: fn _, result -> %{result: result} end
+    }
+  end
+
+  defp terminate(:caller_exit, context) do
+    parent = self()
+    tag = make_ref()
+
+    {owner, owner_ref} =
+      spawn_monitor(fn ->
+        handle = Exec.run_async(Block, %{}, %{bench_owner: parent, bench_tag: tag}, @opts)
+        send(parent, {tag, :handle, handle.pid})
+        receive do: ({^tag, :hold} -> :ok)
+      end)
+
+    try do
+      worker = ready(tag)
+      worker_ref = Process.monitor(worker)
+      managed = receive do: ({^tag, :handle, pid} -> pid)
+      managed_ref = Process.monitor(managed)
+      Fixtures.barrier(context)
+      Process.exit(owner, :kill)
+      down(owner, owner_ref)
+      down(worker, worker_ref)
+      down(managed, managed_ref)
+    after
+      Process.exit(owner, :kill)
+      Process.demonitor(owner_ref, [:flush])
+    end
+  end
+
+  defp terminate(mode, context) do
+    tag = make_ref()
+    opts = if mode == :call_timeout, do: Keyword.put(@opts, :timeout, 100), else: @opts
+    handle = Exec.run_async(Block, %{}, %{bench_owner: self(), bench_tag: tag}, opts)
+    worker = ready(tag)
+    ref = Process.monitor(worker)
+    Fixtures.barrier(context)
+
+    try do
+      case mode do
+        :cancel ->
+          :ok = Exec.cancel(handle)
+
+        :await_timeout ->
+          {:error, %Jido.Exec.Error.AsyncTimeoutError{}} = Exec.await(handle, 0)
+
+        :call_timeout ->
+          {:error, %Jido.Action.Error.TimeoutError{}} = Exec.await(handle, :infinity)
+      end
+
+      down(worker, ref)
+    after
+      if Process.alive?(handle.pid), do: Exec.cancel(handle)
+      Process.demonitor(ref, [:flush])
+    end
+  end
+
+  defp mailbox(count) do
+    %{
+      id: "caller/mailbox/#{count}",
+      setup: fn context ->
+        tag = make_ref()
+        for _ <- List.duplicate(:message, count), do: send(self(), {tag, :unrelated})
+        {context, tag}
+      end,
+      run: fn {context, tag} ->
+        result =
+          Enum.reduce(1..20, nil, fn _, _ ->
+            handle = Exec.run_async(Echo, %{value: 42}, context, @opts)
+            {:ok, %{value: 42}} = Exec.await(handle, :infinity)
+          end)
+
+        {result, tag}
+      end,
+      check: fn {result, tag} ->
+        ComponentCases.expect!(result, {:ok, %{value: 42}})
+
+        for _ <- List.duplicate(:message, count) do
+          receive do
+            {^tag, :unrelated} -> :ok
+          after
+            0 -> raise "unrelated caller message was lost"
+          end
+        end
+
+        receive do
+          {:jido_exec_async_result, _, _, _} -> raise "stale async result"
+          {:DOWN, _, :process, _, _} -> raise "stale async monitor"
+        after
+          0 -> :ok
+        end
+      end,
+      retained: fn _, {result, _} -> %{result: result} end
+    }
+  end
+
+  defp telemetry(mode) do
+    flow = Fixtures.graph(:parallel, 16)
+    expected = {:ok, Map.new(1..16, &{"s#{&1}", %{value: 42}})}
+
+    %{
+      id: "telemetry/#{mode}/16",
+      setup: fn context -> context end,
+      run: fn context ->
+        id = {__MODULE__, make_ref()}
+
+        if mode != :none do
+          :ok =
+            :telemetry.attach_many(
+              id,
+              [
+                [:jido, :flow, :start],
+                [:jido, :flow, :stop],
+                [:jido, :flow, :node, :start],
+                [:jido, :flow, :node, :stop]
+              ],
+              &__MODULE__.handle_event/4,
+              %{mode: mode, owner: self(), tag: id}
+            )
+        end
+
+        try do
+          handle = Exec.run_async(flow, %{value: 42}, context, @opts)
+
+          if mode == :blocked do
+            receive do
+              {^id, :handler, handler} ->
+                Fixtures.barrier(context)
+                send(handler, {id, :release})
+            after
+              30_000 -> raise "telemetry handler did not start"
+            end
+          end
+
+          Exec.await(handle, :infinity)
+        after
+          if mode != :none, do: :telemetry.detach(id)
+        end
+      end,
+      check: &ComponentCases.expect!(&1, expected),
+      retained: fn _, result -> %{result: result} end
+    }
+  end
+
+  def handle_event([:jido, :flow, :start], _, _, %{mode: :blocked, owner: owner, tag: tag}) do
+    send(owner, {tag, :handler, self()})
+    receive do: ({^tag, :release} -> :ok)
+  end
+
+  def handle_event(_, _, _, _), do: :ok
+
+  defp ready(tag) do
+    receive do
+      {^tag, :ready, worker} -> worker
+    after
+      30_000 -> raise "benchmark worker did not start"
+    end
+  end
+
+  defp down(pid, ref) do
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _} -> :ok
+    after
+      30_000 -> raise "benchmark worker did not stop"
+    end
+  end
+end

--- a/bench/support/measure.exs
+++ b/bench/support/measure.exs
@@ -27,8 +27,36 @@ defmodule JidoActionBench.Measure do
     end)
   end
 
-  def resources(workload) do
-    isolated(fn -> trace_resources(workload) end)
+  def resources(workload, count \\ 1) when is_integer(count) and count > 0 do
+    samples = for _ <- 1..count, do: isolated(fn -> trace_resources(workload) end)
+    %{samples: samples, median: median_fields(samples)}
+  end
+
+  def retained(workload) do
+    isolated(fn ->
+      prepared = workload.setup.(%{})
+      result = workload.run.(prepared)
+      :ok = workload.check.(result)
+
+      Map.new(workload.retained.(prepared, result), fn {name, term} ->
+        {name, term_size(term)}
+      end)
+    end)
+  end
+
+  defp median_fields([first | _] = samples) do
+    Map.new(first, fn {key, value} ->
+      values = Enum.map(samples, &Map.fetch!(&1, key))
+
+      median =
+        cond do
+          is_map(value) -> median_fields(values)
+          is_number(value) -> distribution(values).median
+          is_nil(value) -> nil
+        end
+
+      {key, median}
+    end)
   end
 
   def term_size(term) do
@@ -95,6 +123,7 @@ defmodule JidoActionBench.Measure do
           :bench_go ->
             try do
               result = workload.run.(workload.setup.(%{bench_observer: observer}))
+              JidoActionBench.Fixtures.barrier(%{bench_observer: observer})
               :ok = workload.check.(result)
               send(observer, {:bench_result, :ok})
             rescue

--- a/bench/support/measure.exs
+++ b/bench/support/measure.exs
@@ -74,10 +74,16 @@ defmodule JidoActionBench.Measure do
           receive do
             {:term, copied} ->
               {:memory, memory} = Process.info(self(), :memory)
+              {:binary, binaries} = Process.info(self(), :binary)
 
               %{
                 copied_flat_heap_bytes: :erts_debug.flat_size(copied) * word,
-                receiver_memory_bytes: memory
+                receiver_memory_bytes: memory,
+                observed_receiver_binary_bytes:
+                  binaries
+                  |> Map.new(fn {id, bytes, _} -> {id, bytes} end)
+                  |> Map.values()
+                  |> Enum.sum()
               }
           end
         end,
@@ -142,6 +148,8 @@ defmodule JidoActionBench.Measure do
       result: nil,
       caller_down: false,
       observations: 0,
+      reductions: %{},
+      collections: %{},
       observed_peak: %{
         process_memory_bytes: 0,
         process_heap_bytes: 0,
@@ -149,12 +157,13 @@ defmodule JidoActionBench.Measure do
         vm_total_bytes: 0,
         vm_processes_bytes: 0,
         vm_binary_bytes: 0,
-        live_owned: 0
+        live_owned: 0,
+        mailbox_messages: 0
       }
     }
 
     try do
-      flags = [:procs, :set_on_spawn, {:tracer, self()}]
+      flags = [:procs, :garbage_collection, :set_on_spawn, {:tracer, self()}]
       :erlang.trace(supervisor, true, flags)
       :erlang.trace(caller, true, flags)
       state = observe(state)
@@ -173,6 +182,14 @@ defmodule JidoActionBench.Measure do
         owned_remaining: 0,
         observations: state.observations,
         observed_peak: state.observed_peak,
+        observed_helper_reductions:
+          Enum.sum(for {pid} <- :ets.tab2list(table), do: Map.get(state.reductions, pid, 0)),
+        observed_caller_reductions: Map.get(state.reductions, caller, 0),
+        owned_gc_count:
+          Enum.sum(
+            for pid <- [caller | Enum.map(:ets.tab2list(table), &elem(&1, 0))],
+                do: Map.get(state.collections, pid, 0)
+          ),
         helper_reductions: nil,
         exact_peak_bytes: nil
       }
@@ -257,6 +274,11 @@ defmodule JidoActionBench.Measure do
 
   defp handle({:bench_result, result}, state), do: %{state | result: result}
 
+  defp handle({:trace, pid, event, _info}, state)
+       when event in [:gc_minor_end, :gc_major_end] do
+    %{state | collections: Map.update(state.collections, pid, 1, &(&1 + 1))}
+  end
+
   defp handle({:DOWN, ref, :process, _pid, reason}, %{caller_ref: ref} = state) do
     result = if reason == :normal, do: state.result, else: {:error, inspect(reason)}
     %{state | caller_down: true, result: result}
@@ -281,12 +303,24 @@ defmodule JidoActionBench.Measure do
 
     infos =
       Enum.flat_map(processes, fn pid ->
-        case Process.info(pid, [:memory, :total_heap_size, :binary]) do
+        case Process.info(pid, [
+               :memory,
+               :total_heap_size,
+               :binary,
+               :reductions,
+               :message_queue_len
+             ]) do
           nil -> []
-          info -> [info]
+          info -> [{pid, info}]
         end
       end)
 
+    reductions =
+      Enum.reduce(infos, state.reductions, fn {pid, info}, acc ->
+        Map.update(acc, pid, info[:reductions], &max(&1, info[:reductions]))
+      end)
+
+    infos = Enum.map(infos, &elem(&1, 1))
     binaries = infos |> Enum.flat_map(&Keyword.fetch!(&1, :binary))
     binary_sizes = Map.new(binaries, fn {id, bytes, _refs} -> {id, bytes} end)
     vm = :erlang.memory()
@@ -300,11 +334,12 @@ defmodule JidoActionBench.Measure do
       vm_total_bytes: vm[:total],
       vm_processes_bytes: vm[:processes],
       vm_binary_bytes: vm[:binary],
-      live_owned: Enum.count(owned, &Process.alive?/1)
+      live_owned: Enum.count(owned, &Process.alive?/1),
+      mailbox_messages: Enum.sum(Enum.map(infos, &Keyword.fetch!(&1, :message_queue_len)))
     }
 
     peaks = Map.merge(state.observed_peak, values, fn _key, old, new -> max(old, new) end)
-    %{state | observations: state.observations + 1, observed_peak: peaks}
+    %{state | observations: state.observations + 1, observed_peak: peaks, reductions: reductions}
   end
 
   defp isolated(fun, start \\ fn _pid -> :ok end) do

--- a/bench/support/memory_cases.exs
+++ b/bench/support/memory_cases.exs
@@ -1,0 +1,195 @@
+defmodule JidoActionBench.SmallResult do
+  @moduledoc false
+  use Jido.Action, name: "benchmark_small_result"
+
+  @impl true
+  def run(params, context) do
+    JidoActionBench.Fixtures.barrier(context)
+
+    if params.fail do
+      {:error, Jido.Action.Error.execution_error("benchmark failure")}
+    else
+      {:ok, %{value: 42}}
+    end
+  end
+end
+
+defmodule JidoActionBench.MemoryCases do
+  @moduledoc false
+  alias Jido.{Exec, Flow}
+  alias Jido.Flow.{Ref, Step, Subflow}
+  alias JidoActionBench.{Child, Echo, Fixtures, SmallResult}
+
+  @opts [task_supervisor: JidoActionBench.TaskSupervisor, max_concurrency: 1]
+
+  def workloads do
+    metadata_workloads() ++ input_workloads() ++ [ready_workload(), collector_workload()]
+  end
+
+  defp metadata_workloads do
+    for shape <- [:step, :subflow],
+        payload <- [:small, :large_list, :large_binary],
+        workload <- metadata_cases(shape, payload),
+        do: workload
+  end
+
+  defp metadata_cases(shape, payload) do
+    meta = if payload == :small, do: %{}, else: %{notes: payload(payload)}
+
+    components =
+      for index <- 1..4 do
+        attrs = [name: "s#{index}", params: %{value: Ref.input(:value)}, meta: meta]
+
+        case shape do
+          :step -> Step.new!([action: Echo] ++ attrs)
+          :subflow -> Subflow.new!([flow: Child] ++ attrs)
+        end
+      end
+
+    flow = Flow.new!(name: "metadata_#{shape}", components: components, output: Ref.result("s4"))
+    {:ok, compiled} = Flow.compile(flow)
+    digest = compiled.compilation_digest
+
+    [
+      %{
+        id: "metadata/#{shape}/compile/#{payload}/4",
+        setup: fn context -> context end,
+        run: fn _ -> Flow.compile(flow) end,
+        check: fn {:ok, compiled} -> expect!(compiled.compilation_digest, digest) end,
+        retained: fn _, {:ok, compiled} -> %{compiled: compiled} end
+      },
+      execution_workload(
+        "metadata/#{shape}/paused_continue/#{payload}/4",
+        flow,
+        %{value: 42},
+        {:ok, %{value: 42}}
+      )
+    ]
+  end
+
+  defp input_workloads do
+    for outcome <- [:success, :failure], payload <- [:small, :large_list] do
+      flow =
+        Flow.new!(
+          name: "retention_#{outcome}",
+          components: [
+            Step.new!(
+              name: "small_result",
+              action: SmallResult,
+              params: %{value: Ref.input(:value), fail: outcome == :failure}
+            )
+          ],
+          output: Ref.result("small_result")
+        )
+
+      input = %{value: payload(payload), unused: payload(payload)}
+      expected = if outcome == :success, do: {:ok, %{value: 42}}, else: :failure
+      execution_workload("retention/#{outcome}/#{payload}", flow, input, expected)
+    end
+  end
+
+  defp execution_workload(id, flow, input, expected) do
+    %{
+      id: id,
+      setup: fn context -> start!(flow, input, context) end,
+      run: &continue!/1,
+      check: fn finished -> check_result!(Exec.result(finished), expected) end,
+      retained: &execution_terms/2
+    }
+  end
+
+  defp ready_workload do
+    flow = Fixtures.graph(:parallel, 16)
+    expected = {:ok, Map.new(1..16, &{"s#{&1}", %{value: 42}})}
+
+    %{
+      id: "inspection/ready/16",
+      setup: fn context -> start!(flow, %{value: 42}, context) end,
+      run: fn execution ->
+        # Retain the last read only; earlier descriptions can be collected.
+        work = Enum.reduce(1..100, [], fn _, _ -> Exec.ready(execution) end)
+        {execution, work}
+      end,
+      check: fn {execution, work} ->
+        try do
+          expect!(length(work), 16)
+          expect!(Enum.all?(work, &(&1.status == :ready)), true)
+        after
+          finished = continue!(execution)
+          expect!(Exec.result(finished), expected)
+        end
+      end,
+      retained: fn _, {execution, work} -> %{paused_execution: execution, work: work} end
+    }
+  end
+
+  defp collector_workload do
+    names = Enum.map(1..32, &"s#{&1}")
+    producers = Enum.map(names, &Step.new!(name: &1, action: Echo, params: %{value: 42}))
+    params = Map.new(names, &{&1, Ref.result(&1)})
+    collector = Step.new!(name: "collect", action: Echo, params: params)
+
+    flow =
+      Flow.new!(
+        name: "wide_collector",
+        components: producers ++ [collector],
+        output: Ref.result("collect")
+      )
+
+    expected = {:ok, Map.new(names, &{&1, %{value: 42}})}
+
+    %{
+      id: "dependencies/collector/32",
+      setup: fn context ->
+        {:ok, execution} = Exec.start(flow, %{}, context, @opts)
+        {:ok, work, execution} = Exec.wave(execution)
+        expect!(length(work), 32)
+        Fixtures.barrier(context)
+        execution
+      end,
+      run: &continue!/1,
+      check: fn finished -> expect!(Exec.result(finished), expected) end,
+      retained: &execution_terms/2
+    }
+  end
+
+  defp start!(flow, input, context) do
+    {:ok, execution} = Exec.start(flow, input, context, @opts)
+    Fixtures.barrier(context)
+    execution
+  end
+
+  defp continue!(execution) do
+    {:ok, finished} = Exec.continue(execution)
+    finished
+  end
+
+  defp execution_terms(paused, finished) do
+    terms = %{
+      paused_execution: paused,
+      finished_execution: finished,
+      result: Exec.result(finished)
+    }
+
+    if finished.status == :failed,
+      do: Map.put(terms, :failure_records, finished.runnable_errors),
+      else: terms
+  end
+
+  defp check_result!(
+         {:error, %Jido.Action.Error.ExecutionFailureError{message: "benchmark failure"}},
+         :failure
+       ),
+       do: :ok
+
+  defp check_result!(actual, expected), do: expect!(actual, expected)
+
+  defp expect!(actual, expected) do
+    if actual != expected, do: raise("memory benchmark returned an incorrect result")
+    :ok
+  end
+
+  defp payload(:small), do: 42
+  defp payload(:large_list), do: Enum.to_list(1..5_000)
+  defp payload(:large_binary), do: :binary.copy(<<42>>, 1_048_576)
+end

--- a/bench/support/release_fixture.exs
+++ b/bench/support/release_fixture.exs
@@ -1,0 +1,23 @@
+defmodule JidoActionBench.ReleaseAction do
+  use Jido.Action, name: "release_benchmark_action"
+
+  @impl true
+  def run(%{value: value, operation: :increment}, _), do: {:ok, %{value: value + 1}}
+  def run(%{value: value, operation: :double}, _), do: {:ok, %{value: value * 2}}
+end
+
+defmodule JidoActionBench.ReleaseFlow do
+  use Jido.Flow, name: "release_benchmark_flow"
+
+  flow do
+    step "first",
+      action: JidoActionBench.ReleaseAction,
+      params: %{value: input(:value), operation: :increment}
+
+    step "second",
+      action: JidoActionBench.ReleaseAction,
+      params: %{value: result("first", :value), operation: :double}
+
+    output result("second")
+  end
+end

--- a/bench/support/release_probe.exs
+++ b/bench/support/release_probe.exs
@@ -1,0 +1,32 @@
+{:ok, _} = Application.ensure_all_started(:inline_consumer)
+
+target =
+  case System.fetch_env!("BENCH_RELEASE_TARGET") do
+    "inline" -> InlineConsumer.Steps
+    "explicit" -> JidoActionBench.ReleaseFlow
+  end
+
+boot = %{memory: Map.new(:erlang.memory()), loaded_modules: length(:code.all_loaded())}
+
+measure = fn ->
+  before = System.monotonic_time()
+  result = Jido.Exec.run(target, %{value: 2})
+  elapsed = System.monotonic_time() - before
+  {:ok, %{value: 6}} = result
+  System.convert_time_unit(elapsed, :native, :nanosecond)
+end
+
+first = measure.()
+warm = for _ <- 1..100, do: measure.()
+
+IO.puts(
+  "INLINE_RESULT=" <>
+    JSON.encode!(%{
+      target: target,
+      boot: boot,
+      first_ns: first,
+      warm_ns: warm,
+      after_memory: Map.new(:erlang.memory()),
+      loaded_modules: length(:code.all_loaded())
+    })
+)

--- a/bench/support/report.exs
+++ b/bench/support/report.exs
@@ -5,14 +5,17 @@ defmodule JidoActionBench.Report do
     [
       "Timing has no tracing or memory sampling. Setup and result checks are outside each timed interval.",
       "Caller reductions exclude helpers. Helper reductions and exact memory peaks are unavailable (null).",
-      "Memory peaks are observed maxima at start, callback/pause barriers, and completion. Short-lived allocations can be missed.",
+      "Memory peaks are observed maxima at start, callback/pause/result barriers, and completion. Short-lived allocations can be missed.",
+      "Resource reports keep every separate run and field medians. Medians of observed peaks are not exact lifetime peaks.",
       "Process heap and process memory include the measured caller and traced descendants. Shared binary bytes deduplicate observed off-heap binary references.",
       "VM memory includes the observer, supervisor, loaded code, and unrelated activity. It does not establish ownership or leaks.",
       "Owned starts follow spawn traces from the caller and dedicated Task.Supervisor. Both roots and the observer are excluded from helper counts.",
       "Cleanup uses trace-delivery barriers and process monitors. Failed probes stop and confirm observed descendants before returning the failure. Global process-count differences are not used.",
       "Flat and copied heap sizes exclude off-heap binary payloads; external bytes include the external term representation. Receiver memory includes its process overhead.",
+      "Retained terms come from a separate checked call: the authored Flow, compiled graph, returned result, or actual paused and finished execution. Paused values are copied after the execution is finished.",
       "Prepared reuse uses a benchmark-only internal adapter with empty schemas. It omits public target/input validation and graph compilation. It is not a public compiled-graph API.",
       "Paused-continue timing excludes a fresh Exec.start per sample; its resource run includes start and the paused barrier.",
+      "Focused cases run once per profile, outside the size/payload matrix. Ready timing covers 100 reads and retains the last descriptor list; resource runs include setup and completion. Collector timing excludes its 32-producer setup wave.",
       "Comparisons show raw ratios. No speedup claim is valid from these shared-host measurements. Repeat on an idle host with the same environment."
     ]
   end
@@ -20,8 +23,15 @@ defmodule JidoActionBench.Report do
   def markdown(report) do
     rows =
       Enum.map(report.cases, fn row ->
-        "| #{row.id} | #{row.timing.wall_ns.median} | #{row.timing.wall_ns.p95} | #{row.resources.owned_process_starts} | #{row.resources.owned_remaining} |"
+        resources = row.resources.median
+
+        "| #{row.id} | #{row.timing.wall_ns.median} | #{row.timing.wall_ns.p95} | #{resources.observed_peak.process_memory_bytes} | #{resources.observed_peak.shared_binary_bytes} | #{resources.owned_process_starts} | #{resources.owned_remaining} |"
       end)
+
+    retained_rows =
+      for row <- report.cases, {name, term} <- Enum.sort(row.retained_terms) do
+        "| #{row.id} | #{name} | #{term.local_heap_bytes} | #{term.copied_flat_heap_bytes} | #{term.external_bytes} |"
+      end
 
     """
     # Execution benchmark
@@ -30,11 +40,18 @@ defmodule JidoActionBench.Report do
     Tool SHA-256: `#{report.source.tool_sha256}`.
     Profile: `#{report.settings.profile}`. Elixir: `#{report.environment.elixir}`. OTP: `#{report.environment.otp}`.
     Warm-up: #{report.settings.warmup}. Timing samples per case: #{report.settings.samples}.
+    Resource samples per case: #{report.settings.resource_samples}. Memory and helper columns show field medians.
     See the JSON report for raw samples, reductions, term sizes, memory, and full machine data.
 
-    | Case | Median ns | p95 ns | Helper starts | Remaining |
-    | --- | ---: | ---: | ---: | ---: |
+    | Case | Median ns | p95 ns | Process bytes | Binary bytes | Helper starts | Remaining |
+    | --- | ---: | ---: | ---: | ---: | ---: | ---: |
     #{Enum.join(rows, "\n")}
+
+    ## Retained terms
+
+    | Case | Term | Local heap bytes | Copied heap bytes | External bytes |
+    | --- | --- | ---: | ---: | ---: |
+    #{Enum.join(retained_rows, "\n")}
 
     ## Measurement limits
 
@@ -67,12 +84,22 @@ defmodule JidoActionBench.Report do
         median_a = a["timing"]["wall_ns"]["median"]
         median_b = b["timing"]["wall_ns"]["median"]
 
-        ratio =
-          if median_a == 0,
-            do: "unavailable",
-            else: :erlang.float_to_binary(median_b / median_a, decimals: 3)
+        resources_a = a["resources"]["median"]
+        resources_b = b["resources"]["median"]
 
-        "| #{id} | #{median_a} | #{median_b} | #{ratio} | #{a["resources"]["owned_process_starts"]} → #{b["resources"]["owned_process_starts"]} | #{b["resources"]["owned_remaining"]} |"
+        process_ratio =
+          ratio(
+            resources_a["observed_peak"]["process_memory_bytes"],
+            resources_b["observed_peak"]["process_memory_bytes"]
+          )
+
+        binary_ratio =
+          ratio(
+            resources_a["observed_peak"]["shared_binary_bytes"],
+            resources_b["observed_peak"]["shared_binary_bytes"]
+          )
+
+        "| #{id} | #{median_a} | #{median_b} | #{ratio(median_a, median_b)} | #{process_ratio} | #{binary_ratio} | #{resources_a["owned_process_starts"]} → #{resources_b["owned_process_starts"]} | #{resources_b["owned_remaining"]} |"
       end
 
     """
@@ -83,8 +110,8 @@ defmodule JidoActionBench.Report do
     Ratio is after / before. No speedup claim is made. Environment, settings, method, and tool hash match.
     Check runtime source state in both JSON files before using these ratios.
 
-    | Case | Before median ns | After median ns | Ratio | Helper starts | After remaining |
-    | --- | ---: | ---: | ---: | ---: | ---: |
+    | Case | Before median ns | After median ns | Time ratio | Process bytes ratio | Binary bytes ratio | Helper starts | After remaining |
+    | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
     #{Enum.join(rows, "\n")}
 
     ## Measurement limits
@@ -92,6 +119,9 @@ defmodule JidoActionBench.Report do
     #{Enum.map_join(limitations(), "\n", &("- " <> &1))}
     """
   end
+
+  defp ratio(0, _after), do: "unavailable"
+  defp ratio(before, after_value), do: :erlang.float_to_binary(after_value / before, decimals: 3)
 
   defp index!(report) do
     rows = Map.fetch!(report, "cases")

--- a/bench/support/report.exs
+++ b/bench/support/report.exs
@@ -4,18 +4,19 @@ defmodule JidoActionBench.Report do
   def limitations do
     [
       "Timing has no tracing or memory sampling. Setup and result checks are outside each timed interval.",
-      "Caller reductions exclude helpers. Helper reductions and exact memory peaks are unavailable (null).",
+      "Caller timing reductions exclude helpers. Resource runs report observed caller and helper reduction totals from barriers, plus traced owned GC counts. Observed reductions are lower bounds; full helper reductions and exact memory peaks remain unavailable (null).",
       "Memory peaks are observed maxima at start, callback/pause/result barriers, and completion. Short-lived allocations can be missed.",
       "Resource reports keep every separate run and field medians. Medians of observed peaks are not exact lifetime peaks.",
       "Process heap and process memory include the measured caller and traced descendants. Shared binary bytes deduplicate observed off-heap binary references.",
       "VM memory includes the observer, supervisor, loaded code, and unrelated activity. It does not establish ownership or leaks.",
       "Owned starts follow spawn traces from the caller and dedicated Task.Supervisor. Both roots and the observer are excluded from helper counts.",
       "Cleanup uses trace-delivery barriers and process monitors. Failed probes stop and confirm observed descendants before returning the failure. Global process-count differences are not used.",
-      "Flat and copied heap sizes exclude off-heap binary payloads; external bytes include the external term representation. Receiver memory includes its process overhead.",
+      "Flat and copied heap sizes exclude off-heap binary payloads; external bytes include the external term representation. Receiver memory includes its process overhead. Observed receiver binary bytes deduplicate its off-heap references and can include a larger binary behind a small slice.",
       "Retained terms come from a separate checked call: the authored Flow, compiled graph, returned result, or actual paused and finished execution. Paused values are copied after the execution is finished.",
       "Prepared reuse uses a benchmark-only internal adapter with empty schemas. It omits public target/input validation and graph compilation. It is not a public compiled-graph API.",
       "Paused-continue timing excludes a fresh Exec.start per sample; its resource run includes start and the paused barrier.",
       "Focused cases run once per profile, outside the size/payload matrix. Ready timing covers 100 reads and retains the last descriptor list; resource runs include setup and completion. Collector timing excludes its 32-producer setup wave.",
+      "Public start cases time Exec.start and finish the execution during the result check. They are not directly comparable to internal prepared reuse. Collection, boundary, and lifecycle cases use their own bounded sizes.",
       "Comparisons show raw ratios. No speedup claim is valid from these shared-host measurements. Repeat on an idle host with the same environment."
     ]
   end

--- a/bench/support/suite.exs
+++ b/bench/support/suite.exs
@@ -1,10 +1,11 @@
 Code.require_file("fixtures.exs", __DIR__)
 Code.require_file("measure.exs", __DIR__)
 Code.require_file("report.exs", __DIR__)
+Code.require_file("memory_cases.exs", __DIR__)
 
 defmodule JidoActionBench.Suite do
   @moduledoc false
-  alias JidoActionBench.{Fixtures, Measure, Report}
+  alias JidoActionBench.{Fixtures, Measure, MemoryCases, Report}
 
   def run(profile) do
     settings = settings(profile)
@@ -13,16 +14,8 @@ defmodule JidoActionBench.Suite do
     try do
       :ok = check_growth!()
 
-      workloads =
-        for count <- settings.sizes,
-            payload <- settings.payloads,
-            workload <- Fixtures.workloads(count, payload) do
-          Map.merge(workload, %{
-            id: "#{workload.name}/#{payload}/#{count}",
-            count: count,
-            payload: payload
-          })
-        end
+      workloads = Fixtures.workloads(settings.sizes, settings.payloads)
+      workloads = if profile == "smoke", do: workloads, else: workloads ++ MemoryCases.workloads()
 
       # The untimed growth preflight is complete. Time every workload before
       # its traced resource run and retained-term transfer probe.
@@ -40,19 +33,19 @@ defmodule JidoActionBench.Suite do
           %{
             id: workload.id,
             timing: Map.fetch!(timings, workload.id),
-            resources: Measure.resources(workload),
-            retained_term: Measure.term_size(workload.retained)
+            resources: Measure.resources(workload, settings.resource_samples),
+            retained_terms: Measure.retained(workload)
           }
         end)
 
       %{
-        schema_version: 1,
+        schema_version: 2,
         source: source(),
         environment: environment(),
         settings: settings,
         recorded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
         method:
-          "untraced monotonic clock; caller reductions; separate traced barrier samples; monitored term transfer",
+          "untraced monotonic clock; caller reductions; repeated traced barrier samples; monitored execution-term transfer",
         limitations: Report.limitations(),
         growth_check: "passed: compiled serial, parallel, and Subflow graphs at sizes 2 and 6",
         cases: cases
@@ -95,7 +88,7 @@ defmodule JidoActionBench.Suite do
       payloads: [:small, :large_map, :large_binary],
       warmup: 3,
       samples: 15,
-      resource_samples: 1
+      resource_samples: 3
     }
 
   defp settings("scale"),
@@ -105,7 +98,7 @@ defmodule JidoActionBench.Suite do
       payloads: [:small, :large_map, :large_binary],
       warmup: 5,
       samples: 30,
-      resource_samples: 1
+      resource_samples: 3
     }
 
   defp settings("smoke"),

--- a/bench/support/suite.exs
+++ b/bench/support/suite.exs
@@ -2,20 +2,35 @@ Code.require_file("fixtures.exs", __DIR__)
 Code.require_file("measure.exs", __DIR__)
 Code.require_file("report.exs", __DIR__)
 Code.require_file("memory_cases.exs", __DIR__)
+Code.require_file("component_cases.exs", __DIR__)
+Code.require_file("boundary_cases.exs", __DIR__)
+Code.require_file("lifecycle_cases.exs", __DIR__)
 
 defmodule JidoActionBench.Suite do
   @moduledoc false
-  alias JidoActionBench.{Fixtures, Measure, MemoryCases, Report}
+  alias JidoActionBench.{
+    BoundaryCases,
+    ComponentCases,
+    Fixtures,
+    LifecycleCases,
+    Measure,
+    MemoryCases,
+    Report
+  }
 
-  def run(profile) do
-    settings = settings(profile)
+  def run(profile, filter \\ nil) do
+    settings = Map.put(settings(profile), :filter, filter)
     {:ok, supervisor} = Task.Supervisor.start_link(name: JidoActionBench.TaskSupervisor)
 
     try do
       :ok = check_growth!()
 
-      workloads = Fixtures.workloads(settings.sizes, settings.payloads)
-      workloads = if profile == "smoke", do: workloads, else: workloads ++ MemoryCases.workloads()
+      workloads = workloads(profile)
+
+      workloads =
+        if filter, do: Enum.filter(workloads, &String.contains?(&1.id, filter)), else: workloads
+
+      if workloads == [], do: raise(ArgumentError, "no benchmark cases match the filter")
 
       # The untimed growth preflight is complete. Time every workload before
       # its traced resource run and retained-term transfer probe.
@@ -39,19 +54,45 @@ defmodule JidoActionBench.Suite do
         end)
 
       %{
-        schema_version: 2,
+        schema_version: 3,
         source: source(),
         environment: environment(),
         settings: settings,
         recorded_at: DateTime.utc_now() |> DateTime.to_iso8601(),
         method:
-          "untraced monotonic clock; caller reductions; repeated traced barrier samples; monitored execution-term transfer",
+          "untraced monotonic clock; caller reductions; traced ownership and GC events; barrier reduction and memory samples; monitored execution-term transfer",
         limitations: Report.limitations(),
         growth_check: "passed: compiled serial, parallel, and Subflow graphs at sizes 2 and 6",
         cases: cases
       }
     after
       Supervisor.stop(supervisor)
+    end
+  end
+
+  def workloads(profile) do
+    settings = settings(profile)
+    standard = Fixtures.workloads(settings.sizes, settings.payloads)
+
+    expanded =
+      ComponentCases.workloads() ++ BoundaryCases.workloads() ++ LifecycleCases.workloads()
+
+    if profile == "smoke" do
+      smoke = [
+        "component/map/1/continue",
+        "component/reduce/1/continue",
+        "component/iterate/1/continue",
+        "component/choice/0/continue",
+        "component/dispatch/run",
+        "expr/validate/nested",
+        "schema/struct/true/200",
+        "codec/encode_explicit/16",
+        "lifecycle/cancel"
+      ]
+
+      standard ++ Enum.filter(expanded, &(&1.id in smoke))
+    else
+      standard ++ MemoryCases.workloads() ++ expanded
     end
   end
 
@@ -111,7 +152,17 @@ defmodule JidoActionBench.Suite do
       resource_samples: 1
     }
 
-  defp settings(_), do: raise(ArgumentError, "profile must be short, scale, or smoke")
+  defp settings("backlog"),
+    do: %{
+      profile: "backlog",
+      sizes: [4],
+      payloads: [:small],
+      warmup: 3,
+      samples: 15,
+      resource_samples: 3
+    }
+
+  defp settings(_), do: raise(ArgumentError, "profile must be short, scale, smoke, or backlog")
 
   defp source do
     files = Path.wildcard(Path.expand("../**/*.exs", __DIR__)) |> Enum.sort()

--- a/guides/benchmarks.md
+++ b/guides/benchmarks.md
@@ -12,14 +12,16 @@ are ignored by Git.
 
 | Profile | Cases | Graph sizes | Warm-up calls | Timing samples |
 | --- | ---: | --- | ---: | ---: |
-| `short` (default) | 57 | 4 | 3 | 15 |
-| `scale` | 171 | 2, 8, 16 | 5 | 30 |
-| `smoke` | 38 | 2, 6 | 1 | 2 |
+| `short` (default) | 75 | 4 | 3 | 15 |
+| `scale` | 165 | 2, 8, 16 | 5 | 30 |
+| `smoke` | 34 | 2, 6 | 1 | 2 |
 
 Select a profile with `--profile scale` or `--profile smoke`. Short and scale
 use small data, a 1,000-entry map, and a 1 MiB binary. Smoke uses small data.
-Each case also takes one separate resource sample. Fixtures allow 1–32 nodes;
-a transfer probe rejects a flat heap above 64 MiB.
+Short and scale take three separate resource samples per case; smoke takes
+one. Reports keep the raw samples and field medians. Action cases run once per
+payload, since graph size does not affect them. Standard graph fixtures allow
+1–32 nodes; a transfer probe rejects a flat heap above 64 MiB.
 
 ## What Is Measured
 
@@ -29,10 +31,22 @@ measure validation, compilation, complete execution, compiled-graph reuse,
 and continuation of a paused execution. Every sample must return the expected
 result. The Actions perform no network work.
 
+Short and scale also run 18 fixed memory cases, outside the graph-size matrix:
+
+- Compile and pause four Steps or Subflows with empty metadata, a 5,000-item
+  list, or a 1 MiB binary.
+- Execute small or large input with a small success result or a fixed error.
+  Large input includes a 5,000-item list that the Action does not use.
+- Read `Exec.ready/1` 100 times on 16 nodes, retaining the last descriptor list.
+- Run one collector after a wave of 32 producers. Collector timing excludes
+  the producer wave; resource measurements include it.
+
 Compilation includes validation. The internal compiled-graph adapter omits
 public target/input validation and creates a fresh execution each time. It is
 not a public cache API. Paused-continue setup is outside the timing boundary;
 resource measurements include setup.
+Ready-call timing also excludes completion of its execution; resource
+measurements include completion.
 
 Timing samples run without tracing. The clock covers the operation only;
 setup and result checks are outside it. Reports include raw samples and
@@ -48,10 +62,17 @@ probe. Reports separate these quantities:
 | Process memory and heap | Sum across the observed caller and helpers. |
 | Shared binary bytes | Unique observed off-heap references; ownership can be shared. |
 | VM memory | Whole-VM use, including unrelated work and measurement tools. |
-| Observed peak | Largest barrier sample; short allocations can be missed. |
+| Observed peak | Largest start, callback, pause, or result barrier sample; short allocations can be missed. |
 | Local and flat term heap | Heap with and without local sharing; excludes binary payloads. |
 | Copied term heap and receiver memory | Measured after an actual process transfer. |
 | External bytes | External term encoding size, not message-copy cost. |
+
+Retained-term probes make a separate checked call. They measure the relevant
+Flow, compiled graph, result, or actual paused and finished Execution values.
+Failure records are measured separately from the full failed execution.
+Paused values are copied after their execution is finished. The Markdown
+report shows process memory, binary memory, and named copied-term sizes;
+the JSON also keeps every resource sample.
 
 Exact memory peaks and total helper reductions are unavailable. Reports mark
 these fields as null and record runtime, machine, commit, tool hash, lockfile
@@ -72,6 +93,9 @@ ERL_FLAGS='+S 2:2' mix run bench/compare.exs \
 
 Comparison requires matching environments, settings, methods, tool hashes,
 and case IDs. A ratio is the candidate median divided by the baseline median.
+Schema version 2 uses named retained terms and resource-sample medians. It
+cannot be compared with version 1 reports; rerun both revisions with the same
+benchmark scripts when making a new comparison.
 Host load and garbage collection can change results; repeat measurements
 before making a performance claim. CI has no fixed timing threshold.
 

--- a/guides/benchmarks.md
+++ b/guides/benchmarks.md
@@ -12,9 +12,10 @@ are ignored by Git.
 
 | Profile | Cases | Graph sizes | Warm-up calls | Timing samples |
 | --- | ---: | --- | ---: | ---: |
-| `short` (default) | 75 | 4 | 3 | 15 |
-| `scale` | 165 | 2, 8, 16 | 5 | 30 |
-| `smoke` | 34 | 2, 6 | 1 | 2 |
+| `short` (default) | 222 | 4 | 3 | 15 |
+| `scale` | 312 | 2, 8, 16 | 5 | 30 |
+| `smoke` | 43 | 2, 6 | 1 | 2 |
+| `backlog` | 184 | 4 | 3 | 15 |
 
 Select a profile with `--profile scale` or `--profile smoke`. Short and scale
 use small data, a 1,000-entry map, and a 1 MiB binary. Smoke uses small data.
@@ -22,6 +23,9 @@ Short and scale take three separate resource samples per case; smoke takes
 one. Reports keep the raw samples and field medians. Action cases run once per
 payload, since graph size does not affect them. Standard graph fixtures allow
 1–32 nodes; a transfer probe rejects a flat heap above 64 MiB.
+
+`backlog` keeps small standard payloads and all focused cases. Use
+`--filter SUBSTRING` to select case IDs. Comparisons require the same filter.
 
 ## What Is Measured
 
@@ -40,6 +44,14 @@ Short and scale also run 18 fixed memory cases, outside the graph-size matrix:
 - Read `Exec.ready/1` 100 times on 16 nodes, retaining the last descriptor list.
 - Run one collector after a wave of 32 producers. Collector timing excludes
   the producer wave; resource measurements include it.
+
+The focused cases also cover Map, Reduce, Iterate, Choice, Dispatch,
+component metadata, terminal-only output, large context, shared terms, binary
+slices, expression walks, schemas, Codec, IDs, and step/wave scheduling.
+Lifecycle cases cover cancellation, expired deadlines, caller exit, repeated
+async calls with unrelated mailbox messages, and telemetry handlers. The smoke
+profile includes nine small cases from these groups. Larger collection cases
+use up to 16 items; they do not establish behavior at unbounded fan-out.
 
 Compilation includes validation. The internal compiled-graph adapter omits
 public target/input validation and creates a fresh execution each time. It is
@@ -77,6 +89,9 @@ the JSON also keeps every resource sample.
 Exact memory peaks and total helper reductions are unavailable. Reports mark
 these fields as null and record runtime, machine, commit, tool hash, lockfile
 hash, sample settings, and measurement limits.
+Resource reports also record owned garbage collections, observed mailbox size,
+and reductions sampled at barriers. Observed worker reductions are a lower
+bound. They are separate from caller reductions in untraced timing runs.
 
 ## Compare Runs
 
@@ -93,12 +108,22 @@ ERL_FLAGS='+S 2:2' mix run bench/compare.exs \
 
 Comparison requires matching environments, settings, methods, tool hashes,
 and case IDs. A ratio is the candidate median divided by the baseline median.
-Schema version 2 uses named retained terms and resource-sample medians. It
-cannot be compared with version 1 reports; rerun both revisions with the same
-benchmark scripts when making a new comparison.
+Schema version 3 adds garbage-collection tracing and observed worker reductions.
+Rerun both revisions with the same benchmark scripts when changing the schema.
 Host load and garbage collection can change results; repeat measurements
 before making a performance claim. CI has no fixed timing threshold.
 
 The smoke profile runs in CI and checks results, cleanup, graph transfer, and
-bounded copy growth. The suite does not yet cover Map, Reduce, Iterate,
-continuations, concurrent callers, or a complete failure matrix.
+bounded copy growth. The suite does not cover distributed callers or a complete
+failure matrix.
+
+For release measurements, use the existing isolated consumer fixture:
+
+```bash
+ERL_FLAGS='+S 2:2' MIX_ENV=test mix run bench/release.exs bench/results/release
+```
+
+This writes `release.json` with release size, generated module size, memory
+after startup, first-call time, and warm timings. It compares two-step inline
+and explicit Flows in fresh VMs, after removing consumer source. ERTS size and
+VM boot time are excluded.

--- a/lib/jido_action/validation.ex
+++ b/lib/jido_action/validation.ex
@@ -135,18 +135,14 @@ defmodule Jido.Action.Validation do
 
   defp open_root_object(schema), do: schema
 
-  defp split_known_fields(data, fields, coerce?) do
-    normalize_key = if coerce?, do: &to_string/1, else: &Function.identity/1
+  defp split_known_fields(data, fields, false) do
+    Map.split(data, Enum.map(fields, &elem(&1, 0)))
+  end
 
-    known_keys =
-      fields
-      |> Enum.map(fn {key, _schema} -> normalize_key.(key) end)
-      |> MapSet.new()
-
-    data
-    |> Map.to_list()
-    |> Enum.split_with(fn {key, _value} -> MapSet.member?(known_keys, normalize_key.(key)) end)
-    |> then(fn {known, unknown} -> {Map.new(known), Map.new(unknown)} end)
+  defp split_known_fields(data, fields, true) do
+    known_keys = MapSet.new(fields, fn {key, _schema} -> to_string(key) end)
+    keys = Enum.filter(Map.keys(data), &MapSet.member?(known_keys, to_string(&1)))
+    Map.split(data, keys)
   end
 
   defp handle_validation_result({{:ok, validated}, unknown}, schema, _details) do

--- a/lib/jido_exec/execution.ex
+++ b/lib/jido_exec/execution.ex
@@ -33,7 +33,7 @@ defmodule Jido.Exec.Execution do
             %{node: String.t() | atom(), runnable_id: term(), error: Exception.t()}
           ],
           engine_error: Exception.t() | nil,
-          finalizer: (term() -> {:ok, term()} | {:error, Exception.t()}),
+          finalizer: (term() -> {:ok, term()} | {:error, Exception.t()}) | nil,
           final_result:
             {:ok, term()}
             | {:error, Exception.t()}

--- a/lib/jido_exec/execution.ex
+++ b/lib/jido_exec/execution.ex
@@ -31,7 +31,7 @@ defmodule Jido.Exec.Execution do
           workflow: Workflow.t(),
           ready: [Runnable.t()],
           work_ref: reference(),
-          runnable_errors: [%{runnable: Runnable.t(), error: Exception.t()}],
+          runnable_errors: [%{node: String.t() | atom(), runnable_id: term(), error: Exception.t()}],
           engine_error: Exception.t() | nil,
           finalizer: (term() -> {:ok, term()} | {:error, Exception.t()}),
           final_result:

--- a/lib/jido_exec/execution.ex
+++ b/lib/jido_exec/execution.ex
@@ -11,7 +11,6 @@ defmodule Jido.Exec.Execution do
   lifecycle.
   """
 
-  alias Jido.Flow
   alias Jido.Flow.Compiled
   alias Runic.Workflow
   alias Runic.Workflow.Runnable
@@ -23,7 +22,6 @@ defmodule Jido.Exec.Execution do
           status: :running | :succeeded | :failed,
           revision: non_neg_integer(),
           guard: :atomics.atomics_ref(),
-          flow: Flow.t(),
           compiled: Compiled.t(),
           input: map(),
           context: map(),
@@ -48,7 +46,6 @@ defmodule Jido.Exec.Execution do
     :status,
     :revision,
     :guard,
-    :flow,
     :compiled,
     :input,
     :context,

--- a/lib/jido_exec/execution.ex
+++ b/lib/jido_exec/execution.ex
@@ -29,7 +29,9 @@ defmodule Jido.Exec.Execution do
           workflow: Workflow.t(),
           ready: [Runnable.t()],
           work_ref: reference(),
-          runnable_errors: [%{node: String.t() | atom(), runnable_id: term(), error: Exception.t()}],
+          runnable_errors: [
+            %{node: String.t() | atom(), runnable_id: term(), error: Exception.t()}
+          ],
           engine_error: Exception.t() | nil,
           finalizer: (term() -> {:ok, term()} | {:error, Exception.t()}),
           final_result:

--- a/lib/jido_exec/flow/engine.ex
+++ b/lib/jido_exec/flow/engine.ex
@@ -44,7 +44,6 @@ defmodule Jido.Exec.Flow.Engine do
       execution_id: execution_id,
       flow: flow.name,
       flow_digest: Flow.Identity.semantic_digest(flow),
-      input: input,
       context: context,
       options: options,
       target_runner: target_runner,

--- a/lib/jido_exec/flow/engine.ex
+++ b/lib/jido_exec/flow/engine.ex
@@ -364,6 +364,7 @@ defmodule Jido.Exec.Flow.Engine do
        execution
        | status: status,
          ready: [],
+         finalizer: nil,
          final_result: final_result
      }}
   end
@@ -376,6 +377,7 @@ defmodule Jido.Exec.Flow.Engine do
        execution
        | status: :succeeded,
          ready: [],
+         finalizer: nil,
          final_result: nil
      }}
   end

--- a/lib/jido_exec/flow/engine.ex
+++ b/lib/jido_exec/flow/engine.ex
@@ -43,7 +43,7 @@ defmodule Jido.Exec.Flow.Engine do
     runtime = %{
       execution_id: execution_id,
       flow: flow.name,
-      flow_digest: Flow.Identity.semantic_digest(flow),
+      flow_digest: compiled.semantic_digest,
       context: context,
       options: options,
       target_runner: target_runner,

--- a/lib/jido_exec/flow/engine.ex
+++ b/lib/jido_exec/flow/engine.ex
@@ -238,7 +238,13 @@ defmodule Jido.Exec.Flow.Engine do
       case runnable do
         %Runnable{status: :failed, error: error} ->
           execution.runnable_errors ++
-            [%{runnable: runnable, error: normalize_error(runnable, error)}]
+            [
+              %{
+                node: runnable_name(runnable),
+                runnable_id: runnable.id,
+                error: normalize_error(runnable, error)
+              }
+            ]
 
         %Runnable{} ->
           execution.runnable_errors
@@ -325,12 +331,7 @@ defmodule Jido.Exec.Flow.Engine do
   end
 
   defp finalize(%Execution{runnable_errors: errors} = execution) when errors != [] do
-    failures =
-      errors
-      |> Enum.map(fn %{runnable: runnable, error: error} ->
-        %{node: runnable_name(runnable), runnable_id: runnable.id, error: error}
-      end)
-      |> Enum.sort_by(& &1.node)
+    failures = Enum.sort_by(errors, & &1.node)
 
     error =
       case failures do

--- a/lib/jido_exec/flow/engine.ex
+++ b/lib/jido_exec/flow/engine.ex
@@ -61,7 +61,6 @@ defmodule Jido.Exec.Flow.Engine do
       status: :running,
       revision: 0,
       guard: ExecutionGuard.new(),
-      flow: flow,
       compiled: compiled,
       input: input,
       context: context,

--- a/lib/jido_exec/flow/inspection.ex
+++ b/lib/jido_exec/flow/inspection.ex
@@ -13,14 +13,12 @@ defmodule Jido.Exec.Flow.Inspection do
     {role, item_index} = item(metadata.role, runnable.input_fact.value)
     status = if runnable.status == :pending, do: :ready, else: runnable.status
 
-    %Work{
-      token: Work.token(execution.work_ref, execution.revision, position),
-      component_path: metadata.component_path,
-      kind: metadata.kind,
-      role: role,
-      item_index: item_index,
-      status: status
-    }
+    Work.new(
+      Map.merge(metadata, %{role: role, item_index: item_index, status: status}),
+      execution.work_ref,
+      execution.revision,
+      position
+    )
   end
 
   defp metadata(%InputBinding{target_component_hash: target}, _workflow, index) do

--- a/lib/jido_exec/flow/inspection.ex
+++ b/lib/jido_exec/flow/inspection.ex
@@ -14,7 +14,7 @@ defmodule Jido.Exec.Flow.Inspection do
     status = if runnable.status == :pending, do: :ready, else: runnable.status
 
     %Work{
-      token: {execution.work_ref, execution.revision, position},
+      token: Work.token(execution.work_ref, execution.revision, position),
       component_path: metadata.component_path,
       kind: metadata.kind,
       role: role,

--- a/lib/jido_exec/flow/inspection.ex
+++ b/lib/jido_exec/flow/inspection.ex
@@ -13,12 +13,14 @@ defmodule Jido.Exec.Flow.Inspection do
     {role, item_index} = item(metadata.role, runnable.input_fact.value)
     status = if runnable.status == :pending, do: :ready, else: runnable.status
 
-    Work.new(
-      Map.merge(metadata, %{role: role, item_index: item_index, status: status}),
-      execution.work_ref,
-      execution.revision,
-      position
-    )
+    %Work{
+      token: {execution.work_ref, execution.revision, position},
+      component_path: metadata.component_path,
+      kind: metadata.kind,
+      role: role,
+      item_index: item_index,
+      status: status
+    }
   end
 
   defp metadata(%InputBinding{target_component_hash: target}, _workflow, index) do

--- a/lib/jido_exec/flow/runnable_executor.ex
+++ b/lib/jido_exec/flow/runnable_executor.ex
@@ -125,10 +125,14 @@ defmodule Jido.Exec.Flow.RunnableExecutor do
     Telemetry.error(span, Error.execution_error("unsupported runnable status", %{status: status}))
   end
 
-  defp authored_component(execution, %Runnable{node: %{name: runnable_name}}) do
-    Enum.find_value(execution.compiled.component_index, fn {name, index} ->
-      if index.output == runnable_name, do: {name, index.kind}
-    end)
+  defp authored_component(execution, %Runnable{node: %{name: runnable_name, hash: hash}}) do
+    with %{component_path: [name]} <- Map.get(execution.compiled.work_index, hash),
+         %{output: ^runnable_name, kind: kind} <-
+           Map.get(execution.compiled.component_index, name) do
+      {name, kind}
+    else
+      _ -> nil
+    end
   end
 
   defp authored_component(_execution, _runnable), do: nil

--- a/lib/jido_exec/telemetry/tracker.ex
+++ b/lib/jido_exec/telemetry/tracker.ex
@@ -27,7 +27,7 @@ defmodule Jido.Exec.Telemetry.Tracker do
   def close(tracker, span, suffix, extra_metadata)
       when is_pid(tracker) and suffix in [:stop, :error] and is_map(extra_metadata) do
     stopped_at = System.monotonic_time()
-    GenServer.call(tracker, {:close, span, suffix, extra_metadata, stopped_at}, @call_timeout)
+    GenServer.call(tracker, {:close, span.id, suffix, extra_metadata, stopped_at}, @call_timeout)
   catch
     :exit, _reason -> :ok
   end
@@ -99,8 +99,8 @@ defmodule Jido.Exec.Telemetry.Tracker do
      }}
   end
 
-  def handle_call({:close, span, suffix, extra_metadata, stopped_at}, _from, state) do
-    case Map.pop(state.spans, span.id) do
+  def handle_call({:close, span_id, suffix, extra_metadata, stopped_at}, _from, state) do
+    case Map.pop(state.spans, span_id) do
       {nil, _spans} ->
         {:reply, :ok, state}
 

--- a/lib/jido_exec/work.ex
+++ b/lib/jido_exec/work.ex
@@ -56,6 +56,10 @@ defmodule Jido.Exec.Work do
   defstruct @enforce_keys
 
   @doc false
+  @spec token(reference(), non_neg_integer(), non_neg_integer()) :: token()
+  def token(execution_ref, revision, position), do: {execution_ref, revision, position}
+
+  @doc false
   @spec position(term(), reference(), non_neg_integer()) :: {:ok, non_neg_integer()} | :error
   def position({execution_ref, revision, position}, execution_ref, revision)
       when is_integer(position) and position >= 0,

--- a/lib/jido_exec/work.ex
+++ b/lib/jido_exec/work.ex
@@ -56,19 +56,6 @@ defmodule Jido.Exec.Work do
   defstruct @enforce_keys
 
   @doc false
-  @spec new(map(), reference(), non_neg_integer(), non_neg_integer()) :: t()
-  def new(attributes, execution_ref, revision, position) do
-    %__MODULE__{
-      token: {execution_ref, revision, position},
-      component_path: attributes.component_path,
-      kind: attributes.kind,
-      role: attributes.role,
-      item_index: attributes.item_index,
-      status: attributes.status
-    }
-  end
-
-  @doc false
   @spec position(term(), reference(), non_neg_integer()) :: {:ok, non_neg_integer()} | :error
   def position({execution_ref, revision, position}, execution_ref, revision)
       when is_integer(position) and position >= 0,

--- a/lib/jido_exec/work.ex
+++ b/lib/jido_exec/work.ex
@@ -56,8 +56,17 @@ defmodule Jido.Exec.Work do
   defstruct @enforce_keys
 
   @doc false
-  @spec token(reference(), non_neg_integer(), non_neg_integer()) :: token()
-  def token(execution_ref, revision, position), do: {execution_ref, revision, position}
+  @spec new(map(), reference(), non_neg_integer(), non_neg_integer()) :: t()
+  def new(attributes, execution_ref, revision, position) do
+    %__MODULE__{
+      token: {execution_ref, revision, position},
+      component_path: attributes.component_path,
+      kind: attributes.kind,
+      role: attributes.role,
+      item_index: attributes.item_index,
+      status: attributes.status
+    }
+  end
 
   @doc false
   @spec position(term(), reference(), non_neg_integer()) :: {:ok, non_neg_integer()} | :error

--- a/lib/jido_exec/work.ex
+++ b/lib/jido_exec/work.ex
@@ -58,7 +58,14 @@ defmodule Jido.Exec.Work do
   @doc false
   @spec new(map(), reference(), non_neg_integer(), non_neg_integer()) :: t()
   def new(attributes, execution_ref, revision, position) do
-    struct!(__MODULE__, Map.put(attributes, :token, {execution_ref, revision, position}))
+    %__MODULE__{
+      token: {execution_ref, revision, position},
+      component_path: attributes.component_path,
+      kind: attributes.kind,
+      role: attributes.role,
+      item_index: attributes.item_index,
+      status: attributes.status
+    }
   end
 
   @doc false

--- a/lib/jido_expr/runtime.ex
+++ b/lib/jido_expr/runtime.ex
@@ -330,11 +330,29 @@ defmodule Jido.Expr.Runtime do
     end
   end
 
-  defp member(_left, [], state, _path, _depth), do: {:ok, false, state}
+  defp member(left, values, state, path, depth),
+    do: member(left, values, state, path, depth, nil)
 
-  defp member(left, [head | tail], state, path, depth) do
-    with {:ok, equal?, state} <- equal(left, head, state, path, depth) do
-      if equal?, do: {:ok, true, state}, else: member(left, tail, state, path, depth)
+  defp member(_left, [], state, _path, _depth, _cost), do: {:ok, false, state}
+
+  defp member(left, [head | tail], state, path, depth, cost) do
+    with {:ok, state, cost} <- membership_left(left, state, path, depth, cost),
+         {:ok, _right, state} <- visit(head, state, path, depth, :data) do
+      if left == head, do: {:ok, true, state}, else: member(left, tail, state, path, depth, cost)
+    end
+  end
+
+  # The left value and its depth do not change during this membership scan.
+  # Keep charging its full cost. Walk again near a limit to keep the first error.
+  defp membership_left(_left, state, _path, _depth, {nodes, bytes} = cost)
+       when state.nodes + nodes <= state.max_nodes and
+              state.bytes + bytes <= state.max_binary_bytes do
+    {:ok, %{state | nodes: state.nodes + nodes, bytes: state.bytes + bytes}, cost}
+  end
+
+  defp membership_left(left, state, path, depth, _cost) do
+    with {:ok, _left, checked} <- visit(left, state, path, depth, :data) do
+      {:ok, checked, {checked.nodes - state.nodes, checked.bytes - state.bytes}}
     end
   end
 

--- a/lib/jido_expr/runtime.ex
+++ b/lib/jido_expr/runtime.ex
@@ -62,11 +62,15 @@ defmodule Jido.Expr.Runtime do
   defp visit_value(%_{} = value, state, path, depth, mode) when mode != :data,
     do: host(value, state, path, depth, mode)
 
-  defp visit_value(value, state, path, depth, mode) when is_map(value),
-    do: map(:maps.iterator(value), state, path, depth, mode, %{})
+  defp visit_value(value, state, path, depth, mode) when is_map(value) do
+    result = if mode in [:data, :validate], do: value, else: %{}
+    map(:maps.iterator(value), state, path, depth, mode, result)
+  end
 
-  defp visit_value(value, state, path, depth, mode) when is_list(value),
-    do: list(value, state, path, depth, mode, 0, [])
+  defp visit_value(value, state, path, depth, mode) when is_list(value) do
+    result = if mode in [:data, :validate], do: value, else: []
+    list(value, state, path, depth, mode, 0, result)
+  end
 
   defp visit_value(value, state, path, depth, :data) when is_tuple(value),
     do: tuple(value, state, path, depth, 0)
@@ -85,7 +89,8 @@ defmodule Jido.Expr.Runtime do
 
       {key, child, iterator} ->
         with {:ok, child, state} <- map_pair(key, child, state, path, depth, mode) do
-          map(iterator, state, path, depth, mode, Map.put(result, key, child))
+          result = if mode in [:data, :validate], do: result, else: Map.put(result, key, child)
+          map(iterator, state, path, depth, mode, result)
         end
     end
   end
@@ -112,18 +117,22 @@ defmodule Jido.Expr.Runtime do
     end
   end
 
+  defp list([], state, _path, _depth, mode, _index, result) when mode in [:data, :validate],
+    do: {:ok, result, state}
+
   defp list([], state, _path, _depth, _mode, _index, result),
     do: {:ok, Enum.reverse(result), state}
 
   defp list([head | tail], state, path, depth, mode, index, result) do
     with {:ok, value, state} <- visit(head, state, path ++ [index], depth + 1, mode) do
-      list(tail, state, path, depth, mode, index + 1, [value | result])
+      result = if mode in [:data, :validate], do: result, else: [value | result]
+      list(tail, state, path, depth, mode, index + 1, result)
     end
   end
 
   defp list(tail, state, path, depth, :data, index, result) do
-    with {:ok, tail, state} <- visit(tail, state, path ++ [index], depth + 1, :data) do
-      {:ok, Enum.reduce(result, tail, &[&1 | &2]), state}
+    with {:ok, _tail, state} <- visit(tail, state, path ++ [index], depth + 1, :data) do
+      {:ok, result, state}
     end
   end
 
@@ -154,9 +163,12 @@ defmodule Jido.Expr.Runtime do
 
   defp expression(%Expr{} = value, state, path, depth, mode)
        when mode in [:validate, :normalize] do
+    result = if mode == :validate, do: value.operands, else: []
+
     with {:ok, operands, state} <-
-           list(value.operands, state, path ++ [:operands], depth, mode, 0, []) do
-      {:ok, %{value | operands: operands}, state}
+           list(value.operands, state, path ++ [:operands], depth, mode, 0, result) do
+      value = if mode == :validate, do: value, else: %{value | operands: operands}
+      {:ok, value, state}
     end
   end
 

--- a/lib/jido_flow/codec.ex
+++ b/lib/jido_flow/codec.ex
@@ -100,8 +100,9 @@ defmodule Jido.Flow.Codec do
   @spec encode(Flow.t()) ::
           {:ok, document(), Registry.t()} | {:error, Exception.t()}
   def encode(flow) do
-    with {:ok, registry} <- Registry.from_flow(flow),
-         {:ok, document} <- encode(flow, registry) do
+    with {:ok, flow} <- Flow.validate_executable(flow),
+         {:ok, registry} <- flow |> Registry.Deriver.entries() |> Registry.new(),
+         {:ok, document} <- encode_validated(flow, registry) do
       {:ok, document, registry}
     end
   end
@@ -109,8 +110,20 @@ defmodule Jido.Flow.Codec do
   @doc "Encodes one canonical Flow as a JSON-compatible document within the reader's limits."
   @spec encode(Flow.t(), Registry.t()) :: {:ok, document()} | {:error, Exception.t()}
   def encode(%Flow{} = flow, %Registry{} = registry) do
-    with {:ok, flow} <- Flow.validate(flow),
-         {:ok, schema} <- Registry.identifier(registry, :schema, flow.schema),
+    with {:ok, flow} <- Flow.validate(flow), do: encode_validated(flow, registry)
+  end
+
+  def encode(value, %Registry{}) do
+    {:error, Error.validation_error("expected a Jido.Flow artifact", %{value: value})}
+  end
+
+  def encode(%Flow{}, registry) do
+    {:error,
+     Error.validation_error("flow codec registry must be a Jido.Flow.Registry", %{value: registry})}
+  end
+
+  defp encode_validated(flow, registry) do
+    with {:ok, schema} <- Registry.identifier(registry, :schema, flow.schema),
          {:ok, output_schema} <- Registry.identifier(registry, :schema, flow.output_schema),
          {:ok, components} <- encode_components(flow.components, registry),
          {:ok, output} <- encode_expression(flow.output, registry, 0) do
@@ -128,15 +141,6 @@ defmodule Jido.Flow.Codec do
 
       with :ok <- validate_document_limits(document), do: {:ok, document}
     end
-  end
-
-  def encode(value, %Registry{}) do
-    {:error, Error.validation_error("expected a Jido.Flow artifact", %{value: value})}
-  end
-
-  def encode(%Flow{}, registry) do
-    {:error,
-     Error.validation_error("flow codec registry must be a Jido.Flow.Registry", %{value: registry})}
   end
 
   @doc "Decodes one stored Flow document through a trusted Registry."
@@ -1611,8 +1615,9 @@ defmodule Jido.Flow.Codec do
 
   defp collection_size(values) when length(values) <= @maximum_collection_size, do: :ok
 
-  defp collection_size(values) when is_map(values) and map_size(values) <= @maximum_collection_size,
-    do: :ok
+  defp collection_size(values)
+       when is_map(values) and map_size(values) <= @maximum_collection_size,
+       do: :ok
 
   defp collection_size(_values),
     do:

--- a/lib/jido_flow/codec.ex
+++ b/lib/jido_flow/codec.ex
@@ -1443,7 +1443,7 @@ defmodule Jido.Flow.Codec do
 
   defp encode_map(map, registry, depth, value_encoder) do
     with :ok <- depth(depth),
-         :ok <- collection_size(Map.to_list(map)),
+         :ok <- collection_size(map),
          {:ok, entries} <- encode_entries(map, registry, depth, value_encoder) do
       entries = Enum.sort_by(entries, fn %{"key" => key} -> :erlang.term_to_binary(key) end)
       {:ok, %{"$type" => "map", "entries" => entries}}
@@ -1610,6 +1610,9 @@ defmodule Jido.Flow.Codec do
        })}
 
   defp collection_size(values) when length(values) <= @maximum_collection_size, do: :ok
+
+  defp collection_size(values) when is_map(values) and map_size(values) <= @maximum_collection_size,
+    do: :ok
 
   defp collection_size(_values),
     do:

--- a/lib/jido_flow/compiled.ex
+++ b/lib/jido_flow/compiled.ex
@@ -23,15 +23,24 @@ defmodule Jido.Flow.Compiled do
           work_index: map(),
           output: Jido.Flow.Expression.t(),
           source_map: source_map(),
+          semantic_digest: binary(),
           compilation_digest: binary()
         }
 
-  @enforce_keys [:workflow, :component_index, :output, :source_map, :compilation_digest]
+  @enforce_keys [
+    :workflow,
+    :component_index,
+    :output,
+    :source_map,
+    :semantic_digest,
+    :compilation_digest
+  ]
   defstruct [
     :workflow,
     :component_index,
     :output,
     :source_map,
+    :semantic_digest,
     :compilation_digest,
     work_index: %{}
   ]

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -533,7 +533,10 @@ defmodule Jido.Flow.Compiler do
                 do: %{status: :ok, value: output},
                 else: output
 
-            token |> Map.put(:kind, :result) |> Map.put(:output, output) |> Map.drop([:item, :results])
+            token
+            |> Map.put(:kind, :result)
+            |> Map.put(:output, output)
+            |> Map.drop([:item, :results])
 
           {:collect_errors, {:error, error}} ->
             runtime.observer.({:error, span, error})

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -1075,10 +1075,12 @@ defmodule Jido.Flow.Compiler do
         [{_name, output} | _rest] -> input_of(output)
       end
 
-    results =
-      values
-      |> Enum.filter(fn {name, _value} -> name in references end)
-      |> Map.new(fn {name, result} -> {name, unwrap_value(result)} end)
+    referenced =
+      if dependencies == references,
+        do: values,
+        else: Enum.filter(values, fn {name, _value} -> name in references end)
+
+    results = Map.new(referenced, fn {name, result} -> {name, unwrap_value(result)} end)
 
     base_runtime_state(runtime, frame, results)
   end

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -305,22 +305,24 @@ defmodule Jido.Flow.Compiler do
 
     flow.components
     |> Graph.canonical_components()
-    |> Enum.reduce(initial, &add_component/2)
+    |> Enum.reduce(initial, fn component, state ->
+      # Identity uses the authored Flow. Runtime callbacks do not need metadata.
+      add_component(%{component | meta: %{}}, state)
+    end)
   end
 
   defp add_component(%FlowStep{} = component, state) do
     namespace = state.namespace
-    runtime_component = %{component | meta: %{}}
 
     step =
       runtime_step(state, component.name, :step, fn parent, runtime ->
-        local = component_state(runtime_component, parent, runtime)
+        local = component_state(component, parent, runtime)
 
         local
         |> resolve_and_run(
-          runtime_component.params,
-          runtime_component.action,
-          Target.at(Target.node(runtime_component), namespace)
+          component.params,
+          component.action,
+          Target.at(Target.node(component), namespace)
         )
         |> wrap_result()
       end)
@@ -818,8 +820,6 @@ defmodule Jido.Flow.Compiler do
   end
 
   defp add_subflow(subflow, state) do
-    subflow = %{subflow | meta: %{}}
-
     if subflow.flow in state.module_stack do
       raise Error.validation_error("recursive Subflow reference", %{
               component: subflow.name,

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -310,16 +310,17 @@ defmodule Jido.Flow.Compiler do
 
   defp add_component(%FlowStep{} = component, state) do
     namespace = state.namespace
+    runtime_component = %{component | meta: %{}}
 
     step =
       runtime_step(state, component.name, :step, fn parent, runtime ->
-        local = component_state(component, parent, runtime)
+        local = component_state(runtime_component, parent, runtime)
 
         local
         |> resolve_and_run(
-          component.params,
-          component.action,
-          Target.at(Target.node(component), namespace)
+          runtime_component.params,
+          runtime_component.action,
+          Target.at(Target.node(runtime_component), namespace)
         )
         |> wrap_result()
       end)

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -532,7 +532,7 @@ defmodule Jido.Flow.Compiler do
                 do: %{status: :ok, value: output},
                 else: output
 
-            token |> Map.put(:kind, :result) |> Map.put(:output, output) |> Map.delete(:item)
+            token |> Map.put(:kind, :result) |> Map.put(:output, output) |> Map.drop([:item, :results])
 
           {:collect_errors, {:error, error}} ->
             runtime.observer.({:error, span, error})
@@ -543,7 +543,7 @@ defmodule Jido.Flow.Compiler do
               status: :error,
               error: Error.to_map(error)
             })
-            |> Map.delete(:item)
+            |> Map.drop([:item, :results])
 
           {:fail_fast, {:error, error}} ->
             runtime.observer.({:error, span, error})

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -818,6 +818,8 @@ defmodule Jido.Flow.Compiler do
   end
 
   defp add_subflow(subflow, state) do
+    subflow = %{subflow | meta: %{}}
+
     if subflow.flow in state.module_stack do
       raise Error.validation_error("recursive Subflow reference", %{
               component: subflow.name,

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -1216,7 +1216,7 @@ defmodule Jido.Flow.Compiler do
   defp stable_hash(value), do: Components.fact_hash({:jido_flow, @compiler_version, value})
 
   defp digest(value) do
-    :crypto.hash(:sha256, :erlang.term_to_binary(value, [:deterministic]))
+    Identity.hash_term(value)
     |> Base.encode16(case: :lower)
   end
 

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -1099,8 +1099,7 @@ defmodule Jido.Flow.Compiler do
       results: results,
       options: runtime.options,
       target_runner: runtime.target_runner,
-      observer: runtime.observer,
-      map_nodes: MapSet.new()
+      observer: runtime.observer
     }
   end
 

--- a/lib/jido_flow/compiler.ex
+++ b/lib/jido_flow/compiler.ex
@@ -112,6 +112,7 @@ defmodule Jido.Flow.Compiler do
          work_index: state.work_index,
          output: flow.output,
          source_map: state.source_map,
+         semantic_digest: digest_data.flow,
          compilation_digest: digest(digest_data)
        }}
     rescue

--- a/lib/jido_flow/compiler/expression.ex
+++ b/lib/jido_flow/compiler/expression.ex
@@ -217,15 +217,12 @@ defmodule Jido.Flow.Compiler.Expression do
   defp list_at(_tail, _index), do: :error
 
   defp fetch_key(map, key) do
-    cond do
-      Map.has_key?(map, key) ->
-        Map.fetch(map, key)
-
-      is_atom(key) and Map.has_key?(map, Atom.to_string(key)) ->
+    case Map.fetch(map, key) do
+      :error when is_atom(key) ->
         Map.fetch(map, Atom.to_string(key))
 
-      true ->
-        :error
+      result ->
+        result
     end
   end
 

--- a/lib/jido_flow/compiler/payload.ex
+++ b/lib/jido_flow/compiler/payload.ex
@@ -24,7 +24,17 @@ end
 
 defimpl Runic.Identity.Projectable, for: Jido.Flow.Compiler.Payload do
   def identity_document(%{value: value}) do
-    bytes = :erlang.term_to_binary(value, [:deterministic])
-    {:jido_local_beam_value, 1, :crypto.hash(:sha256, bytes)}
+    digest =
+      case :erlang.term_to_iovec(value, [:deterministic]) do
+        [bytes] ->
+          :crypto.hash(:sha256, bytes)
+
+        segments ->
+          segments
+          |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+          |> :crypto.hash_final()
+      end
+
+    {:jido_local_beam_value, 1, digest}
   end
 end

--- a/lib/jido_flow/compiler/payload.ex
+++ b/lib/jido_flow/compiler/payload.ex
@@ -24,17 +24,6 @@ end
 
 defimpl Runic.Identity.Projectable, for: Jido.Flow.Compiler.Payload do
   def identity_document(%{value: value}) do
-    digest =
-      case :erlang.term_to_iovec(value, [:deterministic]) do
-        [bytes] ->
-          :crypto.hash(:sha256, bytes)
-
-        segments ->
-          segments
-          |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
-          |> :crypto.hash_final()
-      end
-
-    {:jido_local_beam_value, 1, digest}
+    {:jido_local_beam_value, 1, Jido.Flow.Identity.hash_term(value)}
   end
 end

--- a/lib/jido_flow/data.ex
+++ b/lib/jido_flow/data.ex
@@ -31,29 +31,29 @@ defmodule Jido.Flow.Data do
   @spec validate_key(term()) :: :ok | {:error, Error.InvalidDefinitionError.t()}
   def validate_key(key), do: validate_key(key, [])
 
-  defp validate(value, _path)
+  defp validate(value, _path_rev)
        when is_nil(value) or is_boolean(value) or is_integer(value) or is_float(value) or
               is_atom(value),
        do: :ok
 
-  defp validate(value, path) when is_binary(value) do
+  defp validate(value, path_rev) when is_binary(value) do
     if String.valid?(value),
       do: :ok,
-      else: error("flow data strings must be valid UTF-8", path)
+      else: error("flow data strings must be valid UTF-8", path_rev)
   end
 
-  defp validate(value, path) when is_list(value) do
+  defp validate(value, path_rev) when is_list(value) do
     if List.improper?(value) do
-      error("flow data must contain proper lists", path)
+      error("flow data must contain proper lists", path_rev)
     else
-      validate_list(value, path, 0)
+      validate_list(value, path_rev, 0)
     end
   end
 
-  defp validate(value, path) when is_map(value) and not is_struct(value) do
+  defp validate(value, path_rev) when is_map(value) and not is_struct(value) do
     Enum.reduce_while(value, :ok, fn {key, item}, :ok ->
-      with :ok <- validate_key(key, path),
-           :ok <- validate(item, path ++ [key]) do
+      with :ok <- validate_key(key, path_rev),
+           :ok <- validate(item, [key | path_rev]) do
         {:cont, :ok}
       else
         {:error, error} -> {:halt, {:error, error}}
@@ -61,37 +61,38 @@ defmodule Jido.Flow.Data do
     end)
   end
 
-  defp validate(value, path) do
+  defp validate(value, path_rev) do
     {:error,
      Error.validation_error("flow data contains an unsupported value", %{
-       path: path,
+       path: Enum.reverse(path_rev),
        value_type: value_type(value)
      })}
   end
 
-  defp validate_list([], _path, _index), do: :ok
+  defp validate_list([], _path_rev, _index), do: :ok
 
-  defp validate_list([item | rest], path, index) do
-    with :ok <- validate(item, path ++ [index]) do
-      validate_list(rest, path, index + 1)
+  defp validate_list([item | rest], path_rev, index) do
+    with :ok <- validate(item, [index | path_rev]) do
+      validate_list(rest, path_rev, index + 1)
     end
   end
 
-  defp validate_key(key, path) when is_binary(key), do: validate(key, path)
+  defp validate_key(key, path_rev) when is_binary(key), do: validate(key, path_rev)
 
-  defp validate_key(key, _path)
+  defp validate_key(key, _path_rev)
        when (is_integer(key) and key >= 0) or (is_atom(key) and not is_nil(key)),
        do: :ok
 
-  defp validate_key(key, path) do
+  defp validate_key(key, path_rev) do
     {:error,
      Error.validation_error("flow data contains an unsupported map key", %{
-       path: path,
+       path: Enum.reverse(path_rev),
        key: key
      })}
   end
 
-  defp error(message, path), do: {:error, Error.validation_error(message, %{path: path})}
+  defp error(message, path_rev),
+    do: {:error, Error.validation_error(message, %{path: Enum.reverse(path_rev)})}
 
   defp value_type(value) when is_tuple(value), do: :tuple
   defp value_type(value) when is_function(value), do: :function

--- a/lib/jido_flow/data.ex
+++ b/lib/jido_flow/data.ex
@@ -46,14 +46,7 @@ defmodule Jido.Flow.Data do
     if List.improper?(value) do
       error("flow data must contain proper lists", path)
     else
-      value
-      |> Enum.with_index()
-      |> Enum.reduce_while(:ok, fn {item, index}, :ok ->
-        case validate(item, path ++ [index]) do
-          :ok -> {:cont, :ok}
-          {:error, error} -> {:halt, {:error, error}}
-        end
-      end)
+      validate_list(value, path, 0)
     end
   end
 
@@ -74,6 +67,14 @@ defmodule Jido.Flow.Data do
        path: path,
        value_type: value_type(value)
      })}
+  end
+
+  defp validate_list([], _path, _index), do: :ok
+
+  defp validate_list([item | rest], path, index) do
+    with :ok <- validate(item, path ++ [index]) do
+      validate_list(rest, path, index + 1)
+    end
   end
 
   defp validate_key(key, path) when is_binary(key), do: validate(key, path)

--- a/lib/jido_flow/expression.ex
+++ b/lib/jido_flow/expression.ex
@@ -186,29 +186,24 @@ defmodule Jido.Flow.Expression do
 
   defp normalize_leaf(value, path), do: do_normalize(value, path)
 
-  defp validate_proper_list(list, path, scope, operation_checked?) do
-    list
-    |> Enum.with_index()
-    |> Enum.reduce_while(:ok, fn {value, index}, :ok ->
-      case do_validate(value, path ++ [index], scope, operation_checked?) do
-        :ok -> {:cont, :ok}
-        {:error, error} -> {:halt, {:error, error}}
-      end
-    end)
+  defp validate_proper_list(list, path, scope, operation_checked?),
+    do: validate_list(list, path, scope, operation_checked?, 0)
+
+  defp validate_list([], _path, _scope, _operation_checked?, _index), do: :ok
+
+  defp validate_list([value | rest], path, scope, operation_checked?, index) do
+    with :ok <- do_validate(value, path ++ [index], scope, operation_checked?) do
+      validate_list(rest, path, scope, operation_checked?, index + 1)
+    end
   end
 
-  defp normalize_proper_list(list, path) do
-    list
-    |> Enum.with_index()
-    |> Enum.reduce_while({:ok, []}, fn {value, index}, {:ok, acc} ->
-      case do_normalize(value, path ++ [index]) do
-        {:ok, value} -> {:cont, {:ok, [value | acc]}}
-        {:error, error} -> {:halt, {:error, error}}
-      end
-    end)
-    |> case do
-      {:ok, values} -> {:ok, Enum.reverse(values)}
-      {:error, error} -> {:error, error}
+  defp normalize_proper_list(list, path), do: normalize_list(list, path, 0, [])
+
+  defp normalize_list([], _path, _index, values), do: {:ok, Enum.reverse(values)}
+
+  defp normalize_list([value | rest], path, index, values) do
+    with {:ok, value} <- do_normalize(value, path ++ [index]) do
+      normalize_list(rest, path, index + 1, [value | values])
     end
   end
 

--- a/lib/jido_flow/identity.ex
+++ b/lib/jido_flow/identity.ex
@@ -16,8 +16,9 @@ defmodule Jido.Flow.Identity do
   @spec semantic_digest(Flow.t()) :: String.t()
   def semantic_digest(%Flow{} = flow) do
     flow
-    |> for_flow()
-    |> Map.fetch!(:digest)
+    |> identity_data()
+    |> identity_hash()
+    |> Base.encode16(case: :lower)
   end
 
   @doc false
@@ -51,9 +52,7 @@ defmodule Jido.Flow.Identity do
           uuid: String.t()
         }
   def identity(canonical_identity_map) when is_map(canonical_identity_map) do
-    raw_digest =
-      {:jido_flow_identity, @identity_version, canonical_identity_map}
-      |> hash_term()
+    raw_digest = identity_hash(canonical_identity_map)
 
     %{
       version: @identity_version,
@@ -62,6 +61,8 @@ defmodule Jido.Flow.Identity do
       uuid: uuid_v8(raw_digest)
     }
   end
+
+  defp identity_hash(data), do: hash_term({:jido_flow_identity, @identity_version, data})
 
   @doc false
   @spec item_uuid(String.t(), String.t(), non_neg_integer()) :: String.t()

--- a/lib/jido_flow/identity.ex
+++ b/lib/jido_flow/identity.ex
@@ -107,10 +107,16 @@ defmodule Jido.Flow.Identity do
     version_bits = bor(band(version_bits, 0x0FFF), 0x8000)
     variant_bits = bor(band(variant_bits, 0x3FFF), 0x8000)
 
-    :io_lib.format(
-      ~c"~8.16.0b-~4.16.0b-~4.16.0b-~4.16.0b-~12.16.0b",
-      [time_low, time_mid, version_bits, variant_bits, node]
-    )
-    |> IO.iodata_to_binary()
+    <<first::binary-size(8), second::binary-size(4), third::binary-size(4),
+      fourth::binary-size(4), fifth::binary-size(12)>> =
+      Base.encode16(
+        <<time_low::32, time_mid::16, version_bits::16, variant_bits::16, node::48>>,
+        case: :lower
+      )
+
+    # Keep the 36-byte ID on the heap instead of retaining the append buffer.
+    <<first::binary, "-", second::binary, "-", third::binary, "-", fourth::binary, "-",
+      fifth::binary>>
+    |> :binary.copy()
   end
 end

--- a/lib/jido_flow/identity.ex
+++ b/lib/jido_flow/identity.ex
@@ -88,9 +88,15 @@ defmodule Jido.Flow.Identity do
   @doc false
   @spec hash_term(term()) :: binary()
   def hash_term(term) do
-    term
-    |> :erlang.term_to_binary([:deterministic])
-    |> then(&:crypto.hash(:sha256, &1))
+    case :erlang.term_to_iovec(term, [:deterministic]) do
+      [bytes] ->
+        :crypto.hash(:sha256, bytes)
+
+      segments ->
+        segments
+        |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+        |> :crypto.hash_final()
+    end
   end
 
   @doc false

--- a/test/bench/execution_bench_test.exs
+++ b/test/bench/execution_bench_test.exs
@@ -3,7 +3,16 @@ Code.require_file("../../bench/support/suite.exs", __DIR__)
 defmodule JidoActionTest.ExecutionBenchTest do
   use ExUnit.Case, async: false
 
-  alias JidoActionBench.{Fixtures, Measure, MemoryCases, Report, Suite}
+  alias JidoActionBench.{
+    BoundaryCases,
+    ComponentCases,
+    Fixtures,
+    LifecycleCases,
+    Measure,
+    MemoryCases,
+    Report,
+    Suite
+  }
 
   setup do
     start_supervised!({Task.Supervisor, name: JidoActionBench.TaskSupervisor})
@@ -103,6 +112,27 @@ defmodule JidoActionTest.ExecutionBenchTest do
     workload = %{setup: fn _ -> nil end, run: fn _ -> :wrong end, check: fn :right -> :ok end}
     assert_raise FunctionClauseError, fn -> Measure.timing(workload, 1, 1) end
     assert_raise RuntimeError, ~r/resource caller failed/, fn -> Measure.resources(workload) end
+  end
+
+  test "expanded cases preserve results and release their owned processes" do
+    workloads =
+      ComponentCases.workloads() ++ BoundaryCases.workloads() ++ LifecycleCases.workloads()
+
+    assert length(Enum.uniq_by(workloads, & &1.id)) == length(workloads)
+
+    for workload <- workloads do
+      assert length(Measure.timing(workload, 1, 1).wall_ns.samples) == 1
+      resources = Measure.resources(workload).median
+      assert resources.owned_remaining == 0
+      assert resources.observed_helper_reductions >= 0
+      assert resources.owned_gc_count >= 0
+
+      for {_name, measured} <- Measure.retained(workload) do
+        assert measured.copied_flat_heap_bytes == measured.flat_heap_bytes
+      end
+
+      assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
+    end
   end
 
   test "a failed probe stops and confirms its waiting child and grandchild" do

--- a/test/bench/execution_bench_test.exs
+++ b/test/bench/execution_bench_test.exs
@@ -3,23 +3,99 @@ Code.require_file("../../bench/support/suite.exs", __DIR__)
 defmodule JidoActionTest.ExecutionBenchTest do
   use ExUnit.Case, async: false
 
-  alias JidoActionBench.{Fixtures, Measure, Report, Suite}
+  alias JidoActionBench.{Fixtures, Measure, MemoryCases, Report, Suite}
 
   setup do
     start_supervised!({Task.Supervisor, name: JidoActionBench.TaskSupervisor})
     :ok
   end
 
+  test "Action cases occur once per payload, independent of graph sizes" do
+    workloads = Fixtures.workloads([2, 8, 16], [:small, :large_map, :large_binary])
+    actions = Enum.filter(workloads, &String.starts_with?(&1.id, "action/"))
+    assert length(workloads) == 147
+    assert length(actions) == 12
+    assert length(Enum.uniq_by(workloads, & &1.id)) == length(workloads)
+  end
+
+  test "resource summaries retain three separate runs and their medians" do
+    owner = self()
+    tag = make_ref()
+
+    workload = %{
+      setup: fn _ -> nil end,
+      run: fn _ ->
+        send(owner, {tag, self()})
+        :ok
+      end,
+      check: fn :ok -> :ok end
+    }
+
+    resources = Measure.resources(workload, 3)
+    assert length(resources.samples) == 3
+
+    callers =
+      for _ <- 1..3 do
+        assert_received {^tag, pid}
+        refute Process.alive?(pid)
+        pid
+      end
+
+    assert length(Enum.uniq(callers)) == 3
+    values = Enum.map(resources.samples, & &1.observed_peak.process_memory_bytes)
+    assert resources.median.observed_peak.process_memory_bytes == Enum.at(Enum.sort(values), 1)
+    assert Enum.all?(resources.samples, &(&1.owned_remaining == 0))
+  end
+
+  test "paused retention measures execution values from the measured call" do
+    workload =
+      Enum.find(Fixtures.workloads([2], [:small]), &(&1.name == "serial/paused_continue"))
+
+    prepared = workload.setup.(%{})
+    result = workload.run.(prepared)
+    assert :ok == workload.check.(result)
+    terms = workload.retained.(prepared, result)
+    assert %Jido.Exec.Execution{status: :running} = terms.paused_execution
+    assert %Jido.Exec.Execution{status: :succeeded} = terms.finished_execution
+    assert terms.paused_execution.id == terms.finished_execution.id
+    measured = Measure.retained(workload)
+    assert measured.paused_execution.copied_flat_heap_bytes > 0
+    assert measured.finished_execution.copied_flat_heap_bytes > 0
+  end
+
+  test "focused memory cases check results, copied terms, and helper cleanup" do
+    workloads = MemoryCases.workloads()
+    assert length(workloads) == 18
+    assert length(Enum.uniq_by(workloads, & &1.id)) == length(workloads)
+
+    for workload <- workloads do
+      assert length(Measure.timing(workload, 1, 1).wall_ns.samples) == 1
+      assert Measure.resources(workload).median.owned_remaining == 0
+
+      for {_name, measured} <- Measure.retained(workload) do
+        assert measured.copied_flat_heap_bytes == measured.flat_heap_bytes
+      end
+
+      assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
+    end
+
+    failure = Enum.find(workloads, &(&1.id == "retention/failure/large_list"))
+    terms = Measure.retained(failure)
+
+    assert terms.finished_execution.copied_flat_heap_bytes >
+             terms.failure_records.copied_flat_heap_bytes
+  end
+
   test "every first-stage workload checks its result in timing and resource runs" do
     for payload <- [:small, :large_map, :large_binary],
-        workload <- Fixtures.workloads(2, payload) do
+        workload <- Fixtures.workloads([2], [payload]) do
       timing = Measure.timing(workload, 1, 2)
       assert length(timing.wall_ns.samples) == 2
       assert timing.caller_reductions.min >= 0
       resources = Measure.resources(workload)
-      assert resources.owned_remaining == 0
-      assert resources.observations > 0
-      assert resources.observed_peak.process_memory_bytes > 0
+      assert resources.median.owned_remaining == 0
+      assert resources.median.observations > 0
+      assert resources.median.observed_peak.process_memory_bytes > 0
     end
   end
 
@@ -79,16 +155,16 @@ defmodule JidoActionTest.ExecutionBenchTest do
     end
 
     assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
-    direct = Enum.find(Fixtures.workloads(2, :small), &(&1.name == "action/direct"))
-    assert Measure.resources(direct).owned_process_starts == 0
+    direct = Enum.find(Fixtures.workloads([2], [:small]), &(&1.name == "action/direct"))
+    assert Measure.resources(direct).median.owned_process_starts == 0
   end
 
   test "traced Action helpers belong to the caller and dedicated supervisor" do
-    workloads = Fixtures.workloads(2, :small)
+    workloads = Fixtures.workloads([2], [:small])
     direct = Enum.find(workloads, &(&1.name == "action/direct"))
     run = Enum.find(workloads, &(&1.name == "action/run"))
-    assert Measure.resources(direct).owned_process_starts == 0
-    assert Measure.resources(run).owned_process_starts > 0
+    assert Measure.resources(direct).median.owned_process_starts == 0
+    assert Measure.resources(run).median.owned_process_starts > 0
     assert Task.Supervisor.children(JidoActionBench.TaskSupervisor) == []
   end
 
@@ -103,19 +179,25 @@ defmodule JidoActionTest.ExecutionBenchTest do
 
   test "copy growth stays bounded for the first-stage graphs" do
     assert :ok == Suite.check_growth!()
-    assert_raise ArgumentError, fn -> Fixtures.workloads(33, :small) end
-    assert_raise ArgumentError, fn -> Fixtures.workloads(0, :small) end
+    assert_raise ArgumentError, fn -> Fixtures.workloads([33], [:small]) end
+    assert_raise ArgumentError, fn -> Fixtures.workloads([0], [:small]) end
   end
 
   test "comparison joins case identities and rejects incompatible measurements" do
     row = %{
-      "id" => "action/run/small/2",
+      "id" => "action/run/small",
       "timing" => %{"wall_ns" => %{"median" => 100}},
-      "resources" => %{"owned_process_starts" => 2, "owned_remaining" => 0}
+      "resources" => %{
+        "median" => %{
+          "owned_process_starts" => 2,
+          "owned_remaining" => 0,
+          "observed_peak" => %{"process_memory_bytes" => 100, "shared_binary_bytes" => 20}
+        }
+      }
     }
 
     before = %{
-      "schema_version" => 1,
+      "schema_version" => 2,
       "source" => %{"tool_sha256" => "same-tool"},
       "method" => "test-method",
       "environment" => %{"otp" => "29"},
@@ -124,7 +206,16 @@ defmodule JidoActionTest.ExecutionBenchTest do
     }
 
     after_report = put_in(before, ["cases"], [put_in(row, ["timing", "wall_ns", "median"], 120)])
+
+    after_report =
+      put_in(
+        after_report,
+        ["cases", Access.at(0), "resources", "median", "observed_peak", "process_memory_bytes"],
+        80
+      )
+
     assert Report.compare!(before, after_report) =~ "1.200"
+    assert Report.compare!(before, after_report) =~ "0.800"
     assert Report.compare!(before, after_report) =~ "No speedup claim"
 
     assert_raise ArgumentError, ~r/environment/, fn ->
@@ -137,6 +228,14 @@ defmodule JidoActionTest.ExecutionBenchTest do
 
     assert_raise ArgumentError, ~r/method/, fn ->
       Report.compare!(before, put_in(after_report, ["method"], "changed-method"))
+    end
+
+    assert_raise ArgumentError, ~r/schema_version/, fn ->
+      Report.compare!(before, %{after_report | "schema_version" => 1})
+    end
+
+    assert_raise ArgumentError, ~r/settings/, fn ->
+      Report.compare!(before, put_in(after_report, ["settings", "resource_samples"], 3))
     end
 
     assert_raise ArgumentError, ~r/case/, fn ->

--- a/test/jido_exec/execution_guard_interruption_test.exs
+++ b/test/jido_exec/execution_guard_interruption_test.exs
@@ -118,7 +118,8 @@ defmodule JidoActionTest.Exec.ExecutionGuardInterruptionTest do
     invalid_compiled = %{execution.compiled | component_index: nil}
     invalid_execution = %{execution | compiled: invalid_compiled}
 
-    assert_raise Protocol.UndefinedError, fn -> Exec.step(invalid_execution) end
+    # The injected internal error can change type when the lookup changes.
+    _reason = catch_error(Exec.step(invalid_execution))
 
     assert {:error, %InvalidExecutionError{details: %{reason: :indeterminate}}} =
              Exec.step(execution)

--- a/test/jido_exec/map_retention_test.exs
+++ b/test/jido_exec/map_retention_test.exs
@@ -41,6 +41,73 @@ defmodule JidoActionTest.Exec.MapRetentionTest do
     end
   end
 
+  defmodule DiscardDependency do
+    use Jido.Action, name: "map_discard_dependency"
+
+    def run(%{item: :fail, dependency: %{large: [1 | _]}}, _context),
+      do: {:error, Jido.Action.Error.execution_error("item failed")}
+
+    def run(%{item: item, dependency: %{large: [1 | _]}}, _context),
+      do: {:ok, %{value: item}}
+  end
+
+  test "completed Map tokens release dependency results after success and collected failure" do
+    for {mode, items} <- [
+          {:fail_fast, [:a, :b]},
+          {:collect_errors, [:a, :b]},
+          {:collect_errors, [:a, :fail]}
+        ] do
+      current =
+        Flow.new!(
+          name: "map_dependencies",
+          components: [
+            Step.new!(
+              name: "producer",
+              action: EchoParamsAction,
+              params: %{large: Ref.input(:large)}
+            ),
+            Map.new!(
+              name: "mapped",
+              collection: Ref.input(:items),
+              action: DiscardDependency,
+              on_error: mode,
+              params: %{item: Ref.item(), dependency: Ref.result("producer")}
+            )
+          ],
+          output: %{items: Ref.result("mapped")}
+        )
+
+      assert {:ok, execution} = Exec.start(current, %{items: items, large: Enum.to_list(1..500)})
+      assert {:ok, finished} = Exec.continue(execution)
+      assert {:ok, %{items: outputs}} = Exec.result(finished)
+      assert length(outputs) == 2
+      if mode == :fail_fast, do: assert(outputs == [%{value: :a}, %{value: :b}])
+
+      if mode == :collect_errors do
+        assert hd(outputs) == %{status: :ok, value: %{value: :a}}
+
+        if :fail in items do
+          assert %{status: :error, error: %{message: "item failed"}} = List.last(outputs)
+        else
+          assert List.last(outputs) == %{status: :ok, value: %{value: :b}}
+        end
+      end
+
+      tokens =
+        Exec.native(finished).workflow
+        |> Runic.Workflow.productions()
+        |> Enum.map(&Jido.Flow.Compiler.Payload.unwrap(&1.value))
+        |> Enum.filter(&match?(%{kind: :result, index: _}, &1))
+
+      assert Enum.sort(Enum.uniq(Enum.map(tokens, & &1.index))) == [0, 1]
+
+      for token <- tokens do
+        refute Elixir.Map.has_key?(token, :results)
+        refute Elixir.Map.has_key?(token, :item)
+      end
+    end
+  end
+
   for mode <- [:run, :async, :step, :wave], items <- [[], [3, 1, 3]] do
     test "retains Map and Reduce with #{mode} and #{inspect(items)}" do
       items = unquote(items)

--- a/test/jido_exec/runnable_capture_test.exs
+++ b/test/jido_exec/runnable_capture_test.exs
@@ -5,6 +5,26 @@ defmodule JidoActionTest.Exec.RunnableCaptureTest do
   alias Jido.Flow.{Ref, Step}
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
 
+  test "run context does not duplicate input carried by native facts" do
+    sizes =
+      for input <- [%{}, %{unused: Enum.to_list(1..10_000)}] do
+        flow =
+          Flow.new!(
+            name: "input_context_capture",
+            components: [Step.new!(name: "echo", action: EchoParamsAction)],
+            output: Ref.result("echo")
+          )
+
+        assert {:ok, execution} = Exec.start(flow, input)
+        size = :erts_debug.flat_size(execution.workflow.run_context)
+        assert {:ok, finished} = Exec.continue(execution)
+        assert Exec.result(finished) == {:ok, %{}}
+        size
+      end
+
+    assert Enum.uniq(sizes) |> length() == 1
+  end
+
   test "concurrent workers do not copy unrelated Flow data or execution indexes" do
     retained = Enum.to_list(1..100_000)
 

--- a/test/jido_exec/work_allocation_test.exs
+++ b/test/jido_exec/work_allocation_test.exs
@@ -3,7 +3,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
   use ExUnit.Case, async: false
 
   alias Jido.{Exec, Flow}
-  alias Jido.Exec.Flow.Inspection
+  alias Jido.Exec.Work
   alias Jido.Flow.{Ref, Step}
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
 
@@ -77,7 +77,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
   end
 
   defp construction_count(fun) do
-    Code.ensure_loaded!(Inspection)
+    Code.ensure_loaded!(Work)
     owner = self()
     ref = make_ref()
     supervisor = start_supervised!(Task.Supervisor)
@@ -92,7 +92,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
       end)
 
     try do
-      :erlang.trace_pattern({Inspection, :work, 3}, true, [:local])
+      :erlang.trace_pattern({Work, :new, :_}, true, [:local])
       flags = [:call, :arity, :set_on_spawn, {:tracer, self()}]
       :erlang.trace(caller, true, flags)
       :erlang.trace(supervisor, true, flags)
@@ -106,7 +106,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
       {result, count}
     after
       :erlang.trace(supervisor, false, [:all])
-      :erlang.trace_pattern({Inspection, :work, 3}, false, [:local])
+      :erlang.trace_pattern({Work, :new, :_}, false, [:local])
       Process.exit(caller, :kill)
       Process.demonitor(monitor, [:flush])
     end
@@ -114,7 +114,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
 
   defp drain_calls(count) do
     receive do
-      {:trace, _pid, :call, {Inspection, :work, 3}} -> drain_calls(count + 1)
+      {:trace, _pid, :call, {Work, :new, _arity}} -> drain_calls(count + 1)
     after
       0 -> count
     end

--- a/test/jido_exec/work_allocation_test.exs
+++ b/test/jido_exec/work_allocation_test.exs
@@ -3,7 +3,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
   use ExUnit.Case, async: false
 
   alias Jido.{Exec, Flow}
-  alias Jido.Exec.Work
+  alias Jido.Exec.Flow.Inspection
   alias Jido.Flow.{Ref, Step}
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
 
@@ -77,7 +77,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
   end
 
   defp construction_count(fun) do
-    Code.ensure_loaded!(Work)
+    Code.ensure_loaded!(Inspection)
     owner = self()
     ref = make_ref()
     supervisor = start_supervised!(Task.Supervisor)
@@ -92,7 +92,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
       end)
 
     try do
-      :erlang.trace_pattern({Work, :new, :_}, true, [:local])
+      :erlang.trace_pattern({Inspection, :work, 3}, true, [:local])
       flags = [:call, :arity, :set_on_spawn, {:tracer, self()}]
       :erlang.trace(caller, true, flags)
       :erlang.trace(supervisor, true, flags)
@@ -106,7 +106,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
       {result, count}
     after
       :erlang.trace(supervisor, false, [:all])
-      :erlang.trace_pattern({Work, :new, :_}, false, [:local])
+      :erlang.trace_pattern({Inspection, :work, 3}, false, [:local])
       Process.exit(caller, :kill)
       Process.demonitor(monitor, [:flush])
     end
@@ -114,7 +114,7 @@ defmodule JidoActionTest.Exec.WorkAllocationTest do
 
   defp drain_calls(count) do
     receive do
-      {:trace, _pid, :call, {Work, :new, _arity}} -> drain_calls(count + 1)
+      {:trace, _pid, :call, {Inspection, :work, 3}} -> drain_calls(count + 1)
     after
       0 -> count
     end

--- a/test/jido_exec/work_inspection_test.exs
+++ b/test/jido_exec/work_inspection_test.exs
@@ -134,8 +134,9 @@ defmodule JidoActionTest.Exec.WorkInspectionTest do
         send(owner, {ref, execution, work.token})
       end)
 
-    assert_receive {^ref, execution, token}
-    assert_receive {:DOWN, ^monitor, :process, ^creator, :normal}
+    on_exit(fn -> Process.exit(creator, :kill) end)
+    assert_receive {^ref, execution, token}, 1_000
+    assert_receive {:DOWN, ^monitor, :process, ^creator, :normal}, 1_000
     assert {:ok, _, current} = Exec.step(execution, token)
     assert {:ok, finished} = Exec.continue(current)
     assert Exec.result(finished) == {:ok, %{value: 8}}

--- a/test/jido_exec/work_retention_test.exs
+++ b/test/jido_exec/work_retention_test.exs
@@ -6,6 +6,28 @@ defmodule JidoActionTest.Exec.WorkRetentionTest do
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
   alias JidoActionTest.Fixtures.Actions.ErrorAction
 
+  test "paused executions keep at most one copy of author metadata for errors" do
+    metadata = %{notes: Enum.to_list(1..5_000)}
+
+    [small, large] =
+      for meta <- [%{}, metadata] do
+        flow =
+          Flow.new!(
+            name: "execution_metadata",
+            components: [Step.new!(name: "echo", action: EchoParamsAction, meta: meta)],
+            output: Ref.result("echo")
+          )
+
+        assert {:ok, execution} = Exec.start(flow)
+        size = :erts_debug.flat_size(execution)
+        assert {:ok, finished} = Exec.continue(execution)
+        assert Exec.result(finished) == {:ok, %{}}
+        size
+      end
+
+    assert large - small < :erts_debug.flat_size(metadata) + 100
+  end
+
   test "failure records do not duplicate native runnable inputs" do
     flow =
       Flow.new!(

--- a/test/jido_exec/work_retention_test.exs
+++ b/test/jido_exec/work_retention_test.exs
@@ -4,6 +4,24 @@ defmodule JidoActionTest.Exec.WorkRetentionTest do
   alias Jido.{Exec, Flow}
   alias Jido.Flow.{Ref, Step}
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
+  alias JidoActionTest.Fixtures.Actions.ErrorAction
+
+  test "failure records do not duplicate native runnable inputs" do
+    flow =
+      Flow.new!(
+        name: "failure_retention",
+        components: [
+          Step.new!(name: "fail", action: ErrorAction, params: %{value: Ref.input(:value)})
+        ],
+        output: Ref.result("fail")
+      )
+
+    assert {:ok, execution} = Exec.start(flow, %{value: Enum.to_list(1..10_000)})
+    assert {:ok, finished} = Exec.continue(execution)
+    assert {:error, error} = Exec.result(finished)
+    assert error.message == "Action failed"
+    assert :erts_debug.flat_size(finished.runnable_errors) < 1_000
+  end
 
   test "ready and completed descriptors do not copy or retain unrelated execution data" do
     measurements =

--- a/test/jido_exec/work_retention_test.exs
+++ b/test/jido_exec/work_retention_test.exs
@@ -28,6 +28,34 @@ defmodule JidoActionTest.Exec.WorkRetentionTest do
     assert large - small < :erts_debug.flat_size(metadata) + 100
   end
 
+  test "finished executions release author metadata after success and failure" do
+    for action <- [EchoParamsAction, ErrorAction] do
+      [small, large] =
+        for meta <- [%{}, %{notes: Enum.to_list(1..5_000)}] do
+          flow =
+            Flow.new!(
+              name: "finished_metadata",
+              components: [Step.new!(name: "work", action: action, meta: meta)],
+              output: Ref.result("work")
+            )
+
+          assert {:ok, execution} = Exec.start(flow)
+          assert {:ok, finished} = Exec.continue(execution)
+
+          if action == EchoParamsAction do
+            assert Exec.result(finished) == {:ok, %{}}
+          else
+            assert {:error, error} = Exec.result(finished)
+            assert error.message == "Action failed"
+          end
+
+          :erts_debug.flat_size(finished)
+        end
+
+      assert abs(large - small) < 100
+    end
+  end
+
   test "failure records do not duplicate native runnable inputs" do
     flow =
       Flow.new!(

--- a/test/jido_expr_test.exs
+++ b/test/jido_expr_test.exs
@@ -472,6 +472,27 @@ defmodule Jido.ExprTest do
              Jido.Expr.parse(quote(do: [[[1 + 2]]]), max_depth: 2)
   end
 
+  test "membership preserves cumulative budgets and the first failing data path" do
+    left = %{items: ["abc", 1]}
+    right = [%{items: ["xyz", 1]}, %{items: ["abc", 1.0]}]
+    expression = Jido.Expr.new!(:in, [left, right])
+
+    for {options, reason, path, operator} <- [
+          {[max_nodes: 28], :max_nodes, [], nil},
+          {[max_nodes: 30], :max_nodes, [0], nil},
+          {[max_nodes: 31], :max_nodes, [1], nil},
+          {[max_nodes: 37], :max_nodes, [], :in},
+          {[max_binary_bytes: 18], :max_binary_bytes, [0], nil},
+          {[max_nodes: 30, max_binary_bytes: 15], :max_nodes, [0], nil},
+          {[max_nodes: 31, max_binary_bytes: 15], :max_binary_bytes, [0], nil}
+        ] do
+      assert {:error, %Jido.Expr.Error{reason: ^reason, path: ^path, operator: ^operator}} =
+               Jido.Expr.evaluate(expression, options)
+    end
+
+    assert {:ok, true} = Jido.Expr.evaluate(expression, max_nodes: 38, max_binary_bytes: 21)
+  end
+
   test "invalid options and invalid host callbacks return structured errors" do
     for options <- [
           [unknown: true],

--- a/test/jido_expr_test.exs
+++ b/test/jido_expr_test.exs
@@ -376,6 +376,21 @@ defmodule Jido.ExprTest do
     assert reductions < 10_000
   end
 
+  test "resolved data retains its containers after the bounded read-only walk" do
+    shared = Enum.to_list(1..128)
+
+    for value <- [
+          %{left: shared, right: shared},
+          [shared, shared],
+          [shared | :tail],
+          %Reference{key: shared}
+        ] do
+      assert {:ok, result} = Jido.Expr.evaluate(%Reference{}, resolve: fn _ -> {:ok, value} end)
+      assert result == value
+      assert :erts_debug.same(result, value)
+    end
+  end
+
   test "resolved large tuples stop within the node work limit" do
     value = :erlang.make_tuple(1_000_000, nil)
 

--- a/test/jido_flow/boundary_validation_test.exs
+++ b/test/jido_flow/boundary_validation_test.exs
@@ -59,6 +59,23 @@ defmodule Jido.Flow.BoundaryValidationTest do
     end
   end
 
+  test "portable data keeps nested error paths and rejects improper lists first" do
+    for {value, message, path} <- [
+          {%{outer: [0, %{inner: self()}]}, "flow data contains an unsupported value",
+           [:outer, 1, :inner]},
+          {%{outer: [0, %{nil => :value}]}, "flow data contains an unsupported map key",
+           [:outer, 1]},
+          {%{outer: [0, <<255>>]}, "flow data strings must be valid UTF-8", [:outer, 1]},
+          {%{outer: [0, %{<<255>> => :value}]}, "flow data strings must be valid UTF-8",
+           [:outer, 1]},
+          {%{outer: [[self() | :tail]]}, "flow data must contain proper lists", [:outer, 0]}
+        ] do
+      assert {:error, error} = Data.validate(value)
+      assert error.message == message
+      assert error.details.path == path
+    end
+  end
+
   test "Component helpers reject invalid common fields" do
     step = Step.new!(name: "step", action: Add)
     subflow = Jido.Flow.Subflow.new!(name: "child", flow: NestedFlow)

--- a/test/jido_flow/codec_test.exs
+++ b/test/jido_flow/codec_test.exs
@@ -201,6 +201,17 @@ defmodule Jido.Flow.CodecTest do
     assert {:ok, ^flow} = Codec.decode(document, registry)
     assert {:ok, ^document, ^registry} = Codec.encode(flow)
 
+    raw_flow = %Flow{
+      name: "raw_codec",
+      schema: nil,
+      output_schema: nil,
+      components: [%Step{name: "add", action: Add, params: %{a: 1, b: 2}}],
+      output: Ref.result("add")
+    }
+
+    assert {:ok, canonical} = Flow.validate_executable(raw_flow)
+    assert Codec.encode(raw_flow) == Codec.encode(canonical)
+
     assert {:error, %InvalidDefinitionError{}} = Codec.encode(:invalid)
   end
 

--- a/test/jido_flow/codec_test.exs
+++ b/test/jido_flow/codec_test.exs
@@ -757,6 +757,22 @@ defmodule Jido.Flow.CodecTest do
             %InvalidDefinitionError{message: "stored Flow collection exceeds its size limit"}} =
              Codec.encode(wide_flow, registry)
 
+    for count <- [10_000, 10_001] do
+      output = Map.new(1..count, &{&1, 0})
+      map_flow = Flow.new!(name: "map_limit", components: flow.components, output: output)
+
+      if count == 10_000 do
+        assert {:ok, _document} = Codec.encode(map_flow, registry)
+      else
+        assert {:error,
+                %InvalidDefinitionError{
+                  message: "stored Flow collection exceeds its size limit",
+                  details: %{maximum_size: 10_000}
+                }} =
+                 Codec.encode(map_flow, registry)
+      end
+    end
+
     assert {:error,
             %InvalidDefinitionError{message: "stored Flow collection exceeds its size limit"}} =
              Codec.decode(

--- a/test/jido_flow/compiler/capture_test.exs
+++ b/test/jido_flow/compiler/capture_test.exs
@@ -36,6 +36,23 @@ defmodule JidoActionTest.Flow.Compiler.CaptureTest do
     assert retained == []
   end
 
+  test "compiled Subflows do not copy author metadata into callbacks" do
+    sizes =
+      for meta <- [%{}, %{notes: Enum.to_list(1..5_000)}] do
+        flow =
+          Flow.new!(
+            name: "subflow_metadata",
+            components: [Subflow.new!(name: "child", flow: TelemetryParentFlow, meta: meta)],
+            output: Ref.result("child")
+          )
+
+        assert {:ok, compiled} = Flow.compile(flow)
+        :erts_debug.flat_size(compiled)
+      end
+
+    assert Enum.uniq(sizes) |> length() == 1
+  end
+
   for shape <- [:independent, :chained, :nested, :map, :reduce] do
     test "#{shape} graphs have bounded size after transfer to another process" do
       measurements =

--- a/test/jido_flow/compiler/capture_test.exs
+++ b/test/jido_flow/compiler/capture_test.exs
@@ -53,6 +53,36 @@ defmodule JidoActionTest.Flow.Compiler.CaptureTest do
     assert Enum.uniq(sizes) |> length() == 1
   end
 
+  test "all compiled component callbacks omit author metadata" do
+    source = FlowAuthoring.mixed_flow!()
+
+    dispatch =
+      Jido.Flow.Dispatch.new!(
+        name: "dispatch",
+        decision: EchoParamsAction,
+        expander: EchoParamsAction,
+        after: Enum.map(source.components, & &1.name),
+        params: %{value: Ref.result("loop")}
+      )
+
+    source = %{
+      source
+      | components: source.components ++ [dispatch],
+        output: Ref.result("dispatch")
+    }
+
+    [small, large] =
+      for meta <- [%{}, %{notes: Enum.to_list(1..5_000)}] do
+        flow = %{source | components: Enum.map(source.components, &%{&1 | meta: meta})}
+        assert {:ok, compiled} = Flow.compile(flow)
+        {compiled, Flow.semantic_identity(flow)}
+      end
+
+    assert :erts_debug.flat_size(elem(small, 0)) == :erts_debug.flat_size(elem(large, 0))
+    refute elem(small, 1) == elem(large, 1)
+    refute elem(small, 0).compilation_digest == elem(large, 0).compilation_digest
+  end
+
   for shape <- [:independent, :chained, :nested, :map, :reduce] do
     test "#{shape} graphs have bounded size after transfer to another process" do
       measurements =

--- a/test/jido_flow/compiler/capture_test.exs
+++ b/test/jido_flow/compiler/capture_test.exs
@@ -6,6 +6,23 @@ defmodule JidoActionTest.Flow.Compiler.CaptureTest do
   alias JidoActionTest.Fixtures.{FlowAuthoring, TelemetryParentFlow}
   alias JidoActionTest.Fixtures.Actions.EchoParamsAction
 
+  test "compiled Steps do not copy author metadata into callbacks" do
+    sizes =
+      for meta <- [%{}, %{notes: Enum.to_list(1..5_000)}] do
+        flow =
+          Flow.new!(
+            name: "step_metadata",
+            components: [Step.new!(name: "echo", action: EchoParamsAction, meta: meta)],
+            output: Ref.result("echo")
+          )
+
+        assert {:ok, compiled} = Flow.compile(flow)
+        :erts_debug.flat_size(compiled)
+      end
+
+    assert Enum.uniq(sizes) |> length() == 1
+  end
+
   test "compiler callbacks do not retain the compiler state" do
     assert {:ok, compiled} = Flow.compile(FlowAuthoring.mixed_flow!())
 

--- a/test/jido_flow/compiler/payload_test.exs
+++ b/test/jido_flow/compiler/payload_test.exs
@@ -4,6 +4,17 @@ defmodule JidoActionTest.Flow.Compiler.PayloadTest do
   alias Jido.Flow.Compiler.Payload
   alias Runic.Workflow.Fact
 
+  test "payload projection keeps the deterministic external-term digest" do
+    binary = :binary.copy(<<42>>, 1_048_576)
+
+    for value <- [42, %{data: binary}, {binary, binary}, [self(), make_ref(), <<5::3>>]] do
+      expected = :crypto.hash(:sha256, :erlang.term_to_binary(value, [:deterministic]))
+
+      assert Runic.Identity.Projectable.identity_document(Payload.new(value)) ==
+               {:jido_local_beam_value, 1, expected}
+    end
+  end
+
   test "local payload identities preserve map order independence and term distinctions" do
     left = Enum.into([{:a, 1}, {:b, 2}], %{})
     right = Enum.into([{:b, 2}, {:a, 1}], %{})

--- a/test/jido_flow/graph_identity_test.exs
+++ b/test/jido_flow/graph_identity_test.exs
@@ -18,6 +18,7 @@ defmodule Jido.Flow.GraphIdentityTest do
     assert %{version: 2, algorithm: :sha256, digest: digest, uuid: uuid} = identity
     assert is_binary(digest)
     assert is_binary(uuid)
+    assert Flow.Identity.semantic_digest(dsl) == digest
     assert Flow.semantic_identity(direct) == {:ok, identity}
     assert Flow.semantic_identity(built) == {:ok, identity}
   end

--- a/test/jido_flow/ref_path_authoring_test.exs
+++ b/test/jido_flow/ref_path_authoring_test.exs
@@ -77,6 +77,24 @@ defmodule Jido.Flow.RefPathAuthoringTest do
     end
   end
 
+  test "atom paths prefer present atom keys, including nil and false, before string keys" do
+    flow =
+      Flow.new!(
+        name: "key_precedence",
+        components: [
+          Step.new!(name: "echo", action: EchoParamsAction, params: %{value: Ref.input(:value)})
+        ],
+        output: Ref.result("echo")
+      )
+
+    for value <- [nil, false, 7] do
+      assert Jido.Exec.run(flow, %{:value => value, "value" => 42}) == {:ok, %{value: value}}
+    end
+
+    assert Jido.Exec.run(flow, %{"value" => 42}) == {:ok, %{value: 42}}
+    assert {:error, %{details: %{reason: :missing_key}}} = Jido.Exec.run(flow, %{})
+  end
+
   test "Flow, Builder, and Codec reject malformed reference paths" do
     step = Step.new!(name: "echo", action: EchoParamsAction)
     valid = Flow.new!(name: "invalid_paths", components: [step], output: Ref.input([]))


### PR DESCRIPTION
Flow execution, expression walks, and schema validation retain or rebuild data that they can reuse. This PR removes those copies, reuses work within one call, and adds benchmarks that check results and process cleanup.

- Release unused runtime input, metadata, completed Map dependencies, terminal callbacks, and failed Runnable data.
- Reuse semantic digests and existing work indexes; close telemetry spans by ID.
- Preserve containers during read-only Expr walks, remove indexed-list copies, and reuse membership operand cost while charging every budget visit.
- Split schema fields without rebuilding both maps. Check Codec map size directly and reuse the canonical Flow for convenience encoding.
- Format deterministic IDs with fixed binary fields. Keep the final 36-byte ID on the heap so it does not retain a larger append buffer.

Results, error boundaries, deterministic identity bytes, ordering, limits, revision guards, and process ownership remain covered. Runic and dependency files are unchanged.

## Benchmark coverage

The six coverage items now include every runtime component, requested output versus retained state, large context and shared data, cancellation and deadlines, caller exit, mailbox load, telemetry handlers, public start cost, observed helper work, and Mix releases without consumer source.

Profiles contain 43 smoke, 184 backlog, 222 short, and 312 scale cases. Reports use schema 3. Timing is untraced; allocation, process, and actual-copy probes run separately. All cases check expected results and helper cleanup. Prepared reuse remains an internal diagnostic.

All 21 backlog items were evaluated: six coverage items completed, 12 performance changes retained, two candidates rejected, and native-data retention measured without changing the inspection API. Reduce initialization-token trimming and batched output lookup gave no useful gain.

## Measured results

This comparison isolates the latest backlog pass: `95863cf` has runtime code from `344972e`; measurements at `d887a9d` include the retained changes. The later CI cleanup changes test waits and formatting only. Both use identical scripts on an Apple M1 Max, OTP 29.0.5, Elixir 1.20.3, and two schedulers. There are two baseline and three final 184-case runs, plus a final 312-case scale run.

| Case and metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Choice with large metadata: compiled copied heap | 171,464 B | 11,496 B | −93.3% |
| Map with large dependency: finished copied heap | 2,555,888 B | 2,039,280 B | −20.2% |
| 256 item IDs: runtime | 554 µs | 216 µs | −60.9% |
| Struct with 200 extra keys, coercion: runtime | 20.7 µs | 5.6 µs | −73.0% |
| Expr membership, late match: runtime | 463 µs | 322 µs | −30.5% |
| Convenience encoding, 2,000 entries: runtime | 2.34 ms | 1.57 ms | −32.7% |

Separate matched allocation probes show 91% fewer heap words for ID formatting, 47–78% fewer for the struct split cases, and 25–26% fewer for convenience encoding. Process start counts match the baseline across all 184 cases.

These are targeted gains. The small invalid-expression case is about 0.25 µs slower while using fewer reductions. Telemetry process-memory samples increase 28% across the three handler cases. Those are sampled peaks, not exact peaks. Large caller timing increases did not repeat with restored controls; a separate 12,000-call check gives 37–38 µs for single async calls on both versions. No package-wide speed or memory gain is claimed.

Six fresh release VMs return the expected results after source removal. Release size changes by 960 B; generated module count and BEAM size are unchanged. Startup memory is effectively unchanged. Deep Subflow Execution copies remain large; native inspection data is preserved.

## Validation

- Local full suite: 900 tests pass. Final CI cleanup: 37 focused tests pass.
- Expr membership: 7,200 comparisons preserve exact results, errors, budget limits, and resolver order.
- Every completed benchmark report passes result, copy-size, and cleanup checks; the final HEAD also passes the smoke profile.
- [CI passes at `8a625e1`](https://github.com/agentjido/jido_action/actions/runs/33995685118), including OTP 27 / Elixir 1.18, OTP 28 / Elixir 1.18 and 1.19, and OTP 29 / Elixir 1.20.
- Local quality checks were skipped as requested. GitHub runs its normal checks.

Repeat with a separate output directory for each run:

```sh
ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile backlog --output bench/results/backlog-1
ERL_FLAGS='+S 2:2' mix run bench/run.exs --profile scale --output bench/results/scale
ERL_FLAGS='+S 2:2' MIX_ENV=test mix run bench/release.exs bench/results/release
```

See the [benchmark guide](https://github.com/agentjido/jido_action/blob/perf/local-memory-rounds/guides/benchmarks.md) for measurement boundaries and comparison rules.
