### PR TITLE
feat(flow): add compile-time DSL macro extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,10 @@ entries return to the normal automated changelog process.
 
 ## Unreleased
 
+### Features:
+
+* flow: add compile-time DSL macro extensions
+
 ## [v3.0.0-beta.2](https://github.com/agentjido/jido_action/compare/v3.0.0-beta.1...v3.0.0-beta.2) (2026-08-27)
 
 ### Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,10 +105,6 @@ entries return to the normal automated changelog process.
 
 ## Unreleased
 
-### Features:
-
-* flow: add compile-time DSL macro extensions
-
 ## [v3.0.0-beta.2](https://github.com/agentjido/jido_action/compare/v3.0.0-beta.1...v3.0.0-beta.2) (2026-08-27)
 
 ### Features:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This foundation keeps the action boundary small:
 - `Jido.Expr` defines fixed, data-only operations for Flow and host DSLs.
 - `Jido.Instruction` captures one requested executable call as data.
 - `Jido.Flow` composes actions as a validated graph with steps and Choices.
+- `Jido.Flow.Extension` adds compile-time macros that lower to the normal Flow DSL.
 - `Jido.Exec` runs actions, instructions, and Flows, including asynchronous
   run-to-completion calls and step-wise Flows.
 

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -31,6 +31,48 @@ An inline body becomes an ordinary Action. The Flow owns the body, so it can
 call the module's private helpers. Headers use data expressions; the body is
 normal Elixir. See [Steps And Output](flow-steps.livemd) for the full syntax.
 
+## Add Authoring Macros
+
+Use a Flow extension when several Flow modules need the same declarative
+shorthand. An extension macro must expand to normal Flow declarations.
+
+```elixir
+defmodule MyApp.Flows.Helpers do
+  use Jido.Flow.Extension
+
+  defmacro notify(name, address) do
+    quote do
+      step unquote(name),
+        action: MyApp.Actions.Notify,
+        params: %{address: unquote(address)}
+    end
+  end
+end
+```
+
+Add the extension through a static module list:
+
+```elixir
+defmodule MyApp.Flows.Welcome do
+  use Jido.Flow,
+    name: "welcome",
+    extensions: [MyApp.Flows.Helpers]
+
+  flow do
+    notify "welcome", input(:address)
+    output result("welcome")
+  end
+end
+```
+
+The extension runs only during compilation. Its macros can expand to core
+declarations, including inline Action forms. Core lowering then applies the
+same validation, source mapping, canonical data, and execution rules.
+
+An extension does not add a new component type or runtime. Put domain work in
+Actions or Flows. Keep runtime input in Flow input or context. The extension
+module must compile before each Flow that configures it.
+
 ## Format The DSL
 
 Add `:jido_action` to the `import_deps` list in your project's `.formatter.exs`.

--- a/guides/flow-modules.md
+++ b/guides/flow-modules.md
@@ -73,6 +73,45 @@ An extension does not add a new component type or runtime. Put domain work in
 Actions or Flows. Keep runtime input in Flow input or context. The extension
 module must compile before each Flow that configures it.
 
+### Use Helpers With Other Authoring Forms
+
+Extensions apply only to the compile-time module DSL. The extension module and
+macro calls are not part of the canonical `%Jido.Flow{}` value.
+
+For Builder authoring, use a normal function that takes and returns a Builder:
+
+```elixir
+defmodule MyApp.Flows.BuilderHelpers do
+  def notify(builder, name, address) do
+    Jido.Flow.Builder.step(
+      builder,
+      name,
+      MyApp.Actions.Notify,
+      %{address: address}
+    )
+  end
+end
+
+builder =
+  Jido.Flow.Builder.new(name: "welcome")
+  |> MyApp.Flows.BuilderHelpers.notify(
+    "welcome",
+    Jido.Flow.Builder.input(:address)
+  )
+  |> Jido.Flow.Builder.output(Jido.Flow.Builder.result("welcome"))
+```
+
+For direct construction, use normal functions that return canonical components
+or a canonical Flow. Builder and direct helpers run as application code. They
+do not use the extension list. Put them in a separate module. Spark imports the
+public functions and macros of a configured extension into the Flow module, so
+the extension module must have a small public namespace.
+
+Codec maps are data only. They cannot name or run an extension. If an
+application owns a higher-level stored format, translate that format to Builder
+or direct constructor calls in trusted application code. Then encode the
+canonical Flow through `Jido.Flow.Codec` and a trusted Registry.
+
 ## Format The DSL
 
 Add `:jido_action` to the `import_deps` list in your project's `.formatter.exs`.

--- a/lib/jido_flow.ex
+++ b/lib/jido_flow.ex
@@ -38,7 +38,8 @@ defmodule Jido.Flow do
         extensions: [MyApp.Flows.Helpers]
 
   Define each extension with `Jido.Flow.Extension`. Extensions change only
-  source authoring. The compiled result remains one canonical Flow value.
+  module DSL source authoring. Builder, direct construction, and Codec do not
+  load extensions. The compiled result remains one canonical Flow value.
 
   For a small operation, bind data and write an inline Step body:
 

--- a/lib/jido_flow.ex
+++ b/lib/jido_flow.ex
@@ -30,6 +30,16 @@ defmodule Jido.Flow do
         end
       end
 
+  A compile-time extension can add macros that expand to normal Flow
+  declarations. Configure extensions as a static module list:
+
+      use Jido.Flow,
+        name: "process_order",
+        extensions: [MyApp.Flows.Helpers]
+
+  Define each extension with `Jido.Flow.Extension`. Extensions change only
+  source authoring. The compiled result remains one canonical Flow value.
+
   For a small operation, bind data and write an inline Step body:
 
       defmodule MyApp.Greeting do

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -101,8 +101,16 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
 
   defp split_options!(opts_ast, caller) when is_list(opts_ast) do
     if Keyword.keyword?(opts_ast) do
-      {extensions_ast, flow_opts_ast} = Keyword.pop(opts_ast, :extensions, [])
-      {flow_opts_ast, extensions!(extensions_ast, caller)}
+      case Keyword.get_values(opts_ast, :extensions) do
+        [] ->
+          {opts_ast, []}
+
+        [extensions_ast] ->
+          {Keyword.delete(opts_ast, :extensions), extensions!(extensions_ast, caller)}
+
+        [_first | _rest] ->
+          extension_error!(caller, "Flow extensions can be configured only once")
+      end
     else
       {opts_ast, []}
     end
@@ -111,7 +119,7 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
   defp split_options!(opts_ast, _caller), do: {opts_ast, []}
 
   defp extensions!(extensions, caller) when is_list(extensions) do
-    if List.improper?(extensions) do
+    if List.improper?(extensions) or Enum.any?(extensions, &improper_list_ast?/1) do
       extension_error!(caller, "Flow extensions must be a proper list")
     end
 
@@ -127,13 +135,17 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
   defp extensions!(_extensions, caller),
     do: extension_error!(caller, "Flow extensions must be a list")
 
+  defp improper_list_ast?({:|, _meta, [_head, _tail]}), do: true
+  defp improper_list_ast?(_extension), do: false
+
   defp extension!(extension_ast, caller) do
     extension = Macro.expand(extension_ast, caller)
 
     with true <- is_atom(extension) and extension not in [nil, true, false],
          {:module, ^extension} <- Code.ensure_compiled(extension),
-         true <- function_exported?(extension, :__jido_flow_extension__, 0),
-         true <- extension.__jido_flow_extension__() == true do
+         true <- Spark.implements_behaviour?(extension, Jido.Flow.Extension),
+         true <- Spark.implements_behaviour?(extension, Spark.Dsl.Extension),
+         true <- function_exported?(extension, :__jido_flow_extension__, 0) do
       extension
     else
       _ -> extension_error!(caller, "Flow extension must use Jido.Flow.Extension")

--- a/lib/jido_flow/dsl/module_compiler.ex
+++ b/lib/jido_flow/dsl/module_compiler.ex
@@ -7,16 +7,17 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
   @doc false
   defmacro __using__(opts_ast) do
     module_compiler = __MODULE__
+    {flow_opts_ast, extensions} = split_options!(opts_ast, __CALLER__)
 
     quote location: :keep do
       @behaviour Jido.Executable
-      use Jido.Flow.DSL
+      use Jido.Flow.DSL, extensions: unquote(Macro.escape(extensions))
       @before_compile Jido.Flow.DSL.ModuleCompiler
       Jido.Action.Inline.setup!(__ENV__)
       unquote(module_compiler).reserve_function!(__ENV__, {:step_action, 1})
 
       {validated_opts, stored_schema, stored_output_schema} =
-        unquote(module_compiler).prepare_config!(unquote(opts_ast), __ENV__)
+        unquote(module_compiler).prepare_config!(unquote(flow_opts_ast), __ENV__)
 
       Module.put_attribute(__MODULE__, :__jido_flow_schema__, stored_schema)
       Module.put_attribute(__MODULE__, :__jido_flow_output_schema__, stored_output_schema)
@@ -96,6 +97,51 @@ defmodule Jido.Flow.DSL.ModuleCompiler do
       @spec run(map(), map()) :: Jido.Exec.exec_result()
       def run(params, context)
     end
+  end
+
+  defp split_options!(opts_ast, caller) when is_list(opts_ast) do
+    if Keyword.keyword?(opts_ast) do
+      {extensions_ast, flow_opts_ast} = Keyword.pop(opts_ast, :extensions, [])
+      {flow_opts_ast, extensions!(extensions_ast, caller)}
+    else
+      {opts_ast, []}
+    end
+  end
+
+  defp split_options!(opts_ast, _caller), do: {opts_ast, []}
+
+  defp extensions!(extensions, caller) when is_list(extensions) do
+    if List.improper?(extensions) do
+      extension_error!(caller, "Flow extensions must be a proper list")
+    end
+
+    modules = Enum.map(extensions, &extension!(&1, caller))
+
+    if length(modules) != length(Enum.uniq(modules)) do
+      extension_error!(caller, "duplicate Flow extension")
+    end
+
+    modules
+  end
+
+  defp extensions!(_extensions, caller),
+    do: extension_error!(caller, "Flow extensions must be a list")
+
+  defp extension!(extension_ast, caller) do
+    extension = Macro.expand(extension_ast, caller)
+
+    with true <- is_atom(extension) and extension not in [nil, true, false],
+         {:module, ^extension} <- Code.ensure_compiled(extension),
+         true <- function_exported?(extension, :__jido_flow_extension__, 0),
+         true <- extension.__jido_flow_extension__() == true do
+      extension
+    else
+      _ -> extension_error!(caller, "Flow extension must use Jido.Flow.Extension")
+    end
+  end
+
+  defp extension_error!(caller, description) do
+    raise CompileError, file: caller.file, line: caller.line, description: description
   end
 
   @doc false

--- a/lib/jido_flow/extension.ex
+++ b/lib/jido_flow/extension.ex
@@ -32,6 +32,11 @@ defmodule Jido.Flow.Extension do
   Extension macros run during normal Flow compilation. The expanded core
   declarations keep the usual validation, source mapping, inline Action, and
   execution rules. Extension modules must be available at compile time.
+
+  Only the module DSL loads extensions. Builder and direct construction use
+  normal Elixir functions that create canonical Flow data. Codec documents
+  contain data only and never load or run an extension. Keep the public API of
+  an extension module limited to macros. Put Builder helpers in another module.
   """
 
   @doc false

--- a/lib/jido_flow/extension.ex
+++ b/lib/jido_flow/extension.ex
@@ -1,0 +1,59 @@
+defmodule Jido.Flow.Extension do
+  @moduledoc """
+  Defines compile-time macro extensions for the Flow module DSL.
+
+  An extension adds authoring macros to `flow do`. Each macro must expand to
+  normal Flow declarations. It does not add a component type, change the
+  canonical `%Jido.Flow{}` value, or add runtime behavior.
+
+      defmodule MyApp.Flows.Helpers do
+        use Jido.Flow.Extension
+
+        defmacro notify(name, address) do
+          quote do
+            step unquote(name),
+              action: MyApp.Actions.Notify,
+              params: %{address: unquote(address)}
+          end
+        end
+      end
+
+      defmodule MyApp.Flows.Welcome do
+        use Jido.Flow,
+          name: "welcome",
+          extensions: [MyApp.Flows.Helpers]
+
+        flow do
+          notify "welcome", input(:address)
+          output result("welcome")
+        end
+      end
+
+  Extension macros run during normal Flow compilation. The expanded core
+  declarations keep the usual validation, source mapping, inline Action, and
+  execution rules. Extension modules must be available at compile time.
+  """
+
+  @doc false
+  @callback __jido_flow_extension__() :: true
+
+  @doc "Installs the Flow extension contract and imports this module into configured Flows."
+  @spec __using__(keyword()) :: Macro.t()
+  defmacro __using__(options) do
+    unless options == [] do
+      raise ArgumentError, "Jido.Flow.Extension does not accept options"
+    end
+
+    extension = __CALLER__.module
+
+    quote do
+      @behaviour Jido.Flow.Extension
+      use Spark.Dsl.Extension, imports: [unquote(extension)]
+
+      @doc false
+      @impl Jido.Flow.Extension
+      @spec __jido_flow_extension__() :: true
+      def __jido_flow_extension__, do: true
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -182,6 +182,7 @@ defmodule JidoAction.MixProject do
           Jido.Flow,
           Jido.Flow.Builder,
           Jido.Flow.Codec,
+          Jido.Flow.Extension,
           Jido.Flow.Registry
         ],
         "Expression API": [Jido.Expr, Jido.Expr.Error],

--- a/test/jido_flow/dsl/extension_test.exs
+++ b/test/jido_flow/dsl/extension_test.exs
@@ -41,6 +41,12 @@ defmodule Jido.Flow.DSL.ExtensionTest.ResultOutput do
   end
 end
 
+defmodule Jido.Flow.DSL.ExtensionTest.MarkerOnly do
+  @moduledoc false
+
+  def __jido_flow_extension__, do: true
+end
+
 defmodule Jido.Flow.DSL.ExtensionTest.ExtendedFlow do
   @moduledoc false
 
@@ -91,6 +97,7 @@ end
 defmodule Jido.Flow.DSL.ExtensionTest do
   use ExUnit.Case, async: true
 
+  alias Jido.Flow.Builder
   alias Jido.Flow.DSL.ExtensionTest.{ExtendedFlow, InlineFlow, PlainFlow}
 
   test "a Flow extension lowers its macros to canonical Flow declarations" do
@@ -100,6 +107,20 @@ defmodule Jido.Flow.DSL.ExtensionTest do
 
   test "extension declarations produce the same canonical Flow as core declarations" do
     assert ExtendedFlow.flow() == PlainFlow.flow()
+  end
+
+  test "extension declarations produce the same canonical Flow as Builder" do
+    builder =
+      Builder.new(name: "extended_flow")
+      |> Builder.step(
+        "add",
+        JidoActionTest.Fixtures.Actions.Add,
+        %{value: Builder.input(:value), amount: Builder.value(2)}
+      )
+      |> Builder.output(Builder.result("add"))
+
+    assert {:ok, flow} = Builder.build(builder)
+    assert ExtendedFlow.flow() == flow
   end
 
   test "an extension can expand to an inline Step that keeps the Flow owner scope" do
@@ -144,11 +165,36 @@ defmodule Jido.Flow.DSL.ExtensionTest do
     end
   end
 
+  test "Flow rejects a marker function without the extension behaviours" do
+    module = unique_module("MarkerOnly")
+
+    source = """
+    defmodule #{inspect(module)} do
+      use Jido.Flow,
+        name: "marker_only_extension",
+        extensions: [Jido.Flow.DSL.ExtensionTest.MarkerOnly]
+
+      flow do
+        step "add",
+          action: JidoActionTest.Fixtures.Actions.Add,
+          params: %{value: value(1), amount: value(1)}
+
+        output result("add")
+      end
+    end
+    """
+
+    assert_raise CompileError, ~r/Flow extension must use Jido.Flow.Extension/, fn ->
+      Code.compile_string(source, "marker_only_flow_extension.ex")
+    end
+  end
+
   test "Flow rejects malformed and duplicate extension lists" do
     extension = Jido.Flow.DSL.ExtensionTest.AddStep
 
     cases = [
       {":invalid", ~r/Flow extensions must be a list/},
+      {"[#{inspect(extension)} | :invalid]", ~r/Flow extensions must be a proper list/},
       {"[#{inspect(extension)}, #{inspect(extension)}]", ~r/duplicate Flow extension/}
     ]
 
@@ -167,6 +213,28 @@ defmodule Jido.Flow.DSL.ExtensionTest do
       assert_raise CompileError, message, fn ->
         Code.compile_string(source, "invalid_flow_extensions.ex")
       end
+    end
+  end
+
+  test "Flow rejects more than one extensions option" do
+    module = unique_module("RepeatedOptions")
+
+    source = """
+    defmodule #{inspect(module)} do
+      use Jido.Flow,
+        name: "repeated_extension_options",
+        extensions: [Jido.Flow.DSL.ExtensionTest.AddStep],
+        extensions: [Jido.Flow.DSL.ExtensionTest.ResultOutput]
+
+      flow do
+        add_step "add", value(1), value(1)
+        output result("add")
+      end
+    end
+    """
+
+    assert_raise CompileError, ~r/Flow extensions can be configured only once/, fn ->
+      Code.compile_string(source, "repeated_flow_extension_options.ex")
     end
   end
 

--- a/test/jido_flow/dsl/extension_test.exs
+++ b/test/jido_flow/dsl/extension_test.exs
@@ -1,0 +1,190 @@
+defmodule Jido.Flow.DSL.ExtensionTest.AddStep do
+  @moduledoc false
+
+  use Jido.Flow.Extension
+
+  defmacro add_step(name, value, amount) do
+    quote do
+      step unquote(name),
+        action: JidoActionTest.Fixtures.Actions.Add,
+        params: %{value: unquote(value), amount: unquote(amount)}
+    end
+  end
+
+  defmacro calculated_step(name, bindings, do: body) do
+    quote do
+      step unquote(name), unquote(bindings) do
+        unquote(body)
+      end
+    end
+  end
+
+  defmacro dependent_step(name, dependency) do
+    quote do
+      step unquote(name),
+        action: JidoActionTest.Fixtures.Actions.Add,
+        params: %{value: 1, amount: 1},
+        after: [unquote(dependency)]
+    end
+  end
+end
+
+defmodule Jido.Flow.DSL.ExtensionTest.ResultOutput do
+  @moduledoc false
+
+  use Jido.Flow.Extension
+
+  defmacro result_output(name) do
+    quote do
+      output result(unquote(name))
+    end
+  end
+end
+
+defmodule Jido.Flow.DSL.ExtensionTest.ExtendedFlow do
+  @moduledoc false
+
+  alias Jido.Flow.DSL.ExtensionTest.{AddStep, ResultOutput}
+
+  use Jido.Flow,
+    name: "extended_flow",
+    extensions: [AddStep, ResultOutput]
+
+  flow do
+    add_step("add", input(:value), value(2))
+    result_output("add")
+  end
+end
+
+defmodule Jido.Flow.DSL.ExtensionTest.PlainFlow do
+  @moduledoc false
+
+  use Jido.Flow, name: "extended_flow"
+
+  flow do
+    step "add",
+      action: JidoActionTest.Fixtures.Actions.Add,
+      params: %{value: input(:value), amount: value(2)}
+
+    output result("add")
+  end
+end
+
+defmodule Jido.Flow.DSL.ExtensionTest.InlineFlow do
+  @moduledoc false
+
+  use Jido.Flow,
+    name: "extension_inline_flow",
+    extensions: [Jido.Flow.DSL.ExtensionTest.AddStep]
+
+  flow do
+    calculated_step "double", value <- input(:value) do
+      {:ok, %{value: double(value)}}
+    end
+
+    output result("double")
+  end
+
+  defp double(value), do: value * 2
+end
+
+defmodule Jido.Flow.DSL.ExtensionTest do
+  use ExUnit.Case, async: true
+
+  alias Jido.Flow.DSL.ExtensionTest.{ExtendedFlow, InlineFlow, PlainFlow}
+
+  test "a Flow extension lowers its macros to canonical Flow declarations" do
+    assert [%Jido.Flow.Step{name: "add"}] = ExtendedFlow.flow().components
+    assert Jido.Exec.run(ExtendedFlow, %{value: 3}) == {:ok, %{value: 5}}
+  end
+
+  test "extension declarations produce the same canonical Flow as core declarations" do
+    assert ExtendedFlow.flow() == PlainFlow.flow()
+  end
+
+  test "an extension can expand to an inline Step that keeps the Flow owner scope" do
+    assert [%Jido.Flow.Step{action: action}] = InlineFlow.flow().components
+    assert action == InlineFlow.step_action("double")
+    assert Jido.Exec.run(InlineFlow, %{value: 3}) == {:ok, %{value: 6}}
+  end
+
+  test "validation errors from extension declarations keep the call site" do
+    module = unique_module("Source")
+
+    source =
+      "defmodule #{inspect(module)} do\n" <>
+        "use Jido.Flow, name: \"extension_source\", extensions: [#{inspect(Jido.Flow.DSL.ExtensionTest.AddStep)}]\n" <>
+        "flow do\n" <>
+        "dependent_step \"add\", \"missing\"\n" <>
+        "output result(\"add\")\n" <>
+        "end\n" <>
+        "end\n"
+
+    error =
+      assert_raise CompileError, fn -> Code.compile_string(source, "extension_source.ex") end
+
+    assert error.file == "extension_source.ex"
+    assert error.line == 4
+  end
+
+  test "Flow rejects an extension that does not use Jido.Flow.Extension" do
+    module = unique_module("Invalid")
+
+    source = """
+    defmodule #{inspect(module)} do
+      use Jido.Flow, name: "invalid_extension", extensions: [String]
+      flow do
+        output %{}
+      end
+    end
+    """
+
+    assert_raise CompileError, ~r/Flow extension must use Jido.Flow.Extension/, fn ->
+      Code.compile_string(source, "invalid_flow_extension.ex")
+    end
+  end
+
+  test "Flow rejects malformed and duplicate extension lists" do
+    extension = Jido.Flow.DSL.ExtensionTest.AddStep
+
+    cases = [
+      {":invalid", ~r/Flow extensions must be a list/},
+      {"[#{inspect(extension)}, #{inspect(extension)}]", ~r/duplicate Flow extension/}
+    ]
+
+    for {extensions, message} <- cases do
+      module = unique_module("Options")
+
+      source = """
+      defmodule #{inspect(module)} do
+        use Jido.Flow, name: "invalid_extensions", extensions: #{extensions}
+        flow do
+          output %{}
+        end
+      end
+      """
+
+      assert_raise CompileError, message, fn ->
+        Code.compile_string(source, "invalid_flow_extensions.ex")
+      end
+    end
+  end
+
+  test "Jido.Flow.Extension rejects configuration options" do
+    module = unique_module("Configured")
+
+    source = """
+    defmodule #{inspect(module)} do
+      use Jido.Flow.Extension, imports: [String]
+    end
+    """
+
+    assert_raise ArgumentError, ~r/Jido.Flow.Extension does not accept options/, fn ->
+      Code.compile_string(source, "configured_flow_extension.ex")
+    end
+  end
+
+  defp unique_module(prefix) do
+    Module.concat(__MODULE__, "#{prefix}#{System.unique_integer([:positive])}")
+  end
+end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -55,6 +55,9 @@ Use `jido_action` for validated work and data-first composition:
 
 - Use the compile-time `Jido.Flow` DSL as the primary developer authoring
   surface.
+- Use `Jido.Flow.Extension` for shared authoring macros that expand to normal
+  Flow declarations. Configure extensions with the static `extensions:` list.
+  Do not add component types or runtime behavior through an extension.
 - Resolve target kinds with `Jido.Executable`. A Flow requires `flow/0` and
   validation callbacks; its generated `run/2` is a convenience function.
 - Add `:jido_action` to `.formatter.exs` `import_deps` to keep DSL declarations


### PR DESCRIPTION
## Summary

- add `Jido.Flow.Extension` for compile-time authoring macros
- accept a static `extensions:` list in `use Jido.Flow`
- keep extension output on the existing canonical Flow DSL and runtime path
- preserve source locations and inline Action owner scope
- reject repeated options, duplicate modules, improper lists, and invalid extension contracts
- document how Builder, direct construction, and Codec stay independent of DSL extensions

## Scope

Extensions add macros that expand to normal Flow declarations. They do not add component types, canonical data fields, or runtime behavior.

Only the module DSL loads extensions. Builder and direct construction use normal Elixir helper functions. Codec documents contain data only and never name, load, or run an extension.

This PR contains only generic public Flow support. It contains no domain-specific extension or private integration code.

## Tests

- `mix test` — 910 passed
- `mix quality` — passed, including ExDoc, Doctor, Credo, and Dialyzer
- `mix test --cover --warnings-as-errors` — 910 passed, 94.93% total coverage
