### PR TITLE
feat(exec): add retryable predicate option

### DIFF
--- a/lib/jido_action/exec.ex
+++ b/lib/jido_action/exec.ex
@@ -109,6 +109,7 @@ defmodule Jido.Exec do
     - `:timeout` - Maximum time (in ms) allowed for the Action to complete (configurable via `:jido_action, :default_timeout`).
     - `:max_retries` - Maximum number of retry attempts (configurable via `:jido_action, :default_max_retries`).
     - `:backoff` - Initial backoff time in milliseconds, doubles with each retry (configurable via `:jido_action, :default_backoff`).
+    - `:retryable?` - Optional `(term() -> boolean())` predicate that decides whether a given error is retried, overriding the default `Jido.Action.Error.retryable?/1` heuristic. Receives the extracted error reason (the term inside `{:error, reason}` or `{:error, reason, other}`).
     - `:log_level` - Override the Jido execution log threshold for this specific action. Accepts #{inspect(Logger.levels())}. Global Logger config still applies.
     - `:telemetry` - `:full` (default) or `:silent` for action span emission.
     - `:context_propagators` - Runtime context propagator modules captured before supervised execution and reattached inside supervised tasks.

--- a/lib/jido_action/exec/retry.ex
+++ b/lib/jido_action/exec/retry.ex
@@ -54,7 +54,9 @@ defmodule Jido.Exec.Retry do
   - `error`: The error that occurred during execution
   - `retry_count`: The current retry attempt number
   - `max_retries`: The maximum number of retries allowed
-  - `opts`: Additional options (currently unused but reserved for future use)
+  - `opts`: Additional options. When `:retryable?` holds a 1-arity function, that
+    function decides the outcome for the extracted error term instead of
+    `Jido.Action.Error.retryable?/1`.
 
   ## Returns
 
@@ -64,8 +66,11 @@ defmodule Jido.Exec.Retry do
 
       iex> Jido.Exec.Retry.should_retry?({:error, "network error"}, 0, 3, [])
       true
-      
+
       iex> Jido.Exec.Retry.should_retry?({:error, "network error"}, 3, 3, [])
+      false
+
+      iex> Jido.Exec.Retry.should_retry?({:error, :access_denied}, 0, 3, retryable?: fn _ -> false end)
       false
   """
   @spec should_retry?(any(), non_neg_integer(), non_neg_integer(), keyword()) :: boolean()
@@ -73,10 +78,13 @@ defmodule Jido.Exec.Retry do
     false
   end
 
-  def should_retry?(error, _retry_count, _max_retries, _opts) do
-    error
-    |> extract_retry_target()
-    |> Error.retryable?()
+  def should_retry?(error, _retry_count, _max_retries, opts) do
+    target = extract_retry_target(error)
+
+    case Keyword.get(opts, :retryable?) do
+      fun when is_function(fun, 1) -> fun.(target)
+      _ -> Error.retryable?(target)
+    end
   end
 
   @doc """
@@ -149,7 +157,9 @@ defmodule Jido.Exec.Retry do
 
   ## Returns
 
-  A keyword list with validated retry configuration values.
+  A keyword list with validated retry configuration values. `:retryable?` is
+  included as given (or `nil` when absent) so callers can inspect the
+  configured predicate alongside `:max_retries` and `:backoff`.
   """
   @spec extract_retry_opts(keyword()) :: keyword()
   def extract_retry_opts(opts) do
@@ -157,7 +167,8 @@ defmodule Jido.Exec.Retry do
 
     [
       max_retries: Keyword.get(opts, :max_retries, defaults[:max_retries]),
-      backoff: Keyword.get(opts, :backoff, defaults[:backoff])
+      backoff: Keyword.get(opts, :backoff, defaults[:backoff]),
+      retryable?: Keyword.get(opts, :retryable?)
     ]
   end
 

--- a/test/jido_action/exec_retry_policy_test.exs
+++ b/test/jido_action/exec_retry_policy_test.exs
@@ -1,7 +1,10 @@
 defmodule Jido.ExecRetryPolicyTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   alias Jido.Action.Error
+  alias Jido.Exec
   alias Jido.Exec.Retry
 
   describe "should_retry?/4" do
@@ -43,6 +46,143 @@ defmodule Jido.ExecRetryPolicyTest do
       error = {:error, Error.execution_error("retry until limit")}
 
       refute Retry.should_retry?(error, 2, 2, [])
+    end
+
+    test "a :retryable? predicate can reject an error the default treats as retryable" do
+      error = {:error, Error.execution_error("temporary failure")}
+
+      refute Retry.should_retry?(error, 0, 3, retryable?: fn _ -> false end)
+    end
+
+    test "a :retryable? predicate can accept an error the default rejects" do
+      error = {:error, Error.validation_error("invalid input")}
+
+      assert Retry.should_retry?(error, 0, 3, retryable?: fn _ -> true end)
+    end
+
+    test "a :retryable? predicate receives the extracted error target" do
+      error = {:error, Error.execution_error("temporary failure")}
+
+      assert Retry.should_retry?(error, 0, 3,
+               retryable?: fn target -> match?(%Error.ExecutionFailureError{}, target) end
+             )
+    end
+
+    test "without :retryable? the default Error.retryable?/1 heuristic still applies" do
+      retryable = {:error, Error.execution_error("temporary failure")}
+      not_retryable = {:error, Error.validation_error("invalid input")}
+
+      assert Retry.should_retry?(retryable, 0, 3, [])
+      refute Retry.should_retry?(not_retryable, 0, 3, [])
+    end
+
+    test "a non-function :retryable? value is ignored and falls back to the default" do
+      retryable = {:error, Error.execution_error("temporary failure")}
+      not_retryable = {:error, Error.validation_error("invalid input")}
+
+      assert Retry.should_retry?(retryable, 0, 3, retryable?: :not_a_function)
+      refute Retry.should_retry?(not_retryable, 0, 3, retryable?: :not_a_function)
+    end
+
+    test "retry_count >= max_retries short-circuits even with a permissive :retryable?" do
+      error = {:error, Error.validation_error("invalid input")}
+
+      refute Retry.should_retry?(error, 3, 3, retryable?: fn _ -> true end)
+    end
+  end
+
+  describe "extract_retry_opts/1" do
+    test "includes :retryable? as nil when absent" do
+      assert Retry.extract_retry_opts([])[:retryable?] == nil
+    end
+
+    test "passes through a provided :retryable? function unchanged" do
+      predicate = fn _ -> true end
+
+      assert Retry.extract_retry_opts(retryable?: predicate)[:retryable?] == predicate
+    end
+  end
+
+  describe "Jido.Exec.run/4 with :retryable?" do
+    defmodule DenyingAction do
+      @moduledoc false
+      use Jido.Action, name: "retry_policy_denying_action"
+
+      def run(_params, context) do
+        :ets.update_counter(context.attempts_table, :attempts, {2, 1})
+        {:error, Error.execution_error("access denied")}
+      end
+    end
+
+    defmodule OverriddenRetryableAction do
+      @moduledoc false
+      use Jido.Action, name: "retry_policy_overridden_retryable_action"
+
+      def run(_params, context) do
+        :ets.update_counter(context.attempts_table, :attempts, {2, 1})
+        {:error, Error.validation_error("rejected input")}
+      end
+    end
+
+    setup do
+      table = :ets.new(:retry_policy_attempts, [:set, :public])
+      :ets.insert(table, {:attempts, 0})
+
+      {:ok, table: table}
+    end
+
+    test "a predicate that rejects a normally-retryable error runs the action exactly once",
+         %{table: table} do
+      capture_log(fn ->
+        assert {:error, %Error.ExecutionFailureError{}} =
+                 Exec.run(DenyingAction, %{}, %{attempts_table: table},
+                   max_retries: 2,
+                   backoff: 1,
+                   retryable?: fn _ -> false end
+                 )
+      end)
+
+      assert :ets.lookup(table, :attempts) == [{:attempts, 1}]
+    end
+
+    test "a predicate that accepts a normally-non-retryable error causes it to be retried",
+         %{table: table} do
+      capture_log(fn ->
+        assert {:error, %Error.InvalidInputError{}} =
+                 Exec.run(OverriddenRetryableAction, %{}, %{attempts_table: table},
+                   max_retries: 2,
+                   backoff: 1,
+                   retryable?: fn _ -> true end
+                 )
+      end)
+
+      assert :ets.lookup(table, :attempts) == [{:attempts, 3}]
+    end
+
+    test "without :retryable? the default behaviour is unchanged (no retry on validation errors)",
+         %{table: table} do
+      capture_log(fn ->
+        Exec.run(OverriddenRetryableAction, %{}, %{attempts_table: table},
+          max_retries: 2,
+          backoff: 1
+        )
+      end)
+
+      assert :ets.lookup(table, :attempts) == [{:attempts, 1}]
+    end
+
+    test "a non-function :retryable? value is ignored, falling back to the default", %{
+      table: table
+    } do
+      capture_log(fn ->
+        Exec.run(OverriddenRetryableAction, %{}, %{attempts_table: table},
+          max_retries: 2,
+          backoff: 1,
+          retryable?: :not_a_function
+        )
+      end)
+
+      assert :ets.lookup(table, :attempts) == [{:attempts, 1}]
     end
   end
 end


### PR DESCRIPTION
## Description

`Jido.Exec.Retry.should_retry?/4` accepts an options argument but does not use it
when deciding whether to retry. Callers that need a strict allowlist therefore
have to disable retries entirely with `max_retries: 0`, which also prevents
retrying genuine transient failures.

Add an optional `:retryable?` predicate to `Jido.Exec.run/4`. When present, the
one-arity function receives the extracted error reason and decides whether the
current failure is retryable. When absent, the existing
`Jido.Action.Error.retryable?/1` heuristic remains unchanged. Non-function values
also fall back to the existing heuristic.

Example:

```elixir
Jido.Exec.run(MyAction, params, context,
  max_retries: 1,
  retryable?: &match?(%Jido.Action.Error.TimeoutError{}, &1)
)
```

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Breaking Changes

None. The option is opt-in; existing callers retain the current retry behavior.

## Testing

- [x] Focused retry-policy tests pass
- [x] Full test suite passes (`910 passed`)
- [x] Quality checks pass (`mix quality`)
- [x] Formatting check passes (`mix format --check-formatted`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated the documentation accordingly
- [x] I have added tests that prove the fix works
- [x] All new and existing tests pass
- [x] My commit follows conventional commit format
- [x] I have **NOT** edited `CHANGELOG.md`

## Related Issues

- [Retry policy hardening (#91)](https://github.com/agentjido/jido_action/issues/91)
- [Retry policy implementation (#96)](https://github.com/agentjido/jido_action/pull/96)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/agentjido/codesmith/jido_action/pr/264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791495460&installation_model_id=434874&pr_number=264&repository=agentjido%2Fjido_action&return_to=https%3A%2F%2Fgithub.com%2Fagentjido%2Fjido_action%2Fpull%2F264&signature=6f56cf386941c38dd9a3ee076da3b6a892233a654efa668ca8072f2fee457533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->